### PR TITLE
implement per-event enemy level overrides for JABS

### DIFF
--- a/project/js/plugins/J-Base.js
+++ b/project/js/plugins/J-Base.js
@@ -59,6 +59,8 @@
  *
  * ============================================================================
  * CHANGELOG:
+ * - 2.2.1
+ *    Added dev filter function for action to skill mapping for enemies.
  * - 2.2.0
  *    Added parent class for subclassing to strongly type plugin metadata.
  *    Added Game_Character#isVehicle function.
@@ -5503,10 +5505,11 @@ class RPGManager
     noteLines.forEach(line =>
     {
       // check if this line matches the given regex structure.
-      if (line.match(structure))
+      const match = structure.exec(line);
+      if (match)
       {
         // extract the captured formula.
-        const [ , result ] = structure.exec(line);
+        const [ , result ] = match;
 
         // parse the value out of the regex capture group.
         val.push(result);
@@ -8515,6 +8518,7 @@ Game_Enemy.prototype.skills = function()
   // grab the actions for the enemy.
   const actions = this.enemy()
     .actions
+    .filter(this.canMapActionToSkill, this)
     .map(action => this.skill(action.skillId), this);
 
   // grab any additional skills added via traits.
@@ -8526,6 +8530,16 @@ Game_Enemy.prototype.skills = function()
   return actions
     .concat(skillTraits)
     .sort();
+};
+
+/**
+ * Determines whether or not the action can be mapped to a skill.
+ * @param {RPG_EnemyAction} action The action being mapped to a skill.
+ * @returns {boolean}
+ */
+Game_Enemy.prototype.canMapActionToSkill = function(action)
+{
+  return true;
 };
 
 /**

--- a/project/js/plugins/J-Base.js
+++ b/project/js/plugins/J-Base.js
@@ -2,7 +2,7 @@
 /*:
  * @target MZ
  * @plugindesc
- * [v2.2.0 BASE] The base class for all J plugins.
+ * [v2.2.1 BASE] The base class for all J plugins.
  * @author JE
  * @url https://github.com/je-can-code/rmmz-plugins
  * @help
@@ -114,7 +114,7 @@ J.BASE = {};
  */
 J.BASE.Metadata = {};
 J.BASE.Metadata.Name = `J-Base`;
-J.BASE.Metadata.Version = '2.2.0';
+J.BASE.Metadata.Version = '2.2.1';
 
 /**
  * A collection of helpful mappings for `notes` that are placed in

--- a/project/js/plugins/J-LevelMaster.js
+++ b/project/js/plugins/J-LevelMaster.js
@@ -2,7 +2,7 @@
 /*:
  * @target MZ
  * @plugindesc
- * [v1.1.2 LEVEL] Allows levels to have greater control and purpose.
+ * [v1.2.0 LEVEL] Allows levels to have greater control and purpose.
  * @author JE
  * @url https://github.com/je-can-code/rmmz-plugins
  * @base J-Base
@@ -222,7 +222,7 @@
  * This same logic is again applied to gold from each defeated enemy.
  * ============================================================================
  * CHANGELOG:
- * - 1.1.2
+ * - 1.2.0
  *    Added ability to override JABS enemies on the map with a new level.
  * - 1.1.1
  *    Added ability to manipulate max level for actors.
@@ -438,7 +438,7 @@ J.LEVEL = {};
 /**
  * The `metadata` associated with this plugin, such as version.
  */
-J.LEVEL.Metadata = new J_LevelPluginMetadata(`J-LevelMaster`, '1.1.2');
+J.LEVEL.Metadata = new J_LevelPluginMetadata(`J-LevelMaster`, '1.2.0');
 
 /**
  * All aliased methods for this plugin.

--- a/project/js/plugins/J-LevelMaster.js
+++ b/project/js/plugins/J-LevelMaster.js
@@ -2,11 +2,12 @@
 /*:
  * @target MZ
  * @plugindesc
- * [v1.1.1 LEVEL] Allows levels to have greater control and purpose.
+ * [v1.1.2 LEVEL] Allows levels to have greater control and purpose.
  * @author JE
  * @url https://github.com/je-can-code/rmmz-plugins
  * @base J-Base
  * @orderAfter J-Base
+ * @orderAfter J-ABS
  * @help
  * ============================================================================
  * OVERVIEW
@@ -25,6 +26,10 @@
  * CAUTION:
  * This probably won't work with any other plugins that mess with the
  * level functionality of battlers.
+ *
+ * Integrates with others of mine plugins:
+ * - J-ABS; enables per-event-enemy level overrides.
+ *
  * ============================================================================
  * PLUGIN PARAMETERS BREAKDOWN:
  *  - Start Enabled:
@@ -78,6 +83,15 @@
  * each member of your party that gives experience- and is affected by the
  * normal level-scaling mechanics. The same applies to gold rewards.
  *
+ * NOTE ABOUT WORKING WITH JABS:
+ * If a level is present on an event that is identified as a JABS enemy, this
+ * level will override whatever is present on the database note section. You
+ * can think of the event as the real level, while the database notes are the
+ * "default" level for enemies. The overriden level still gets combined with
+ * any other modifications from states and whatnot. If an enemy has a level, by
+ * default it will show up in their battler name. If it is desired to be
+ * hidden, it can be converted to ??? by using the hide level tag.
+ *
  * DETAILS:
  * This was initially designed only for enemies, but has since been expanded to
  * also allow you to apply modifiers to your actors as well. For enemies, since
@@ -90,6 +104,7 @@
  * ENEMY TAG USAGE:
  * - Enemies
  * - States
+ * - Events (w/ JABS)
  *
  * ACTOR TAG USAGE:
  * - Actors
@@ -107,6 +122,7 @@
  *  <level:4>
  * On enemies, if on the enemy, it would set their base level to 4.
  * On enemies, if on a state, it would grant a +4 modifier to their base level.
+ * On events, this will override whatever the JABS enemy's level would be.
  * On actors, this would grant a +4 level modifier to their base level.
  *
  *  <level:-2>
@@ -114,6 +130,12 @@
  * On enemies, if on a state, and they have a base level set,
  *  this will grant a -2 modifier to their base level.
  * On actors, this will grant a -2 modifier to their base level.
+ *
+ *  <hideLevel>
+ * On enemies, this will turn the level into "???" instead of the level value.
+ * On events, this will override a singular enemy into hiding the value.
+ * On states, this will do nothing.
+ *
  * ============================================================================
  * SAMPLE CALCULATIONS:
  * Here is an example back and forth encounter between an allied party and
@@ -200,6 +222,8 @@
  * This same logic is again applied to gold from each defeated enemy.
  * ============================================================================
  * CHANGELOG:
+ * - 1.1.2
+ *    Added ability to override JABS enemies on the map with a new level.
  * - 1.1.1
  *    Added ability to manipulate max level for actors.
  *    Adapted extended plugin metadata structure.
@@ -414,20 +438,24 @@ J.LEVEL = {};
 /**
  * The `metadata` associated with this plugin, such as version.
  */
-J.LEVEL.Metadata = new J_LevelPluginMetadata(`J-LevelMaster`, '1.1.1');
+J.LEVEL.Metadata = new J_LevelPluginMetadata(`J-LevelMaster`, '1.1.2');
 
 /**
  * All aliased methods for this plugin.
  */
 J.LEVEL.Aliased = {
+  Game_Action: new Map(),
   Game_Actor: new Map(),
   Game_Battler: new Map(),
-  Game_Action: new Map(),
+  Game_Enemy: new Map(),
+  Game_Event: new Map(),
   Game_System: new Map(),
   Game_Temp: new Map(),
   Game_Troop: new Map(),
 
   DataManager: new Map(),
+
+  Sprite_Character: new Map(),
 };
 
 /**
@@ -435,10 +463,22 @@ J.LEVEL.Aliased = {
  */
 J.LEVEL.RegExp = {
   /**
+   * The regex for hiding the level display of a battler.
+   * @type {RegExp}
+   */
+  HideLevel: /<hideLevel>/i,
+
+  /**
    * The regex for the level tag on various database objects.
    * @type {RegExp}
    */
-  BattlerLevel: /<(?:lv|lvl|level):[ ]?(-?\+?\d+)>/i,
+  Level: /<(?:lv|lvl|level):[ ]?(-?\+?\d+)>/i,
+
+  /**
+   * The regex for when a skill id is learned at a designated level.
+   * @type {RegExp}
+   */
+  Learning: /<learning: ?(\[\d+, ?\d+])>/i,
 
   /**
    * The regex for granting bonuses or penalties to max level (for actors only).
@@ -879,7 +919,7 @@ Game_Battler.prototype.getLevel = function()
   {
     // add the level extracted from the data.
     level += this.extractLevel(rpgData);
-  });
+  }, this);
 
   // return the new amount.
   return level;
@@ -920,11 +960,192 @@ Game_Battler.prototype.getLevelBalancer = function()
 Game_Battler.prototype.extractLevel = function(rpgData)
 {
   // extract the level from the notes.
-  return rpgData.getNumberFromNotesByRegex(J.LEVEL.RegExp.BattlerLevel);
+  return RPGManager.getNumberFromNoteByRegex(rpgData, J.LEVEL.RegExp.Level);
 };
 //endregion Game_Battler
 
 //region Game_Enemy
+
+/**
+ * Extends {@link Game_Enemy.setup}.<br>
+ * Includes setting up the learned level map for skills.
+ */
+J.LEVEL.Aliased.Game_Enemy.set('initMembers', Game_Enemy.prototype.initMembers);
+Game_Enemy.prototype.initMembers = function()
+{
+  // perform original logic.
+  J.LEVEL.Aliased.Game_Enemy.get('initMembers')
+    .call(this);
+
+  /**
+   * The J object where all my additional properties live.
+   */
+  this._j ||= {};
+
+  /**
+   * A grouping of all properties associated with levels.
+   */
+  this._j._level ||= {};
+
+  /**
+   * All skill learnings this enemy has for it recorded as a dictionary.
+   * @type {Record<number, number>}
+   */
+  this._j._level._skillLearnings = {};
+};
+
+/**
+ * Sets a skill's learning by its skill and level.
+ * @param {number} skillId The skill id to be learned.
+ * @param {number} level The level the corresponding skill is learned.
+ */
+Game_Enemy.prototype.setSkillLearning = function(skillId, level)
+{
+  this._j._level._skillLearnings[skillId] = level;
+};
+
+/**
+ * Extends {@link Game_Enemy.setup}.<br>
+ * Includes setting up the learned level map for skills.
+ */
+J.LEVEL.Aliased.Game_Enemy.set('setup', Game_Enemy.prototype.setup);
+Game_Enemy.prototype.setup = function(enemyId, x, y)
+{
+  // perform original logic.
+  J.LEVEL.Aliased.Game_Enemy.get('setup')
+    .call(this, enemyId, x, y);
+
+  // initialize the skill learnings for this enemy.
+  this.setupSkillLearnings();
+};
+
+/**
+ * Sets up the learnings defined on the enemy.
+ */
+Game_Enemy.prototype.setupSkillLearnings = function()
+{
+  const learnings = RPGManager.getArraysFromNotesByRegex(this.enemy(), J.LEVEL.RegExp.Learning) ?? [];
+  if (learnings.length === 0) return;
+
+  learnings.forEach(learning => this.setSkillLearning(learning.at(0), learning.at(1)));
+};
+
+/**
+ * Extends {@link #canMapActionToSkill}.<br/>
+ * Also factors in whether or not the skill is technically learned or not.
+ * @param {RPG_EnemyAction} action The action being mapped to a skill.
+ * @returns {boolean}
+ */
+J.LEVEL.Aliased.Game_Enemy.set('canMapActionToSkill', Game_Enemy.prototype.canMapActionToSkill);
+Game_Enemy.prototype.canMapActionToSkill = function(action)
+{
+  // perform original logic.
+  const baseCanMap = J.LEVEL.Aliased.Game_Enemy.get('canMapActionToSkill')
+    .call(this, action);
+
+  // if the skill is otherwise unmappable, then don't bother with level-related logic.
+  if (baseCanMap === false) return false;
+
+  // determine if the skill is learned according to its level.
+  const isLearned = this.isLearnedSkillByLevel(action);
+
+  // return what we found.
+  return isLearned;
+};
+
+/**
+ * Determines if a skill has been learned from potential level restrictions.
+ * @param {RPG_EnemyAction} action The action being mapped to a skill.
+ * @returns {boolean}
+ */
+Game_Enemy.prototype.isLearnedSkillByLevel = function(action)
+{
+  const levelLearned = this._j._level._skillLearnings[action.skillId];
+
+  // if the skill didn't map, then the value will be undefined.
+  if (levelLearned === undefined) return true;
+
+  // if the enemy is at or above the level learned, then the skill is learned.
+  if (this.level >= levelLearned) return true;
+
+  // otherwise, the skill is not learned and shouldn't be considered.
+  return false;
+};
+
+/**
+ * Overrides {@link #getBattlerBaseLevel}.<br/>
+ * Instead of defaulting to zero, it will use the enemy's own note, accommodating any overrides if present.
+ * @returns {number}
+ */
+J.LEVEL.Aliased.Game_Enemy.set('getBattlerBaseLevel', Game_Enemy.prototype.getBattlerBaseLevel);
+Game_Enemy.prototype.getBattlerBaseLevel = function()
+{
+  // calculate the original level- probably zero unless another plugin modifies this.
+  const defaultBaseLevel = J.LEVEL.Aliased.Game_Enemy.get('getBattlerBaseLevel')
+    .call(this);
+
+  // grab the level from the enemy's own note.
+  const noteLevel = RPGManager.getNumberFromNoteByRegex(this.enemy(), J.LEVEL.RegExp.Level);
+
+  // combine the default and enemy levels.
+  const baseLevel = defaultBaseLevel + noteLevel;
+
+  // if there are no overrides, then return the base level.
+  if (this.hasLevelOverride() === false) return baseLevel;
+
+  // get the JABS_Battler associated with this enemy by UUID.
+  const jabsBattler = JABS_AiManager.getBattlerByUuid(this.getUuid());
+
+  // return the level override.
+  return jabsBattler.getCharacter()
+    .getLevelOverrides();
+};
+
+/**
+ * Checks if this enemy in particular has any JABS level overrides.
+ * @returns {boolean}
+ */
+Game_Enemy.prototype.hasLevelOverride = function()
+{
+  // if JABS isn't available, then there won't be a level override.
+  if (!J.ABS) return false;
+
+  // if there is no battler on this enemy, then there won't be a level override to check.
+  if (!this.getUuid()) return false;
+
+  // get the JABS_Battler associated with this enemy by UUID.
+  const jabsBattler = JABS_AiManager.getBattlerByUuid(this.getUuid());
+
+  // if there is no battler being tracked by this UUID, then there are no overrides.
+  if (!jabsBattler) return false;
+
+  // if overrides is null, then there are none.
+  if (jabsBattler.getCharacter()
+    .getLevelOverrides() === null)
+  {
+    return false;
+  }
+
+  // there must be overrides!
+  return true;
+};
+
+/**
+ * Determines if the level should be hidden for this enemy based on its notes.
+ * @returns {boolean} True if the level should be hidden, false otherwise.
+ */
+Game_Enemy.prototype.shouldHideLevel = function()
+{
+  // grab the reference data for this battler.
+  const referenceData = this.enemy();
+
+  // check if the hideLevel tag exists in the enemy's notes.
+  const hideLevel = RPGManager.checkForBooleanFromNoteByRegex(referenceData, J.LEVEL.RegExp.HideLevel);
+
+  // return whether the level should be hidden.
+  return hideLevel;
+};
+
 /**
  * Gets all database sources we can get levels from.
  * @returns {RPG_BaseItem[]}
@@ -933,19 +1154,8 @@ Game_Enemy.prototype.getLevelSources = function()
 {
   // our sources of data that a level can be retrieved from.
   return [
-    this.enemy(),     // this enemy is a source.
     ...this.states(), // all states applied to this enemy are sources.
   ];
-};
-
-/**
- * The base or default level for this battler.
- * Enemies do not have a base level.
- * @returns {number}
- */
-Game_Enemy.prototype.getBattlerBaseLevel = function()
-{
-  return 0;
 };
 
 /**
@@ -965,6 +1175,182 @@ Game_Enemy.prototype.getLevelBalancer = function()
   return 0;
 };
 //endregion Game_Enemy
+
+//region Game_Event
+/**
+ * Extends {@link Game_Event.initMembers}.<br>
+ * Initializes level-related properties.
+ */
+J.LEVEL.Aliased.Game_Event.set('initMembers', Game_Event.prototype.initMembers);
+Game_Event.prototype.initMembers = function()
+{
+  // perform original logic.
+  J.LEVEL.Aliased.Game_Event.get('initMembers')
+    .call(this);
+
+  /**
+   * The J object where all my additional properties live.
+   */
+  this._j ||= {};
+
+  /**
+   * A grouping of all properties associated with levels.
+   */
+  this._j._level ||= {};
+
+  /**
+   * The cached level override value.
+   * @type {number|null}
+   */
+  this._j._level._cachedLevelOverride = null;
+
+  /**
+   * The cached check of whether or not to hide the level in the battler's name.
+   * @type {boolean|null}
+   */
+  this._j._level._cachedHideLevel = null;
+};
+
+/**
+ * Gets the cached level override.<br>
+ * If there is no override, this returns null instead.
+ * @returns {number|null}
+ */
+Game_Event.prototype.getCachedLevelOverride = function()
+{
+  return this._j._level._cachedLevelOverride;
+};
+
+/**
+ * Gets the cached flag for whether or not the level should be hidden.<br>
+ * If there is this hasn't been parsed, this returns null instead.
+ * @returns {boolean|null}
+ */
+Game_Event.prototype.getCachedHideLevel = function()
+{
+  return this._j._level._cachedHideLevel;
+};
+
+/**
+ * Sets the level override as a cached value.
+ * @param {number|null} level The new cached value.
+ */
+Game_Event.prototype.setCachedLevelOverride = function(level)
+{
+  this._j._level._cachedLevelOverride = level;
+};
+
+/**
+ * Sets the flag for hiding the level as a cached value.
+ * @param {boolean|null} hideLevel The new cached value.
+ */
+Game_Event.prototype.setCachedHideLevel = function(hideLevel)
+{
+  this._j._level._cachedHideLevel = hideLevel;
+};
+
+/**
+ * Extends {@link Game_Event.refresh}.<br>
+ * Clears the level override cache when the event page changes.
+ */
+J.LEVEL.Aliased.Game_Event.set('refresh', Game_Event.prototype.refresh);
+Game_Event.prototype.refresh = function()
+{
+  // perform original logic.
+  J.LEVEL.Aliased.Game_Event.get('refresh')
+    .call(this);
+
+  // clear the level override cache when the event page changes
+  this.clearLevelCache();
+};
+
+/**
+ * Clears the cached values related to levels.
+ */
+Game_Event.prototype.clearLevelCache = function()
+{
+  // reset back to default.
+  this.setCachedLevelOverride(null);
+  this.setCachedHideLevel(null);
+};
+
+/**
+ * Parses out the level from a list of event commands.
+ * @returns {number|null} The found level, or null if not found.
+ */
+Game_Event.prototype.getLevelOverrides = function()
+{
+  // check if we have a cached value
+  if (this._j._level._cachedLevelOverride !== null)
+  {
+    // return the cached value
+    return this._j._level._cachedLevelOverride;
+  }
+
+  // default to no level override
+  let level = null;
+
+  // check all the valid event commands to see if we have a level override
+  this.getValidCommentCommands()
+    .forEach(command =>
+    {
+      // shorthand the comment into a variable
+      const [ comment, ] = command.parameters;
+
+      // check if the comment matches the regex
+      const regexResult = J.LEVEL.RegExp.Level.exec(comment);
+
+      // if the comment didn't match, then don't try to parse it
+      if (!regexResult) return;
+
+      // parse the value out of the regex capture group
+      level = parseInt(regexResult[1]);
+    });
+
+  // cache the result for future use
+  this._j._level._cachedLevelOverride = level;
+
+  // return what we found
+  return level;
+};
+
+/**
+ * Determines if the level should be hidden for this event.
+ * @returns {boolean} True if the level should be hidden, false otherwise.
+ */
+Game_Event.prototype.shouldHideLevel = function()
+{
+  // check if we have a cached value.
+  if (this.getCachedHideLevel() !== null)
+  {
+    // return the cached value.
+    return this.getCachedHideLevel();
+  }
+
+  // default to not hiding the level.
+  let hideLevel = false;
+
+  // check all the valid event commands to see if we have a hide level tag.
+  this.getValidCommentCommands()
+    .forEach(command =>
+    {
+      // shorthand the comment into a variable.
+      const [ comment, ] = command.parameters;
+
+      // check if the comment contains the hideLevel tag.
+      if (J.LEVEL.RegExp.HideLevel.test(comment))
+      {
+        hideLevel = true;
+      }
+    });
+
+  // cache the result for future use
+  this.setCachedHideLevel(hideLevel);
+
+  // return what we found
+  return hideLevel;
+};
+//endregion Game_Event
 
 //region Game_Party
 /**
@@ -1248,3 +1634,51 @@ Game_Troop.prototype.getScaledExpResult = function()
   return Math.round(deadEnemies.reduce(reducer, 0));
 };
 //endregion Game_Troop
+
+//region Sprite_Character
+/**
+ * Gets this battler's name.
+ * If there is no battler, this will return an empty string.
+ * @returns {string}
+ */
+J.LEVEL.Aliased.Sprite_Character.set('getBattlerName', Sprite_Character.prototype.getBattlerName);
+Sprite_Character.prototype.getBattlerName = function()
+{
+  // get the original name of the sprite.
+  const originalName = J.LEVEL.Aliased.Sprite_Character.get('getBattlerName')
+    .call(this);
+
+  // if there was no battler name, then there probably isn't a battler.
+  if (originalName === String.empty) return originalName;
+
+  // grab the battler- we know it should exist by now.
+  const battler = this.getBattler();
+
+  // non-enemies don't get levels in their names.
+  if (battler.isEnemy() === false) return originalName;
+
+  // get the battler's level.
+  const level = battler.level;
+
+  // a zero level indicates there is no level logic associated with this battler.
+  if (level === 0) return originalName;
+
+  // capture the level as a string type for type-correct potential overriding.
+  let levelString = `${level.padZero(3)}`;
+
+  // check if this character is an event and if the level should be hidden
+  if (this._character && this._character.isEvent() && this._character.shouldHideLevel())
+  {
+    levelString = "???";
+  }
+
+  // if the level is not already hidden by event comments, check the enemy notes
+  if (levelString !== "???" && battler.shouldHideLevel())
+  {
+    levelString = "???";
+  }
+
+  // return the name with level.
+  return `${levelString} ${originalName}`;
+};
+//endregion Sprite_Character

--- a/project/js/plugins/J-Proficiency.js
+++ b/project/js/plugins/J-Proficiency.js
@@ -1245,6 +1245,7 @@ Game_Battler.prototype.canGainProficiency = function()
 J.PROF.Aliased.Game_Enemy.set("initMembers", Game_Enemy.prototype.initMembers);
 Game_Enemy.prototype.initMembers = function()
 {
+  // perform original logic.
   J.PROF.Aliased.Game_Enemy.get("initMembers")
     .call(this);
 

--- a/project/js/plugins/J-SDP.js
+++ b/project/js/plugins/J-SDP.js
@@ -2064,6 +2064,16 @@ Game_Actor.prototype.getAllSdpRankings = function()
 };
 
 /**
+ * Gets the total number of SDP ranks this actor has.
+ * @returns {number}
+ */
+Game_Actor.prototype.getTotalSdpRanks = function()
+{
+  return this.getAllSdpRankings()
+    .reduce((total, panelRanking) => total + panelRanking.currentRank, 0);
+};
+
+/**
  * Gets all unlocked panels for this actor.
  * @returns {PanelRanking[]}
  */
@@ -2149,7 +2159,7 @@ Game_Actor.prototype.modAccumulatedTotalSdpPoints = function(points)
  */
 Game_Actor.prototype.getAccumulatedSpentSdpPoints = function()
 {
-  return this._j._sdp._pointsEverGained;
+  return this._j._sdp._pointsSpent;
 };
 
 /**

--- a/project/js/plugins/J-SDP.js
+++ b/project/js/plugins/J-SDP.js
@@ -808,7 +808,7 @@ class StatDistributionPanel
 /*:
  * @target MZ
  * @plugindesc
- * [v2.0.1 SDP] Enables the SDP system, aka Stat Distribution Panels.
+ * [v2.0.2 SDP] Enables the SDP system, aka Stat Distribution Panels.
  * @author JE
  * @url https://github.com/je-can-code/rmmz-plugins
  * @base J-Base
@@ -944,6 +944,8 @@ class StatDistributionPanel
  * will now gain 50% increased SDP points (80 - 30 = 50).
  * ============================================================================
  * CHANGELOG:
+ * - 2.0.2
+ *    Added new getTotalSdpRanks function to actors for a new data point.
  * - 2.0.1
  *    Added filter for skipping panels that start with particular characters.
  *    Retroactively added note about breaking web deploys for this plugin.
@@ -1286,7 +1288,7 @@ J.SDP = {};
 /**
  * The metadata associated with this plugin.
  */
-J.SDP.Metadata = new J_SdpPluginMetadata('J-SDP', '2.0.0');
+J.SDP.Metadata = new J_SdpPluginMetadata('J-SDP', '2.0.2');
 
 /**
  * A collection of all aliased methods for this plugin.

--- a/project/js/plugins/abs/J-ABS.js
+++ b/project/js/plugins/abs/J-ABS.js
@@ -31152,13 +31152,13 @@ Sprite_Character.prototype.createBattlerNameSprite = function()
   // build the text sprite.
   const sprite = new Sprite_BaseText()
     .setText(battlerName)
-    .setFontSize(10)
+    .setFontSize(16)
     .setAlignment(Sprite_BaseText.Alignments.Left)
     .setColor("#ffffff");
   sprite.setText(battlerName); // TODO: is this second assignment necessary???
 
   // relocate the sprite to a better position.
-  sprite.move(-30, 8);
+  sprite.move(-70, 0);
 
   // return this created sprite.
   return sprite;

--- a/project/js/plugins/abs/J-ABS.js
+++ b/project/js/plugins/abs/J-ABS.js
@@ -11607,7 +11607,7 @@ class JABS_Timer
 /*:
  * @target MZ
  * @plugindesc
- * [v3.4.1 JABS] Enables combat to be carried out on the map.
+ * [v3.4.2 JABS] Enables combat to be carried out on the map.
  * @author JE
  * @url https://github.com/je-can-code/rmmz-plugins
  * @base J-Base
@@ -11651,6 +11651,8 @@ class JABS_Timer
  * JABS lives at the top instead of the bottom like the rest of my plugins.
  *
  * CHANGELOG:
+ * - 3.4.2
+ *    Adjusted font size and sprite location for enemy battler name on map.
  * - 3.4.1
  *    Applied significant regeneration reduction for actors while in-combat.
  *    Fixed facing-auto-parry not working as-intended.
@@ -13649,7 +13651,7 @@ J.ABS.Helpers.PluginManager.TranslateElementalIcons = obj =>
  */
 J.ABS.Metadata = {};
 J.ABS.Metadata.Name = 'J-ABS';
-J.ABS.Metadata.Version = '3.4.1';
+J.ABS.Metadata.Version = '3.4.2';
 
 /**
  * The actual `plugin parameters` extracted from RMMZ.

--- a/src/build-tools/init.js
+++ b/src/build-tools/init.js
@@ -5,7 +5,7 @@
  * This nodejs script is intended to be used to quickly scaffold a group of
  * common directories using this opinionated way of dividing up RMMZ plugin
  * code logic. This also assumes it will be ran from the convenient npm package.json
- * commands found in the root package.json of this plugins monolith project.
+ * commands found in the root package.json of this plugins monorepo project.
  *
  * USAGE:
  * To use this nodejs script, just run it with a single argument:

--- a/src/plugins/_base/_metadata/_annotations.js
+++ b/src/plugins/_base/_metadata/_annotations.js
@@ -2,7 +2,7 @@
 /*:
  * @target MZ
  * @plugindesc
- * [v2.2.0 BASE] The base class for all J plugins.
+ * [v2.2.1 BASE] The base class for all J plugins.
  * @author JE
  * @url https://github.com/je-can-code/rmmz-plugins
  * @help

--- a/src/plugins/_base/_metadata/_annotations.js
+++ b/src/plugins/_base/_metadata/_annotations.js
@@ -59,6 +59,8 @@
  *
  * ============================================================================
  * CHANGELOG:
+ * - 2.2.1
+ *    Added dev filter function for action to skill mapping for enemies.
  * - 2.2.0
  *    Added parent class for subclassing to strongly type plugin metadata.
  *    Added Game_Character#isVehicle function.

--- a/src/plugins/_base/_metadata/initialization.js
+++ b/src/plugins/_base/_metadata/initialization.js
@@ -13,7 +13,7 @@ J.BASE = {};
  */
 J.BASE.Metadata = {};
 J.BASE.Metadata.Name = `J-Base`;
-J.BASE.Metadata.Version = '2.2.0';
+J.BASE.Metadata.Version = '2.2.1';
 
 /**
  * A collection of helpful mappings for `notes` that are placed in

--- a/src/plugins/_base/managers/RPGManager.js
+++ b/src/plugins/_base/managers/RPGManager.js
@@ -687,10 +687,11 @@ class RPGManager
     noteLines.forEach(line =>
     {
       // check if this line matches the given regex structure.
-      if (line.match(structure))
+      const match = structure.exec(line);
+      if (match)
       {
         // extract the captured formula.
-        const [ , result ] = structure.exec(line);
+        const [ , result ] = match;
 
         // parse the value out of the regex capture group.
         val.push(result);

--- a/src/plugins/_base/objects/Game_Enemy.js
+++ b/src/plugins/_base/objects/Game_Enemy.js
@@ -67,6 +67,7 @@ Game_Enemy.prototype.skills = function()
   // grab the actions for the enemy.
   const actions = this.enemy()
     .actions
+    .filter(this.canMapActionToSkill, this)
     .map(action => this.skill(action.skillId), this);
 
   // grab any additional skills added via traits.
@@ -78,6 +79,16 @@ Game_Enemy.prototype.skills = function()
   return actions
     .concat(skillTraits)
     .sort();
+};
+
+/**
+ * Determines whether or not the action can be mapped to a skill.
+ * @param {RPG_EnemyAction} action The action being mapped to a skill.
+ * @returns {boolean}
+ */
+Game_Enemy.prototype.canMapActionToSkill = function(action)
+{
+  return true;
 };
 
 /**

--- a/src/plugins/abs/core/_metadata/_annotations.js
+++ b/src/plugins/abs/core/_metadata/_annotations.js
@@ -2,7 +2,7 @@
 /*:
  * @target MZ
  * @plugindesc
- * [v3.4.1 JABS] Enables combat to be carried out on the map.
+ * [v3.4.2 JABS] Enables combat to be carried out on the map.
  * @author JE
  * @url https://github.com/je-can-code/rmmz-plugins
  * @base J-Base
@@ -46,6 +46,8 @@
  * JABS lives at the top instead of the bottom like the rest of my plugins.
  *
  * CHANGELOG:
+ * - 3.4.2
+ *    Adjusted font size and sprite location for enemy battler name on map.
  * - 3.4.1
  *    Applied significant regeneration reduction for actors while in-combat.
  *    Fixed facing-auto-parry not working as-intended.

--- a/src/plugins/abs/core/_metadata/initialization.js
+++ b/src/plugins/abs/core/_metadata/initialization.js
@@ -96,7 +96,7 @@ J.ABS.Helpers.PluginManager.TranslateElementalIcons = obj =>
  */
 J.ABS.Metadata = {};
 J.ABS.Metadata.Name = 'J-ABS';
-J.ABS.Metadata.Version = '3.4.1';
+J.ABS.Metadata.Version = '3.4.2';
 
 /**
  * The actual `plugin parameters` extracted from RMMZ.

--- a/src/plugins/abs/core/sprites/Sprite_Character.js
+++ b/src/plugins/abs/core/sprites/Sprite_Character.js
@@ -551,13 +551,13 @@ Sprite_Character.prototype.createBattlerNameSprite = function()
   // build the text sprite.
   const sprite = new Sprite_BaseText()
     .setText(battlerName)
-    .setFontSize(10)
+    .setFontSize(16)
     .setAlignment(Sprite_BaseText.Alignments.Left)
     .setColor("#ffffff");
   sprite.setText(battlerName); // TODO: is this second assignment necessary???
 
   // relocate the sprite to a better position.
-  sprite.move(-30, 8);
+  sprite.move(-70, 0);
 
   // return this created sprite.
   return sprite;

--- a/src/plugins/level/_metadata/_annotations.js
+++ b/src/plugins/level/_metadata/_annotations.js
@@ -2,7 +2,7 @@
 /*:
  * @target MZ
  * @plugindesc
- * [v1.1.2 LEVEL] Allows levels to have greater control and purpose.
+ * [v1.2.0 LEVEL] Allows levels to have greater control and purpose.
  * @author JE
  * @url https://github.com/je-can-code/rmmz-plugins
  * @base J-Base
@@ -222,7 +222,7 @@
  * This same logic is again applied to gold from each defeated enemy.
  * ============================================================================
  * CHANGELOG:
- * - 1.1.2
+ * - 1.2.0
  *    Added ability to override JABS enemies on the map with a new level.
  * - 1.1.1
  *    Added ability to manipulate max level for actors.

--- a/src/plugins/level/_metadata/_annotations.js
+++ b/src/plugins/level/_metadata/_annotations.js
@@ -2,11 +2,12 @@
 /*:
  * @target MZ
  * @plugindesc
- * [v1.1.1 LEVEL] Allows levels to have greater control and purpose.
+ * [v1.1.2 LEVEL] Allows levels to have greater control and purpose.
  * @author JE
  * @url https://github.com/je-can-code/rmmz-plugins
  * @base J-Base
  * @orderAfter J-Base
+ * @orderAfter J-ABS
  * @help
  * ============================================================================
  * OVERVIEW
@@ -25,6 +26,10 @@
  * CAUTION:
  * This probably won't work with any other plugins that mess with the
  * level functionality of battlers.
+ *
+ * Integrates with others of mine plugins:
+ * - J-ABS; enables per-event-enemy level overrides.
+ *
  * ============================================================================
  * PLUGIN PARAMETERS BREAKDOWN:
  *  - Start Enabled:
@@ -78,6 +83,15 @@
  * each member of your party that gives experience- and is affected by the
  * normal level-scaling mechanics. The same applies to gold rewards.
  *
+ * NOTE ABOUT WORKING WITH JABS:
+ * If a level is present on an event that is identified as a JABS enemy, this
+ * level will override whatever is present on the database note section. You
+ * can think of the event as the real level, while the database notes are the
+ * "default" level for enemies. The overriden level still gets combined with
+ * any other modifications from states and whatnot. If an enemy has a level, by
+ * default it will show up in their battler name. If it is desired to be
+ * hidden, it can be converted to ??? by using the hide level tag.
+ *
  * DETAILS:
  * This was initially designed only for enemies, but has since been expanded to
  * also allow you to apply modifiers to your actors as well. For enemies, since
@@ -90,6 +104,7 @@
  * ENEMY TAG USAGE:
  * - Enemies
  * - States
+ * - Events (w/ JABS)
  *
  * ACTOR TAG USAGE:
  * - Actors
@@ -107,6 +122,7 @@
  *  <level:4>
  * On enemies, if on the enemy, it would set their base level to 4.
  * On enemies, if on a state, it would grant a +4 modifier to their base level.
+ * On events, this will override whatever the JABS enemy's level would be.
  * On actors, this would grant a +4 level modifier to their base level.
  *
  *  <level:-2>
@@ -114,6 +130,12 @@
  * On enemies, if on a state, and they have a base level set,
  *  this will grant a -2 modifier to their base level.
  * On actors, this will grant a -2 modifier to their base level.
+ *
+ *  <hideLevel>
+ * On enemies, this will turn the level into "???" instead of the level value.
+ * On events, this will override a singular enemy into hiding the value.
+ * On states, this will do nothing.
+ *
  * ============================================================================
  * SAMPLE CALCULATIONS:
  * Here is an example back and forth encounter between an allied party and
@@ -200,6 +222,8 @@
  * This same logic is again applied to gold from each defeated enemy.
  * ============================================================================
  * CHANGELOG:
+ * - 1.1.2
+ *    Added ability to override JABS enemies on the map with a new level.
  * - 1.1.1
  *    Added ability to manipulate max level for actors.
  *    Adapted extended plugin metadata structure.

--- a/src/plugins/level/_metadata/initialization.js
+++ b/src/plugins/level/_metadata/initialization.js
@@ -11,20 +11,24 @@ J.LEVEL = {};
 /**
  * The `metadata` associated with this plugin, such as version.
  */
-J.LEVEL.Metadata = new J_LevelPluginMetadata(`J-LevelMaster`, '1.1.1');
+J.LEVEL.Metadata = new J_LevelPluginMetadata(`J-LevelMaster`, '1.1.2');
 
 /**
  * All aliased methods for this plugin.
  */
 J.LEVEL.Aliased = {
+  Game_Action: new Map(),
   Game_Actor: new Map(),
   Game_Battler: new Map(),
-  Game_Action: new Map(),
+  Game_Enemy: new Map(),
+  Game_Event: new Map(),
   Game_System: new Map(),
   Game_Temp: new Map(),
   Game_Troop: new Map(),
 
   DataManager: new Map(),
+
+  Sprite_Character: new Map(),
 };
 
 /**
@@ -32,10 +36,22 @@ J.LEVEL.Aliased = {
  */
 J.LEVEL.RegExp = {
   /**
+   * The regex for hiding the level display of a battler.
+   * @type {RegExp}
+   */
+  HideLevel: /<hideLevel>/i,
+
+  /**
    * The regex for the level tag on various database objects.
    * @type {RegExp}
    */
-  BattlerLevel: /<(?:lv|lvl|level):[ ]?(-?\+?\d+)>/i,
+  Level: /<(?:lv|lvl|level):[ ]?(-?\+?\d+)>/i,
+
+  /**
+   * The regex for when a skill id is learned at a designated level.
+   * @type {RegExp}
+   */
+  Learning: /<learning: ?(\[\d+, ?\d+])>/i,
 
   /**
    * The regex for granting bonuses or penalties to max level (for actors only).

--- a/src/plugins/level/_metadata/initialization.js
+++ b/src/plugins/level/_metadata/initialization.js
@@ -11,7 +11,7 @@ J.LEVEL = {};
 /**
  * The `metadata` associated with this plugin, such as version.
  */
-J.LEVEL.Metadata = new J_LevelPluginMetadata(`J-LevelMaster`, '1.1.2');
+J.LEVEL.Metadata = new J_LevelPluginMetadata(`J-LevelMaster`, '1.2.0');
 
 /**
  * All aliased methods for this plugin.

--- a/src/plugins/level/objects/Game_Battler.js
+++ b/src/plugins/level/objects/Game_Battler.js
@@ -55,7 +55,7 @@ Game_Battler.prototype.getLevel = function()
   {
     // add the level extracted from the data.
     level += this.extractLevel(rpgData);
-  });
+  }, this);
 
   // return the new amount.
   return level;
@@ -96,6 +96,6 @@ Game_Battler.prototype.getLevelBalancer = function()
 Game_Battler.prototype.extractLevel = function(rpgData)
 {
   // extract the level from the notes.
-  return rpgData.getNumberFromNotesByRegex(J.LEVEL.RegExp.BattlerLevel);
+  return RPGManager.getNumberFromNoteByRegex(rpgData, J.LEVEL.RegExp.Level);
 };
 //endregion Game_Battler

--- a/src/plugins/level/objects/Game_Enemy.js
+++ b/src/plugins/level/objects/Game_Enemy.js
@@ -1,4 +1,185 @@
 //region Game_Enemy
+
+/**
+ * Extends {@link Game_Enemy.setup}.<br>
+ * Includes setting up the learned level map for skills.
+ */
+J.LEVEL.Aliased.Game_Enemy.set('initMembers', Game_Enemy.prototype.initMembers);
+Game_Enemy.prototype.initMembers = function()
+{
+  // perform original logic.
+  J.LEVEL.Aliased.Game_Enemy.get('initMembers')
+    .call(this);
+
+  /**
+   * The J object where all my additional properties live.
+   */
+  this._j ||= {};
+
+  /**
+   * A grouping of all properties associated with levels.
+   */
+  this._j._level ||= {};
+
+  /**
+   * All skill learnings this enemy has for it recorded as a dictionary.
+   * @type {Record<number, number>}
+   */
+  this._j._level._skillLearnings = {};
+};
+
+/**
+ * Sets a skill's learning by its skill and level.
+ * @param {number} skillId The skill id to be learned.
+ * @param {number} level The level the corresponding skill is learned.
+ */
+Game_Enemy.prototype.setSkillLearning = function(skillId, level)
+{
+  this._j._level._skillLearnings[skillId] = level;
+};
+
+/**
+ * Extends {@link Game_Enemy.setup}.<br>
+ * Includes setting up the learned level map for skills.
+ */
+J.LEVEL.Aliased.Game_Enemy.set('setup', Game_Enemy.prototype.setup);
+Game_Enemy.prototype.setup = function(enemyId, x, y)
+{
+  // perform original logic.
+  J.LEVEL.Aliased.Game_Enemy.get('setup')
+    .call(this, enemyId, x, y);
+
+  // initialize the skill learnings for this enemy.
+  this.setupSkillLearnings();
+};
+
+/**
+ * Sets up the learnings defined on the enemy.
+ */
+Game_Enemy.prototype.setupSkillLearnings = function()
+{
+  const learnings = RPGManager.getArraysFromNotesByRegex(this.enemy(), J.LEVEL.RegExp.Learning) ?? [];
+  if (learnings.length === 0) return;
+
+  learnings.forEach(learning => this.setSkillLearning(learning.at(0), learning.at(1)));
+};
+
+/**
+ * Extends {@link #canMapActionToSkill}.<br/>
+ * Also factors in whether or not the skill is technically learned or not.
+ * @param {RPG_EnemyAction} action The action being mapped to a skill.
+ * @returns {boolean}
+ */
+J.LEVEL.Aliased.Game_Enemy.set('canMapActionToSkill', Game_Enemy.prototype.canMapActionToSkill);
+Game_Enemy.prototype.canMapActionToSkill = function(action)
+{
+  // perform original logic.
+  const baseCanMap = J.LEVEL.Aliased.Game_Enemy.get('canMapActionToSkill')
+    .call(this, action);
+
+  // if the skill is otherwise unmappable, then don't bother with level-related logic.
+  if (baseCanMap === false) return false;
+
+  // determine if the skill is learned according to its level.
+  const isLearned = this.isLearnedSkillByLevel(action);
+
+  // return what we found.
+  return isLearned;
+};
+
+/**
+ * Determines if a skill has been learned from potential level restrictions.
+ * @param {RPG_EnemyAction} action The action being mapped to a skill.
+ * @returns {boolean}
+ */
+Game_Enemy.prototype.isLearnedSkillByLevel = function(action)
+{
+  const levelLearned = this._j._level._skillLearnings[action.skillId];
+
+  // if the skill didn't map, then the value will be undefined.
+  if (levelLearned === undefined) return true;
+
+  // if the enemy is at or above the level learned, then the skill is learned.
+  if (this.level >= levelLearned) return true;
+
+  // otherwise, the skill is not learned and shouldn't be considered.
+  return false;
+};
+
+/**
+ * Overrides {@link #getBattlerBaseLevel}.<br/>
+ * Instead of defaulting to zero, it will use the enemy's own note, accommodating any overrides if present.
+ * @returns {number}
+ */
+J.LEVEL.Aliased.Game_Enemy.set('getBattlerBaseLevel', Game_Enemy.prototype.getBattlerBaseLevel);
+Game_Enemy.prototype.getBattlerBaseLevel = function()
+{
+  // calculate the original level- probably zero unless another plugin modifies this.
+  const defaultBaseLevel = J.LEVEL.Aliased.Game_Enemy.get('getBattlerBaseLevel')
+    .call(this);
+
+  // grab the level from the enemy's own note.
+  const noteLevel = RPGManager.getNumberFromNoteByRegex(this.enemy(), J.LEVEL.RegExp.Level);
+
+  // combine the default and enemy levels.
+  const baseLevel = defaultBaseLevel + noteLevel;
+
+  // if there are no overrides, then return the base level.
+  if (this.hasLevelOverride() === false) return baseLevel;
+
+  // get the JABS_Battler associated with this enemy by UUID.
+  const jabsBattler = JABS_AiManager.getBattlerByUuid(this.getUuid());
+
+  // return the level override.
+  return jabsBattler.getCharacter()
+    .getLevelOverrides();
+};
+
+/**
+ * Checks if this enemy in particular has any JABS level overrides.
+ * @returns {boolean}
+ */
+Game_Enemy.prototype.hasLevelOverride = function()
+{
+  // if JABS isn't available, then there won't be a level override.
+  if (!J.ABS) return false;
+
+  // if there is no battler on this enemy, then there won't be a level override to check.
+  if (!this.getUuid()) return false;
+
+  // get the JABS_Battler associated with this enemy by UUID.
+  const jabsBattler = JABS_AiManager.getBattlerByUuid(this.getUuid());
+
+  // if there is no battler being tracked by this UUID, then there are no overrides.
+  if (!jabsBattler) return false;
+
+  // if overrides is null, then there are none.
+  if (jabsBattler.getCharacter()
+    .getLevelOverrides() === null)
+  {
+    return false;
+  }
+
+  // there must be overrides!
+  return true;
+};
+
+/**
+ * Determines if the level should be hidden for this enemy based on its notes.
+ * @returns {boolean} True if the level should be hidden, false otherwise.
+ */
+Game_Enemy.prototype.shouldHideLevel = function()
+{
+  // grab the reference data for this battler.
+  const referenceData = this.enemy();
+
+  // check if the hideLevel tag exists in the enemy's notes.
+  const hideLevel = RPGManager.checkForBooleanFromNoteByRegex(referenceData, J.LEVEL.RegExp.HideLevel);
+
+  // return whether the level should be hidden.
+  return hideLevel;
+};
+
 /**
  * Gets all database sources we can get levels from.
  * @returns {RPG_BaseItem[]}
@@ -7,19 +188,8 @@ Game_Enemy.prototype.getLevelSources = function()
 {
   // our sources of data that a level can be retrieved from.
   return [
-    this.enemy(),     // this enemy is a source.
     ...this.states(), // all states applied to this enemy are sources.
   ];
-};
-
-/**
- * The base or default level for this battler.
- * Enemies do not have a base level.
- * @returns {number}
- */
-Game_Enemy.prototype.getBattlerBaseLevel = function()
-{
-  return 0;
 };
 
 /**

--- a/src/plugins/level/objects/Game_Event.js
+++ b/src/plugins/level/objects/Game_Event.js
@@ -1,0 +1,175 @@
+//region Game_Event
+/**
+ * Extends {@link Game_Event.initMembers}.<br>
+ * Initializes level-related properties.
+ */
+J.LEVEL.Aliased.Game_Event.set('initMembers', Game_Event.prototype.initMembers);
+Game_Event.prototype.initMembers = function()
+{
+  // perform original logic.
+  J.LEVEL.Aliased.Game_Event.get('initMembers')
+    .call(this);
+
+  /**
+   * The J object where all my additional properties live.
+   */
+  this._j ||= {};
+
+  /**
+   * A grouping of all properties associated with levels.
+   */
+  this._j._level ||= {};
+
+  /**
+   * The cached level override value.
+   * @type {number|null}
+   */
+  this._j._level._cachedLevelOverride = null;
+
+  /**
+   * The cached check of whether or not to hide the level in the battler's name.
+   * @type {boolean|null}
+   */
+  this._j._level._cachedHideLevel = null;
+};
+
+/**
+ * Gets the cached level override.<br>
+ * If there is no override, this returns null instead.
+ * @returns {number|null}
+ */
+Game_Event.prototype.getCachedLevelOverride = function()
+{
+  return this._j._level._cachedLevelOverride;
+};
+
+/**
+ * Gets the cached flag for whether or not the level should be hidden.<br>
+ * If there is this hasn't been parsed, this returns null instead.
+ * @returns {boolean|null}
+ */
+Game_Event.prototype.getCachedHideLevel = function()
+{
+  return this._j._level._cachedHideLevel;
+};
+
+/**
+ * Sets the level override as a cached value.
+ * @param {number|null} level The new cached value.
+ */
+Game_Event.prototype.setCachedLevelOverride = function(level)
+{
+  this._j._level._cachedLevelOverride = level;
+};
+
+/**
+ * Sets the flag for hiding the level as a cached value.
+ * @param {boolean|null} hideLevel The new cached value.
+ */
+Game_Event.prototype.setCachedHideLevel = function(hideLevel)
+{
+  this._j._level._cachedHideLevel = hideLevel;
+};
+
+/**
+ * Extends {@link Game_Event.refresh}.<br>
+ * Clears the level override cache when the event page changes.
+ */
+J.LEVEL.Aliased.Game_Event.set('refresh', Game_Event.prototype.refresh);
+Game_Event.prototype.refresh = function()
+{
+  // perform original logic.
+  J.LEVEL.Aliased.Game_Event.get('refresh')
+    .call(this);
+
+  // clear the level override cache when the event page changes
+  this.clearLevelCache();
+};
+
+/**
+ * Clears the cached values related to levels.
+ */
+Game_Event.prototype.clearLevelCache = function()
+{
+  // reset back to default.
+  this.setCachedLevelOverride(null);
+  this.setCachedHideLevel(null);
+};
+
+/**
+ * Parses out the level from a list of event commands.
+ * @returns {number|null} The found level, or null if not found.
+ */
+Game_Event.prototype.getLevelOverrides = function()
+{
+  // check if we have a cached value
+  if (this._j._level._cachedLevelOverride !== null)
+  {
+    // return the cached value
+    return this._j._level._cachedLevelOverride;
+  }
+
+  // default to no level override
+  let level = null;
+
+  // check all the valid event commands to see if we have a level override
+  this.getValidCommentCommands()
+    .forEach(command =>
+    {
+      // shorthand the comment into a variable
+      const [ comment, ] = command.parameters;
+
+      // check if the comment matches the regex
+      const regexResult = J.LEVEL.RegExp.Level.exec(comment);
+
+      // if the comment didn't match, then don't try to parse it
+      if (!regexResult) return;
+
+      // parse the value out of the regex capture group
+      level = parseInt(regexResult[1]);
+    });
+
+  // cache the result for future use
+  this._j._level._cachedLevelOverride = level;
+
+  // return what we found
+  return level;
+};
+
+/**
+ * Determines if the level should be hidden for this event.
+ * @returns {boolean} True if the level should be hidden, false otherwise.
+ */
+Game_Event.prototype.shouldHideLevel = function()
+{
+  // check if we have a cached value.
+  if (this.getCachedHideLevel() !== null)
+  {
+    // return the cached value.
+    return this.getCachedHideLevel();
+  }
+
+  // default to not hiding the level.
+  let hideLevel = false;
+
+  // check all the valid event commands to see if we have a hide level tag.
+  this.getValidCommentCommands()
+    .forEach(command =>
+    {
+      // shorthand the comment into a variable.
+      const [ comment, ] = command.parameters;
+
+      // check if the comment contains the hideLevel tag.
+      if (J.LEVEL.RegExp.HideLevel.test(comment))
+      {
+        hideLevel = true;
+      }
+    });
+
+  // cache the result for future use
+  this.setCachedHideLevel(hideLevel);
+
+  // return what we found
+  return hideLevel;
+};
+//endregion Game_Event

--- a/src/plugins/level/sprites/Sprite_Character.js
+++ b/src/plugins/level/sprites/Sprite_Character.js
@@ -1,0 +1,47 @@
+//region Sprite_Character
+/**
+ * Gets this battler's name.
+ * If there is no battler, this will return an empty string.
+ * @returns {string}
+ */
+J.LEVEL.Aliased.Sprite_Character.set('getBattlerName', Sprite_Character.prototype.getBattlerName);
+Sprite_Character.prototype.getBattlerName = function()
+{
+  // get the original name of the sprite.
+  const originalName = J.LEVEL.Aliased.Sprite_Character.get('getBattlerName')
+    .call(this);
+
+  // if there was no battler name, then there probably isn't a battler.
+  if (originalName === String.empty) return originalName;
+
+  // grab the battler- we know it should exist by now.
+  const battler = this.getBattler();
+
+  // non-enemies don't get levels in their names.
+  if (battler.isEnemy() === false) return originalName;
+
+  // get the battler's level.
+  const level = battler.level;
+
+  // a zero level indicates there is no level logic associated with this battler.
+  if (level === 0) return originalName;
+
+  // capture the level as a string type for type-correct potential overriding.
+  let levelString = `${level.padZero(3)}`;
+
+  // check if this character is an event and if the level should be hidden
+  if (this._character && this._character.isEvent() && this._character.shouldHideLevel())
+  {
+    levelString = "???";
+  }
+
+  // if the level is not already hidden by event comments, check the enemy notes
+  if (levelString !== "???" && battler.shouldHideLevel())
+  {
+    levelString = "???";
+  }
+
+  // return the name with level.
+  return `${levelString} ${originalName}`;
+};
+//endregion Sprite_Character

--- a/src/plugins/natural/_metadata/_annotations.js
+++ b/src/plugins/natural/_metadata/_annotations.js
@@ -2,7 +2,7 @@
 /*:
  * @target MZ
  * @plugindesc
- * [v2.0.1 NATURAL] Enables level-based growth of all parameters.
+ * [v2.1.0 NATURAL] Enables level-based growth of all parameters.
  * @author JE
  * @url https://github.com/je-can-code/rmmz-plugins
  * @base J-Base
@@ -16,6 +16,7 @@
  * Integrates with others of mine plugins:
  * - J-CriticalFactors; enables natural growths of CDM/CDR.
  * - J-Passives; updates with relic gain as well.
+ * - J-LevelMaster; enables the ".lvl" access for formulas.
  *
  * ----------------------------------------------------------------------------
  * DETAILS:
@@ -93,6 +94,38 @@
  *  <atkGrowthPlus:[a.level * 3]>
  * Gain (the battler's level multiplied by 3) attack (atk) per level.
  * This would result in gaining an ever-increasing amount of attack per level.
+ * ----------------------------------------------------------------------------
+ * NATURAL GROWTHS AND REWARDS:
+ * While the above parameters and such are shared between actors and enemies
+ * alike, and thus a common pattern was useful, there are a couple of
+ * "parameters" that are unique to enemies: rewards. Specifically, experience
+ * and gold. Since they aren't directly useful in combat, their tags are a bit
+ * different.
+ *
+ * NOTE:
+ * The base value that is in the database for experience will be added to the
+ * calculated value for exp/gold, thus the static value in the database can
+ * be thought of as a "base" value.
+ *
+ * TAG USAGE:
+ * - Enemies
+ * - States
+ *
+ * TAG FORMAT:
+ *  <(REWARD)(PLUS):[FORMULA]>
+ * Where (REWARD) is either exp or gold.
+ * Where (PLUS) is... plus. There is no "rate" for this value.
+ * Where [FORMULA] is the formula to produce the amount.
+ *
+ * EXAMPLE:
+ *  <expPlus:[5 + a.lvl * 50]>
+ * When defeating this enemy, the experience gained will be increased by the
+ * enemy's level multiplied by 50, plus an extra 5.
+ *
+ *  <goldPlus:[100 + a.luk + a.level ** 2]>
+ * When defeating this enemy, the gold gained will be increased by 100 plus the
+ * enemy's luck value plus the enemy's level squared (to the second power).
+ *
  * ==============================================================================
  * EXAMPLE IDEAS:
  * While you can read about the syntax in the next section below, here I wanted
@@ -178,8 +211,14 @@
  * Custom Parameters:
  * - mtp (max tp)
  *
+ * Rewards (plus only, no rate):
+ * - exp
+ * - gold
+ *
  * ============================================================================
  * CHANGELOG:
+ * - 2.1.0
+ *    Added formula evaluation for enemy rewards on enemies.
  * - 2.0.1
  *    Fixed issue with buffs not being refreshed in Scene_Equip.
  * - 2.0.0

--- a/src/plugins/natural/_metadata/initialization.js
+++ b/src/plugins/natural/_metadata/initialization.js
@@ -21,7 +21,7 @@ J.NATURAL.Metadata = {
   /**
    * The version of this plugin.
    */
-  Version: '2.0.1',
+  Version: '2.1.0',
 };
 
 /**
@@ -195,5 +195,9 @@ J.NATURAL.RegExp = {
   MaxTechBuffRate: /mtpBuffRate:\[([+\-*/ ().\w]+)]>/gi,
   MaxTechGrowthPlus: /mtpGrowthPlus:\[([+\-*/ ().\w]+)]>/gi,
   MaxTechGrowthRate: /mtpGrowthRate:\[([+\-*/ ().\w]+)]>/gi,
+
+  // battle result rewards.
+  RewardExp: /<expPlus:\[([+\-*/ ().\w]+)]>/gi,
+  RewardGold: /<goldPlus:\[([+\-*/ ().\w]+)]>/gi,
 };
 //endregion Metadata

--- a/src/plugins/natural/objects/Game_Battler.js
+++ b/src/plugins/natural/objects/Game_Battler.js
@@ -124,6 +124,18 @@ Game_Battler.prototype.initNaturalGrowthParameters = function()
    * @type {number[]}
    */
   this._j._natural._xParamsBuffRate = [ 0, 0, 0, 0, 0, 0, 0, 0, 0, 0 ];
+
+  /**
+   * The amount of additional exp to gain. Only affects experience gained from an enemy's defeat.
+   * @type {number}
+   */
+  this._j._natural._expPlus = 0;
+
+  /**
+   * The amount of additional gold to gain. Only affects gold gained from an enemy's defeat.
+   * @type {number}
+   */
+  this._j._natural._goldPlus = 0;
 };
 
 //region max tp
@@ -445,6 +457,43 @@ Game_Battler.prototype.setXparamBuffRate = function(paramId, amount)
   this._j._natural._xParamsBuffRate[paramId] = amount;
 };
 //endregion x-params
+
+//region rewards
+/**
+ * Gets the bonus to rewarded experience.
+ * @returns {number}
+ */
+Game_Battler.prototype.expPlus = function()
+{
+  return this._j._natural._expPlus ?? 0;
+};
+
+/**
+ * Sets the bonus to rewarded experience.
+ * @param {number} expPlus The new bonus rewarded experience value.
+ */
+Game_Battler.prototype.setExpPlus = function(expPlus)
+{
+  this._j._natural._expPlus = expPlus;
+};
+
+/**
+ * Gets the bonus to rewarded gold.
+ */
+Game_Battler.prototype.goldPlus = function()
+{
+  return this._j._natural._goldPlus ?? 0;
+};
+
+/**
+ * Sets the bonus to rewarded gold.
+ * @param {number} goldPlus The new bonus rewarded gold value.
+ */
+Game_Battler.prototype.setGoldPlus = function(goldPlus)
+{
+  this._j._natural._goldPlus = goldPlus;
+};
+//endregion rewards
 //endregion properties
 
 /**
@@ -460,6 +509,7 @@ Game_Battler.prototype.refreshAllParameterBuffs = function()
   this.refreshBParamBuffs();
   this.refreshSParamBuffs();
   this.refreshXParamBuffs();
+  this.refreshRewardBonuses();
 };
 
 /**
@@ -476,6 +526,8 @@ Game_Battler.prototype.clearAllParameterBuffs = function()
   this._j._natural._sParamsBuffRate = [ 0, 0, 0, 0, 0, 0, 0, 0, 0, 0 ];
   this._j._natural._xParamsBuffPlus = [ 0, 0, 0, 0, 0, 0, 0, 0, 0, 0 ];
   this._j._natural._xParamsBuffRate = [ 0, 0, 0, 0, 0, 0, 0, 0, 0, 0 ];
+  this._j._natural._expPlus = 0;
+  this._j._natural._goldPlus = 0;
 };
 
 /**
@@ -599,6 +651,14 @@ Game_Battler.prototype.refreshSParamBuffs = function()
     // set the s-param buff rate modifier to this amount.
     this.setSparamBuffRate(paramId, buffRate);
   }, this);
+};
+
+/**
+ * Refreshes battle reward bonuses for the battler.
+ */
+Game_Battler.prototype.refreshRewardBonuses = function()
+{
+  // do nothing at this level.
 };
 
 /**

--- a/src/plugins/natural/objects/Game_Enemy.js
+++ b/src/plugins/natural/objects/Game_Enemy.js
@@ -211,4 +211,90 @@ Game_Enemy.prototype.getSparamNaturalBonuses = function(sparamId, baseParam)
   return this.calculateSpParamBuff(sparamId, baseParam);
 };
 //endregion sp params
+
+//region rewards
+/**
+ * Overrides {@link #refreshRewardBonuses}.<br>
+ * Implements the refresh for battle reward bonuses for the enemy.
+ */
+Game_Enemy.prototype.refreshRewardBonuses = function()
+{
+  this.refreshExpRewardBonuses();
+  this.refreshGoldRewardBonuses();
+};
+
+/**
+ * Refreshes the experience reward bonuses for this enemy.
+ */
+Game_Enemy.prototype.refreshExpRewardBonuses = function()
+{
+  // add the extracted formulai to an array.
+  const expBonusFormulai = this.extractParameterFormulai(J.NATURAL.RegExp.RewardExp);
+
+  // if no formulai were found, then stop processing.
+  if (!expBonusFormulai.length) return;
+
+  // calculate all formulai found for this enemy that could affect experience.
+  const bonusExp = this.naturalParamBuff(J.NATURAL.RegExp.RewardExp, this.enemy().exp);
+
+  // update the experience reward bonus.
+  this.setExpPlus(bonusExp);
+};
+
+/**
+ * Refreshes the gold reward bonuses for this enemy.
+ */
+Game_Enemy.prototype.refreshGoldRewardBonuses = function()
+{
+  // add the extracted formulai to an array.
+  const goldBonusFormulai = this.extractParameterFormulai(J.NATURAL.RegExp.RewardGold);
+
+  // if no formulai were found, then stop processing.
+  if (!goldBonusFormulai.length) return;
+
+  // calculate all formulai found for this enemy that could affect gold.
+  const bonusGold = this.naturalParamBuff(J.NATURAL.RegExp.RewardGold, this.enemy().gold);
+
+  // update the gold reward bonus.
+  this.setGoldPlus(bonusGold);
+};
+
+/**
+ * Extends {@link #exp}.<br>
+ * Also adds on any natural bonuses of experience.
+ * @returns {number}
+ */
+J.NATURAL.Aliased.Game_Enemy.set("exp", Game_Enemy.prototype.exp);
+Game_Enemy.prototype.exp = function()
+{
+  // grab the original value.
+  const baseReward = J.NATURAL.Aliased.Game_Enemy.get("exp")
+    .call(this);
+
+  // grab the bonus experience rewards.
+  const expBonus = this.expPlus();
+
+  // return the combined value.
+  return (baseReward + expBonus);
+};
+
+/**
+ * Extends {@link #gold}.<br>
+ * Also adds on any natural bonuses of gold.
+ * @returns {number}
+ */
+J.NATURAL.Aliased.Game_Enemy.set("gold", Game_Enemy.prototype.gold);
+Game_Enemy.prototype.gold = function()
+{
+  // grab the original value.
+  const baseReward = J.NATURAL.Aliased.Game_Enemy.get("gold")
+    .call(this);
+
+  // grab the bonus gold rewards.
+  const goldBonus = this.goldPlus();
+
+  // return the combined value.
+  return (baseReward + goldBonus);
+};
+//endregion rewards
 //endregion Game_Enemy

--- a/src/plugins/prof/objects/Game_Enemy.js
+++ b/src/plugins/prof/objects/Game_Enemy.js
@@ -2,6 +2,7 @@
 J.PROF.Aliased.Game_Enemy.set("initMembers", Game_Enemy.prototype.initMembers);
 Game_Enemy.prototype.initMembers = function()
 {
+  // perform original logic.
   J.PROF.Aliased.Game_Enemy.get("initMembers")
     .call(this);
 

--- a/src/plugins/sdp/_metadata/_annotations.js
+++ b/src/plugins/sdp/_metadata/_annotations.js
@@ -3,7 +3,7 @@
 /*:
  * @target MZ
  * @plugindesc
- * [v2.0.1 SDP] Enables the SDP system, aka Stat Distribution Panels.
+ * [v2.0.2 SDP] Enables the SDP system, aka Stat Distribution Panels.
  * @author JE
  * @url https://github.com/je-can-code/rmmz-plugins
  * @base J-Base
@@ -139,6 +139,8 @@
  * will now gain 50% increased SDP points (80 - 30 = 50).
  * ============================================================================
  * CHANGELOG:
+ * - 2.0.2
+ *    Added new getTotalSdpRanks function to actors for a new data point.
  * - 2.0.1
  *    Added filter for skipping panels that start with particular characters.
  *    Retroactively added note about breaking web deploys for this plugin.

--- a/src/plugins/sdp/_metadata/initialization.js
+++ b/src/plugins/sdp/_metadata/initialization.js
@@ -24,7 +24,7 @@ J.SDP = {};
 /**
  * The metadata associated with this plugin.
  */
-J.SDP.Metadata = new J_SdpPluginMetadata('J-SDP', '2.0.0');
+J.SDP.Metadata = new J_SdpPluginMetadata('J-SDP', '2.0.2');
 
 /**
  * A collection of all aliased methods for this plugin.

--- a/src/plugins/sdp/objects/Game_Actor.js
+++ b/src/plugins/sdp/objects/Game_Actor.js
@@ -95,6 +95,16 @@ Game_Actor.prototype.getAllSdpRankings = function()
 };
 
 /**
+ * Gets the total number of SDP ranks this actor has.
+ * @returns {number}
+ */
+Game_Actor.prototype.getTotalSdpRanks = function()
+{
+  return this.getAllSdpRankings()
+    .reduce((total, panelRanking) => total + panelRanking.currentRank, 0);
+};
+
+/**
  * Gets all unlocked panels for this actor.
  * @returns {PanelRanking[]}
  */
@@ -180,7 +190,7 @@ Game_Actor.prototype.modAccumulatedTotalSdpPoints = function(points)
  */
 Game_Actor.prototype.getAccumulatedSpentSdpPoints = function()
 {
-  return this._j._sdp._pointsEverGained;
+  return this._j._sdp._pointsSpent;
 };
 
 /**


### PR DESCRIPTION
This is primarily an update for the `J-LevelMaster` plugin to expand on the functionality of levels for enemies and integrate with JABS.

Now enemy events can have a `<level:VALUE>` tag on them and that will dynamically override whatever the level set in the database is. Additionally, the level is now displayed as a part of the battler name should a level be present either on the enemy in the database or in the event. The level value can be "hidden" aka masked by using the `<hideLevel>` tag on the enemy either in the database (effectively, the default) or on the event (effectively, the override). Also, you can have certain skills in an enemy's action list only become available in their list of considered skills by level by using one or more of the `<learning:[SKILL_ID, LEVEL_LEARNED]>` tags, to further master the levels (of enemies)!

![image](https://github.com/user-attachments/assets/c5edf06d-5bcb-4b49-9b1d-e1d553552181)

> If you're already familiar with this plugin, then you probably also know that changing level doesn't directly change stats, but it does impact the exp/gold earned and the damage dealt/received. However, if you wanted to be creative, you could leverage my `J-NaturalGrowths` plugin and apply formulas for various parameters to give the effect that stats also go up as they level- now also including their `exp` and `gold` rewards.

---
As a part of this effort, multiple plugins received minor updates:

### `J-LevelMaster` minor version update: `1.1.1` >> `1.2.0`
- allows defining per-enemy-event level overrides
- allows enemies to have skills that are only accessible if they are a high enough level
- displays enemy level on the battler name sprite that shows up when using JABS (allowing hiding tags)

### `J-Base` patch version update: `2.2.0` >> `2.2.1`
- includes an override-able function for mapping enemy skills

### `J-ABS` patch version update: `3.4.1` >> `3.4.2`
- adjusts battler name font size and sprite location for enemies on the map (bigger and left more)

### `J-NaturalGrowths` minor version update: `2.0.1` >> `2.1.0`
- adds new formulai for `exp` and `gold` rewards on enemies

### `J-SDP` patch version update: `2.0.1` >> `2.0.2`
- includes new `getTotalSdpRanks` on actors for a new data point