### PR TITLE
in combat indicator & sprint/dash interop

### DIFF
--- a/.junie/guidelines.md
+++ b/.junie/guidelines.md
@@ -175,8 +175,13 @@ When constructing new extensions, typically the structure defined is as such:
   * Never echo my feedback into the JsDocs- only write what the purpose of the function is so someone who reads it will understand the purpose of the function and not the iterative changes that occurred to the method as it was being built.
 * Always terminate statements with semicolons.
 * Always indent with 2 spaces, where applicable.
-* Prefer double quotes for strings.
-* Always use template literals for interpolation.
+* Prefer single quotes for strings.
+* Prefer to destructure objects and arrays if more than one property/item is being leveraged from the object/array.
+* Never write nested ternary operators.
+  * If you need to nest ternary operators, spell out the conditions with if blocks.
+* Prefer modern syntax where possible (such as `this._j ||= {}` instead of `if (!this._j) this._j = {}` or `this._j = this._j || {}` instead of `this._j = this._j || {}`).
+* Always prefer to expose new properties with getter and setter functions rather than direct property mutation.
+* Always use template literals for interpolation instead of `const someString = anotherString + yetAnotherString;`.
 * All example snippets in this document (including aliasing examples) should follow the same style rules (double quotes, semicolons, 2-space indent).
 * Trailing commas in arrays/objects are acceptable and even encouraged in some cases to indicate there are other (possibly useful but currently ignored) parameters available.
 * Line length should be capped at 120 for all source files except `_annotations.js` files.
@@ -184,6 +189,16 @@ When constructing new extensions, typically the structure defined is as such:
     * The whole file is effectively a metadata file that gets parsed explicitly by the RPG Maker MZ editor.
     * It is very much an oversized JSDoc, and uses multi-line comments, opening with `/**`, having ` * ` on every line, and closing with `*/`.
     * There are a number of special @ annotations and multi-line structures (see existing examples for reference).
+* do not needlessly/defensively attempt to validate/coerce state- it should be assumed that the state is valid.
+* When working with state, use this formula to determine the structure:
+  * `this._j.SENSIBLE_PLUGIN_ABBREVATION.FUNCTION_CONTAINER_NAME.SOME_STATE_NAME = default state`.
+    * for example, `this._j._abs._input._lastInput = null;`.
+  * always provide getter and setter functions for accessing and mutating state.
+  * never mutate state outside of a setter function.
+  * when a state represents a boolean, the getter may be named like `hasSomeState` or `isSomeState`.
+  * when a state represents a boolean, the setter may be named like `flagSomeState` or `toggleSomeState` or more appropriately based on the intended functionality.
+  * state should never be initialized in a getter or setter function, with one exception:
+    * if state is in a window, and properties need to be calculated upon initialization, then the getter/setter may need property initialization- use a common "init state" function (like _root()) to establish state default if it doesn't exist.
 * **Braces placement**:
   * Opening braces `{` should always be on a new line if syntactically possible
   * Closing braces `}` are on their own line

--- a/package.json
+++ b/package.json
@@ -21,7 +21,9 @@
   "scripts": {
     "plugin:init": "node ./src/build-tools/init.js",
 
-    "hotfix": "npm run build:all && npm run copy:to-all",
+    "hotfix": "npm run clean:out && npm run build:all && npm run copy:to-all",
+
+    "clean:out": "node ./src/build-tools/obliterator.js ./out",
 
     "copy:to-test": "node ./src/build-tools/copy.js",
     "copy:to-ca": "node ./src/build-tools/copy.js ../ca/chef-adventure/js/plugins/j",

--- a/project/js/plugins/J-Base.js
+++ b/project/js/plugins/J-Base.js
@@ -2,7 +2,7 @@
 /*:
  * @target MZ
  * @plugindesc
- * [v2.3.0 BASE] The base class for all J plugins.
+ * [v2.3.1 BASE] The base class for all J plugins.
  * @author JE
  * @url https://github.com/je-can-code/rmmz-plugins
  * @help
@@ -92,6 +92,10 @@
  *
  * ============================================================================
  * CHANGELOG:
+ * - 2.3.1
+ *    Added flag for showing external file load info across plugins.
+ *    Removed extraneous note tag enum-like object.
+ *    Updated various custom sprites with additional helpful methods.
  * - 2.3.0
  *    Added base Max TP management with tags for battlers.
  *    Added helper functions for detecting plugin commands inside of events.
@@ -165,7 +169,7 @@ J.BASE = {};
  */
 J.BASE.Metadata = {};
 J.BASE.Metadata.Name = `J-Base`;
-J.BASE.Metadata.Version = '2.3.0';
+J.BASE.Metadata.Version = '2.3.1';
 
 /**
  * The actual `plugin parameters` extracted from RMMZ.
@@ -174,34 +178,8 @@ J.BASE.PluginParameters = PluginManager.parameters(J.BASE.Metadata.Name);
 J.BASE.Metadata.BaseTpMaxActors = Number(J.BASE.PluginParameters['actorBaseTp']);
 J.BASE.Metadata.BaseTpMaxEnemies = Number(J.BASE.PluginParameters['enemyBaseTp']);
 
-/**
- * A collection of helpful mappings for `notes` that are placed in
- * various locations, like events on the map, or in a database enemy.
- */
-J.BASE.Notetags = {
-  // on actors in database.
-  KnockbackResist: "knockbackResist",
-  NoSwitch: "noSwitch",
-
-  MaxRefineCount: "maxRefine",
-  MaxRefineTraits: "maxRefinedTraits",
-  NotRefinementBase: "notRefinementBase",
-  NotRefinementMaterial: "notRefinementMaterial",
-  NoRefinement: "noRefine",
-
-  // on events on map.
-  Sight: "s",
-  Pursuit: "p",
-  MoveSpeed: "ms",
-  NoIdle: "noIdle",
-  NoHpBar: "noHpBar",
-  NoDangerIndicator: "noDangerIndicator",
-  NoBattlerName: "noName",
-  Inanimate: "inanimate",
-  AlertDuration: "ad",
-  AlertSightBoost: "as",
-  AlertPursuitBoost: "ap",
-};
+// TODO: plugin parameterize this and make it "show/minimal/hide".
+J.BASE.Metadata.ShowExternalFileLoadInfo = false;
 
 /**
  * The various traits captured here by id with a more meaningful descriptor.
@@ -288,6 +266,10 @@ J.BASE.Traits = {
  * All regular expressions used by this plugin.
  */
 J.BASE.RegExp = {};
+
+/**
+ * The basic structure for the maximum count of a number of items holdable is.
+ */
 J.BASE.RegExp.MaxItems = /<max:(d+)>/gi;
 
 /**
@@ -301,7 +283,6 @@ J.BASE.RegExp.MaxItems = /<max:(d+)>/gi;
  *    <someKeyWithStringValue:someValue>
  *    <someKeyWithRangeValue:startRange-endRange>
  *  </pre>
- * @type {RegExp}
  */
 J.BASE.RegExp.ParsableComment = /^<[[\]\w :"',.!+\-*/\\]+>$/i;
 
@@ -9564,9 +9545,9 @@ class Sprite_BaseText
    * The available supported text alignments.
    */
   static Alignments = {
-    Left: "left",
-    Center: "center",
-    Right: "right",
+    Left: 'left',
+    Center: 'center',
+    Right: 'right',
   };
 
   /**
@@ -9612,7 +9593,7 @@ class Sprite_BaseText
      * This should be a hexcode.
      * @type {string}
      */
-    this._j._color = "#ffffff";
+    this._j._color = '#ffffff';
 
     /**
      * The alignment of text in this sprite.
@@ -9643,6 +9624,19 @@ class Sprite_BaseText
      * @type {number}
      */
     this._j._fontSize = $gameSystem.mainFontSize();
+
+    /**
+     * The minimum width of the text.
+     * @type {number}
+     */
+    this._j._minWidth = 0;
+
+    /**
+     * Some systems that leverage {@link Sprite_BaseText} may have automation to manage the opacity of their text.
+     * Setting this flag to true will disable that automation and allow you to manage the opacity yourself.
+     * @type {boolean}
+     */
+    this._j._disableManagedOpacity = false;
   }
 
   /**
@@ -9676,6 +9670,9 @@ class Sprite_BaseText
     this.bitmap.fontBold = this.isBold();
     this.bitmap.fontItalic = this.isItalics();
     this.bitmap.textColor = this.color();
+
+    this.bitmap.outlineColor = "#000000"; // or a theme color
+    this.bitmap.outlineWidth = Math.max(2, Math.floor(this.fontSize() / 6));
   }
 
   /**
@@ -9714,8 +9711,10 @@ class Sprite_BaseText
     this._j._testBitmap.fontItalic = this.isItalics();
     this._j._testBitmap.fontBold = this.isBold();
 
-    // and return the measured text width.
-    return this._j._testBitmap.measureTextWidth(this.text());
+    // measure the text and respect a configured minimum width, if any.
+    const measured = this._j._testBitmap.measureTextWidth(this.text());
+    const min = this._j._minWidth;
+    return Math.max(measured, min);
   }
 
   /**
@@ -9797,7 +9796,7 @@ class Sprite_BaseText
   isValidColor(color)
   {
     // use regex to validate the hex color.
-    const structure = /^#([A-Fa-f0-9]{6}|[A-Fa-f0-9]{3})$/
+    const structure = /^#([A-Fa-f0-9]{6}|[A-Fa-f0-9]{3})$/;
     const isHexColor = structure.test(color);
 
     // check if we failed the validation.
@@ -9849,7 +9848,8 @@ class Sprite_BaseText
   isValidAlignment(alignment)
   {
     const validAlignments = [
-      Sprite_BaseText.Alignments.Left, Sprite_BaseText.Alignments.Center, Sprite_BaseText.Alignments.Right ]
+      Sprite_BaseText.Alignments.Left, Sprite_BaseText.Alignments.Center, Sprite_BaseText.Alignments.Right
+    ];
 
     return validAlignments.includes(alignment);
   }
@@ -9961,16 +9961,71 @@ class Sprite_BaseText
   }
 
   /**
+   * Gets the minimum width for the text box.
+   * @returns {number}
+   */
+  minWidth()
+  {
+    return this._j._minWidth;
+  }
+
+  /**
+   * Sets a minimum width for the text box. Useful to make center/right alignment visible.
+   * @param {number} width The minimum pixel width of this sprite’s bitmap.
+   * @returns {this}
+   */
+  setMinWidth(width)
+  {
+    // guard to make sure the width isn't being set to something negative.
+    const w = Math.max(0, width);
+
+    if (this._j._minWidth !== w)
+    {
+      this._j._minWidth = w;
+      this.refresh();
+    }
+
+    // return this for chaining if desired.
+    return this;
+  }
+
+  /**
+   * Flags this sprite to disable the managed opacity automation.
+   */
+  selfManageOpacity()
+  {
+    this._j._disableManagedOpacity = true;
+  }
+
+  /**
+   * Unflags this sprite to enable the managed opacity automation.
+   */
+  autoManageOpacity()
+  {
+    this._j._disableManagedOpacity = false;
+  }
+
+  /**
+   * Checks whether or not this sprite is flagged for self-managed opacity.
+   * @returns {boolean}
+   */
+  hasSelfManagedOpacity()
+  {
+    return this._j._disableManagedOpacity;
+  }
+
+  /**
    * Renders the text of this sprite.
    */
   renderText()
   {
-    const width = this.alignment() === Sprite_BaseText.Alignments.Center
-      ? this.width
+    // always draw using the bitmap’s own width so alignment behaves predictably.
+    const drawWidth = this.bitmap
+      ? this.bitmap.width
       : this.bitmapWidth();
 
     // draw the text with the current settings onto the bitmap.
-    this.bitmap.drawText(this.text(), 0, 0, width, this.bitmapHeight(), this.alignment());
+    this.bitmap.drawText(this.text(), 0, 0, drawWidth, this.bitmapHeight(), this.alignment());
   }
 }
 
@@ -10126,6 +10181,13 @@ class Sprite_Icon
      * @type {number}
      */
     this._j._iconColumns = ImageManager.iconColumns;
+
+    /**
+     * Some systems that leverage {@link Sprite_Icon} may have automation to manage the opacity of their icons.
+     * Setting this flag to true will disable that automation and allow you to manage the opacity yourself.
+     * @type {boolean}
+     */
+    this._j._disableManagedOpacity = false;
   }
 
   /**
@@ -10148,7 +10210,7 @@ class Sprite_Icon
     // upon promise delivery, execute the rendering.
     Promise.all([ bitmapPromise ])
       // execute on-ready logic, such as setting the icon index of this sprite to render.
-      .then(() => this.onReady(iconIndex))
+      .then(() => this.onReady(iconIndex));
   }
 
   /**
@@ -10177,6 +10239,7 @@ class Sprite_Icon
     this.bitmap = bitmap;
   }
 
+  //region properties
   /**
    * Gets the icon index from the iconset for this sprite.
    * @returns {number}
@@ -10255,6 +10318,33 @@ class Sprite_Icon
   {
     this._j._iconColumns = columns;
   }
+
+  /**
+   * Flags this sprite to disable the managed opacity automation.
+   */
+  selfManageOpacity()
+  {
+    this._j._disableManagedOpacity = true;
+  }
+
+  /**
+   * Unflags this sprite to enable the managed opacity automation.
+   */
+  autoManageOpacity()
+  {
+    this._j._disableManagedOpacity = false;
+  }
+
+  /**
+   * Checks whether or not this sprite is flagged for self-managed opacity.
+   * @returns {boolean}
+   */
+  hasSelfManagedOpacity()
+  {
+    return this._j._disableManagedOpacity;
+  }
+
+  //endregion properties
 
   /**
    * Upon becoming ready, execute this logic.
@@ -10618,21 +10708,21 @@ Window_Base.TextAlignments = {
    * The "left" text alignment.
    * This is the default and not normally required to be set.
    */
-  Left: "left",
+  Left: 'left',
 
   /**
    * The "center" text alignment.
    * This requires the full width of the area attempting to be centered within
    * be provided (such as the whole window's width).
    */
-  Center: "center",
+  Center: 'center',
 
   /**
    * The "right" text alignment.
    * It is encouraged to use {@link Window_Base.prototype.textWidth} to define the
    * width parameter in order to properly right-align.
    */
-  Right: "right"
+  Right: 'right'
 };
 
 /**

--- a/project/js/plugins/J-Difficulty.js
+++ b/project/js/plugins/J-Difficulty.js
@@ -732,7 +732,7 @@ class DifficultyMetadata
 /*:
  * @target MZ
  * @plugindesc
- * [v2.0.0 DIFFICULTY] A layered difficulty system.
+ * [v2.0.1 DIFFICULTY] A layered difficulty system.
  * @author JE
  * @url https://github.com/je-can-code/rmmz-plugins
  * @base J-Base
@@ -747,15 +747,19 @@ class DifficultyMetadata
  * actors and enemies alike.
  * ----------------------------------------------------------------------------
  * NOTE:
- * There are no tags for this plugin, but all difficulty layers are defined in
- * the plugin parameters.
+ * There are no tags for this plugin.
+ * All difficulties are defined in an external JSON file.
  * ============================================================================
  * CHANGELOG:
+ * - 2.0.1
+ *    Added flag for showing external file load info.
+ *    Removed dead plugin parameter inputs.
  * - 2.0.0
  *    Updated window layout of scene.
  *    Added multiple layer application support.
  *    Updated difficulty layers to also be applicable to actors if desired.
  *    Refactored a lot of underlying code.
+ *    Externalized difficulty layer data.
  * - 1.0.0
  *    Initial release.
  * ============================================================================
@@ -776,14 +780,6 @@ class DifficultyMetadata
  * @text Default Difficulty
  * @desc The key of the starting or default difficulty before it is decided.
  * @default 000_default
- *
- * @param difficulties
- * @parent difficultyConfigs
- * @type struct<DifficultyStruct>[]
- * @text Difficulties
- * @desc All difficulties, locked or otherwise.
- * @default ["{\"key\":\"020_Normal\",\"name\":\"Normal\",\"iconIndex\":\"883\",\"enabled\":\"false\",\"unlocked\":\"true\",\"hidden\":\"false\",\"description\":\"Your expected gameplay difficulty. Nothing is modified.\",\"bparams\":\"[]\",\"xparams\":\"[]\",\"sparams\":\"[]\",\"bonuses\":\"[]\"}","{\"key\":\"010_Easy\",\"name\":\"Easy\",\"iconIndex\":\"881\",\"enabled\":\"false\",\"unlocked\":\"true\",\"hidden\":\"false\",\"description\":\"A mild experience for players that want to try less and fun more.\",\"bparams\":\"[\\\"{\\\\\\\"parameterId\\\\\\\":\\\\\\\"0\\\\\\\",\\\\\\\"parameterRate\\\\\\\":\\\\\\\"80\\\\\\\"}\\\",\\\"{\\\\\\\"parameterId\\\\\\\":\\\\\\\"1\\\\\\\",\\\\\\\"parameterRate\\\\\\\":\\\\\\\"80\\\\\\\"}\\\",\\\"{\\\\\\\"parameterId\\\\\\\":\\\\\\\"2\\\\\\\",\\\\\\\"parameterRate\\\\\\\":\\\\\\\"80\\\\\\\"}\\\",\\\"{\\\\\\\"parameterId\\\\\\\":\\\\\\\"4\\\\\\\",\\\\\\\"parameterRate\\\\\\\":\\\\\\\"80\\\\\\\"}\\\",\\\"{\\\\\\\"parameterId\\\\\\\":\\\\\\\"7\\\\\\\",\\\\\\\"parameterRate\\\\\\\":\\\\\\\"110\\\\\\\"}\\\"]\",\"xparams\":\"[\\\"{\\\\\\\"parameterId\\\\\\\":\\\\\\\"1\\\\\\\",\\\\\\\"parameterRate\\\\\\\":\\\\\\\"50\\\\\\\"}\\\",\\\"{\\\\\\\"parameterId\\\\\\\":\\\\\\\"3\\\\\\\",\\\\\\\"parameterRate\\\\\\\":\\\\\\\"0\\\\\\\"}\\\",\\\"{\\\\\\\"parameterId\\\\\\\":\\\\\\\"4\\\\\\\",\\\\\\\"parameterRate\\\\\\\":\\\\\\\"0\\\\\\\"}\\\"]\",\"sparams\":\"[\\\"{\\\\\\\"parameterId\\\\\\\":\\\\\\\"6\\\\\\\",\\\\\\\"parameterRate\\\\\\\":\\\\\\\"120\\\\\\\"}\\\",\\\"{\\\\\\\"parameterId\\\\\\\":\\\\\\\"7\\\\\\\",\\\\\\\"parameterRate\\\\\\\":\\\\\\\"120\\\\\\\"}\\\"]\",\"bonuses\":\"[\\\"{\\\\\\\"bonusId\\\\\\\":\\\\\\\"0\\\\\\\",\\\\\\\"bonusRate\\\\\\\":\\\\\\\"120\\\\\\\"}\\\",\\\"{\\\\\\\"bonusId\\\\\\\":\\\\\\\"1\\\\\\\",\\\\\\\"bonusRate\\\\\\\":\\\\\\\"120\\\\\\\"}\\\",\\\"{\\\\\\\"bonusId\\\\\\\":\\\\\\\"2\\\\\\\",\\\\\\\"bonusRate\\\\\\\":\\\\\\\"120\\\\\\\"}\\\",\\\"{\\\\\\\"bonusId\\\\\\\":\\\\\\\"3\\\\\\\",\\\\\\\"bonusRate\\\\\\\":\\\\\\\"120\\\\\\\"}\\\"]\"}","{\"key\":\"030_Hard\",\"name\":\"Hard\",\"iconIndex\":\"885\",\"enabled\":\"false\",\"unlocked\":\"true\",\"hidden\":\"false\",\"description\":\"A more challenging experience where you might have to try more than button mashing to win.\",\"bparams\":\"[\\\"{\\\\\\\"parameterId\\\\\\\":\\\\\\\"0\\\\\\\",\\\\\\\"parameterRate\\\\\\\":\\\\\\\"120\\\\\\\"}\\\",\\\"{\\\\\\\"parameterId\\\\\\\":\\\\\\\"1\\\\\\\",\\\\\\\"parameterRate\\\\\\\":\\\\\\\"120\\\\\\\"}\\\",\\\"{\\\\\\\"parameterId\\\\\\\":\\\\\\\"2\\\\\\\",\\\\\\\"parameterRate\\\\\\\":\\\\\\\"120\\\\\\\"}\\\",\\\"{\\\\\\\"parameterId\\\\\\\":\\\\\\\"4\\\\\\\",\\\\\\\"parameterRate\\\\\\\":\\\\\\\"120\\\\\\\"}\\\",\\\"{\\\\\\\"parameterId\\\\\\\":\\\\\\\"7\\\\\\\",\\\\\\\"parameterRate\\\\\\\":\\\\\\\"120\\\\\\\"}\\\"]\",\"xparams\":\"[\\\"{\\\\\\\"parameterId\\\\\\\":\\\\\\\"1\\\\\\\",\\\\\\\"parameterRate\\\\\\\":\\\\\\\"150\\\\\\\"}\\\",\\\"{\\\\\\\"parameterId\\\\\\\":\\\\\\\"3\\\\\\\",\\\\\\\"parameterRate\\\\\\\":\\\\\\\"150\\\\\\\"}\\\",\\\"{\\\\\\\"parameterId\\\\\\\":\\\\\\\"4\\\\\\\",\\\\\\\"parameterRate\\\\\\\":\\\\\\\"150\\\\\\\"}\\\"]\",\"sparams\":\"[\\\"{\\\\\\\"parameterId\\\\\\\":\\\\\\\"6\\\\\\\",\\\\\\\"parameterRate\\\\\\\":\\\\\\\"80\\\\\\\"}\\\",\\\"{\\\\\\\"parameterId\\\\\\\":\\\\\\\"7\\\\\\\",\\\\\\\"parameterRate\\\\\\\":\\\\\\\"80\\\\\\\"}\\\"]\",\"bonuses\":\"[\\\"{\\\\\\\"bonusId\\\\\\\":\\\\\\\"0\\\\\\\",\\\\\\\"bonusRate\\\\\\\":\\\\\\\"150\\\\\\\"}\\\",\\\"{\\\\\\\"bonusId\\\\\\\":\\\\\\\"1\\\\\\\",\\\\\\\"bonusRate\\\\\\\":\\\\\\\"150\\\\\\\"}\\\",\\\"{\\\\\\\"bonusId\\\\\\\":\\\\\\\"2\\\\\\\",\\\\\\\"bonusRate\\\\\\\":\\\\\\\"150\\\\\\\"}\\\",\\\"{\\\\\\\"bonusId\\\\\\\":\\\\\\\"3\\\\\\\",\\\\\\\"bonusRate\\\\\\\":\\\\\\\"150\\\\\\\"}\\\"]\"}"]
- *
  *
  * @command callDifficultyMenu
  * @text Call Difficulty Menu
@@ -839,242 +835,6 @@ class DifficultyMetadata
  * @desc The amount to modify the max layer points by. This can be negative.
  * @min -999999
  * @max 999999
- */
-/*~struct~DifficultyStruct:
- * @param key
- * @parent overview
- * @type string
- * @text Unique Key
- * @desc A unique identifier for this difficulty.
- * Only letters, numbers, and underscores are recognized.
- * @default 010_Easy
- *
- * @param name
- * @parent overview
- * @type string
- * @text Name
- * @desc The name of the difficulty.
- * Displayed in the list of difficulties on the left.
- * @default Normal
- *
- * @param iconIndex
- * @parent overview
- * @type number
- * @text Icon Index
- * @desc The index of the icon to represent this difficulty.
- * @default 1
- *
- * @param description
- * @parent overview
- * @type string
- * @text Help Window Text
- * @desc Some text maybe describing the panel.
- * Shows up in the bottom help window.
- * @default Some really cool panel that has lots of hardcore powers.
- *
- * @param cost
- * @parent overview
- * @type number
- * @text Cost
- * @desc The cost required to enable this difficulty.
- * @default 0
- *
- * @param enabled
- * @parent overview
- * @text Is Enabled
- * @type boolean
- * @desc If this is ON/true, then this difficulty will be enabled when a new game starts.
- * @default false
- *
- * @param unlocked
- * @parent overview
- * @text Is Unlocked
- * @type boolean
- * @desc If this is ON/true, then this difficulty will be unlocked when a new game is started.
- * @default false
- *
- * @param hidden
- * @parent overview
- * @text Is Hidden
- * @type boolean
- * @desc If this is ON/true, then this difficulty will be hidden when a new game is started.
- * @default false
- *
- * @param enemyEffects
- * @parent data
- * @type struct<BattlerEffectsStruct>
- * @text Enemy Effects
- * @desc The effects that are applied to enemy battlers.
- * @default {"bparams":"[]","xparams":"[]","sparams":"[]"}
- *
- * @param actorEffects
- * @parent data
- * @type struct<BattlerEffectsStruct>
- * @text Actor Effects
- * @desc The effects that are applied to actor battlers.
- * @default {"bparams":"[]","xparams":"[]","sparams":"[]"}
- *
- * @param bonuses
- * @parent data
- * @type struct<BonusStruct>[]
- * @text Bonus Modifiers
- * @desc Bonuses listed here will be modified by the their respective provided rates.
- * @default []
- */
-/*~struct~BParamStruct:
- * @param parameterId
- * @text Parameter Id
- * @desc 0-7 are core parameters.
- * @type number
- * @type select
- * @option All params
- * @value -1
- * @option Max HP
- * @value 0
- * @option Max MP
- * @value 1
- * @option Power
- * @value 2
- * @option Endurance
- * @value 3
- * @option Force
- * @value 4
- * @option Resist
- * @value 5
- * @option Speed
- * @value 6
- * @option Luck
- * @value 7
- * @default 0
- *
- * @param parameterRate
- * @text Parameter Rate
- * @type number
- * @desc The percent multiplier that the given parameter will be modified by.
- * @default 100
- */
-/*~struct~XParamStruct:
- * @param parameterId
- * @text X-Parameter Id
- * @desc This x-parameter to be modified.
- * @type select
- * @option All params
- * @value -1
- * @option Hit Rate
- * @value 0
- * @option Evasion Rate
- * @value 1
- * @option Crit Chance
- * @value 2
- * @option Crit Evasion
- * @value 3
- * @option Magic Evasion
- * @value 4
- * @option Magic Reflect Rate
- * @value 5
- * @option Counter Rate
- * @value 6
- * @option HP Regen
- * @value 7
- * @option MP Regen
- * @value 8
- * @option TP Regen
- * @value 9
- * @default 0
- *
- * @param parameterRate
- * @text Parameter Rate
- * @type number
- * @desc The percent multiplier that the given parameter will be modified by.
- * @default 100
- */
-/*~struct~SParamStruct:
- * @param parameterId
- * @text S-Parameter Id
- * @desc This s-parameter to be modified.
- * @type select
- * @option All params
- * @value -1
- * @option Targeting Rate
- * @value 0
- * @option Guard Rate
- * @value 1
- * @option Recovery Rate
- * @value 2
- * @option Pharmacy Rate
- * @value 3
- * @option MP Cost Reduction
- * @value 4
- * @option TP Cost Reduction
- * @value 5
- * @option Phys DMG Reduction
- * @value 6
- * @option Magi DMG Reduction
- * @value 7
- * @option Floor DMG Reduction
- * @value 8
- * @option Experience Rate
- * @value 9
- * @default 0
- *
- * @param parameterRate
- * @text Parameter Rate
- * @type number
- * @desc The percent multiplier that the given parameter will be modified by.
- * @default 100
- */
-/*~struct~BonusStruct:
- * @param bonusId
- * @text Bonus Modifier
- * @desc This bonus rate to be modified.
- * @type select
- * @option Experience Earned
- * @value 0
- * @option Gold Found
- * @value 1
- * @option Loot Dropped
- * @value 2
- * @option SDP Acquired
- * @value 3
- * @default 0
- *
- * @param bonusRate
- * @text Bonus Rate
- * @type number
- * @desc The percent multiplier that the given bonus will be modified by.
- * @default 100
- */
-/*~struct~BattlerEffectsStruct:
- * @param bparams
- * @parent data
- * @type struct<BParamStruct>[]
- * @text B-Parameter Modifiers
- * @desc Parameters listed here will be modified by the their respective provided rates.
- * @default []
- *
- * @param xparams
- * @parent data
- * @type struct<XParamStruct>[]
- * @text X-Parameter Modifiers
- * @desc Parameters listed here will be modified by the their respective provided rates.
- * @default []
- *
- * @param sparams
- * @parent data
- * @type struct<SParamStruct>[]
- * @text S-Parameter Modifiers
- * @desc Parameters listed here will be modified by the their respective provided rates.
- * @default []
- *
- */
-/*
- * ==============================================================================
- * CHANGELOG:
- * - 2.0.0
- *    Updated to enable toggling one to many difficulties on at once.
- * - 1.0.0
- *    Initial release.
- * ==============================================================================
  */
 /* eslint-enable */
 
@@ -1267,9 +1027,16 @@ class J_DiffPluginMetadata
      */
     this.allMetadatas = classifiedMetadatas;
 
-    console.log(`loaded:
+    if (J.BASE.Metadata.ShowExternalFileLoadInfo)
+    {
+      console.log(`loaded:
       - ${this.allMetadatas.size} difficulty layers
       from file ${J_DiffPluginMetadata.CONFIG_PATH}.`);
+    }
+    else
+    {
+      console.log(`loaded from file ${J_DiffPluginMetadata.CONFIG_PATH}.`);
+    }
   }
 
   initializeMetadata()
@@ -1303,7 +1070,7 @@ var J = J || {};
 (() =>
 {
   // Check to ensure we have the minimum required version of the J-Base plugin.
-  const requiredBaseVersion = '2.1.3';
+  const requiredBaseVersion = '2.3.1';
   const hasBaseRequirement = J.BASE.Helpers.satisfies(J.BASE.Metadata.Version, requiredBaseVersion);
   if (!hasBaseRequirement)
   {
@@ -1320,7 +1087,7 @@ J.DIFFICULTY = {};
 /**
  * The `metadata` associated with this plugin, such as version.
  */
-J.DIFFICULTY.Metadata = new J_DiffPluginMetadata('J-Difficulty', '3.0.0');
+J.DIFFICULTY.Metadata = new J_DiffPluginMetadata('J-Difficulty', '2.0.1');
 
 /**
  * The actual `plugin parameters` extracted from RMMZ.

--- a/project/js/plugins/J-Proficiency.js
+++ b/project/js/plugins/J-Proficiency.js
@@ -179,7 +179,7 @@ SkillProficiency.prototype.improve = function(value)
 /*:
  * @target MZ
  * @plugindesc
- * [v2.0.0 PROF] Enables skill proficiency tracking.
+ * [v2.0.1 PROF] Enables skill proficiency tracking.
  * @author JE
  * @url https://github.com/je-can-code/rmmz-plugins
  * @base J-Base
@@ -324,6 +324,9 @@ SkillProficiency.prototype.improve = function(value)
  * - Decreasing the proficiency will NOT undo rewards gained.
  * ============================================================================
  * CHANGELOG:
+ * - 2.0.1
+ *    Added flag for showing external file load info.
+ *    Removed dead plugin parameters for conditionals.
  * - 2.0.0
  *    THIS UPDATE BREAKS WEB DEPLOY FUNCTIONALITY FOR YOUR GAME.
  *    Updated to extend common plugin metadata patterns.
@@ -333,12 +336,6 @@ SkillProficiency.prototype.improve = function(value)
  * - 1.0.0
  *    The initial release.
  * ============================================================================
- * @param conditionals
- * @type struct<ProficiencyConditionalStruct>[]
- * @text Proficiency Conditionals
- * @desc A set of conditions that when met reward the player.
- * @default []
- *
  * @command modifyActorSkillProficiency
  * @text Modify Actor's Proficiency
  * @desc Increase/decrease one or more actor's proficiency with one or more skills.
@@ -396,14 +393,16 @@ class J_ProficiencyPluginMetadata
         .map(requirement => new ProficiencyRequirement(
           requirement.skillId,
           requirement.proficiency,
-          requirement.secondarySkillIds));
+          requirement.secondarySkillIds
+        ));
 
       return new ProficiencyConditional(
         conditional.key,
         conditional.actorIds,
         requirements,
         conditional.skillRewards,
-        conditional.jsRewards);
+        conditional.jsRewards
+      );
     });
   }
 
@@ -460,11 +459,18 @@ class J_ProficiencyPluginMetadata
         data.push(conditional);
         this.actorConditionalsMap.set(actorId, data);
       });
-    })
+    });
 
-    console.log(`loaded:
+    if (J.BASE.Metadata.ShowExternalFileLoadInfo)
+    {
+      console.log(`loaded:
       - ${this.conditionals.length} proficiency conditionals
       from file ${J_ProficiencyPluginMetadata.CONFIG_PATH}.`);
+    }
+    else
+    {
+      console.log(`loaded from file ${J_ProficiencyPluginMetadata.CONFIG_PATH}.`);
+    }
   }
 }
 
@@ -484,7 +490,7 @@ J.PROF = {};
  * The metadata associated with this plugin.
  * @type {J_ProficiencyPluginMetadata}
  */
-J.PROF.Metadata = new J_ProficiencyPluginMetadata('J-Proficiency', '2.0.0');
+J.PROF.Metadata = new J_ProficiencyPluginMetadata('J-Proficiency', '2.0.1');
 
 /**
  * The various aliases associated with this plugin.

--- a/project/js/plugins/J-SDP.js
+++ b/project/js/plugins/J-SDP.js
@@ -808,7 +808,7 @@ class StatDistributionPanel
 /*:
  * @target MZ
  * @plugindesc
- * [v2.1.0 SDP] Enables the SDP system, aka Stat Distribution Panels.
+ * [v2.1.1 SDP] Enables the SDP system, aka Stat Distribution Panels.
  * @author JE
  * @url https://github.com/je-can-code/rmmz-plugins
  * @base J-Base
@@ -1002,6 +1002,8 @@ class StatDistributionPanel
  *
  * ============================================================================
  * CHANGELOG:
+ * - 2.1.1
+ *    Added flag for showing external file load info.
  * - 2.1.0
  *    Removed association of SDPs being backed by actual database items.
  *    Implemented JABS-centric basis for dynamically generating drops.
@@ -1152,9 +1154,9 @@ class J_SdpPluginMetadata
     {
       // validate the name is not one of the organizational names for the editor-only.
       const panelName = parsedPanel.name;
-      if (panelName.startsWith("__")) return;
-      if (panelName.startsWith("==")) return;
-      if (panelName.startsWith("--")) return;
+      if (panelName.startsWith('__')) return;
+      if (panelName.startsWith('==')) return;
+      if (panelName.startsWith('--')) return;
 
       // destructure the details we care about.
       const {
@@ -1171,7 +1173,8 @@ class J_SdpPluginMetadata
           parseInt(parsedParameter.parameterId),
           parseFloat(parsedParameter.perRank),
           parsedParameter.isFlat,
-          parsedParameter.isCore);
+          parsedParameter.isCore
+        );
         parsedPanelParameters.push(panelParameter);
       });
 
@@ -1185,7 +1188,8 @@ class J_SdpPluginMetadata
           const panelReward = new PanelRankupReward(
             parsedReward.rewardName,
             parseInt(parsedReward.rankRequired),
-            parsedReward.effect);
+            parsedReward.effect
+          );
           parsedPanelRewards.push(panelReward);
         });
       }
@@ -1208,7 +1212,7 @@ class J_SdpPluginMetadata
         .build();
 
       parsedPanels.push(panel);
-    }
+    };
 
     // build an SDP from each parsed item provided.
     parsedBlob.forEach(foreacher, this);
@@ -1272,9 +1276,16 @@ class J_SdpPluginMetadata
      */
     this.panelsMap = panelMap;
 
-    console.log(`loaded:
+    if (this.#hasMinimumBaseVersion() && J.BASE.Metadata.ShowExternalFileLoadInfo)
+    {
+      console.log(`loaded:
       - ${this.panels.length} panels
       from file ${J_SdpPluginMetadata.CONFIG_PATH}.`);
+    }
+    else
+    {
+      console.log(`loaded from file ${J_SdpPluginMetadata.CONFIG_PATH}.`);
+    }
   }
 
   initializeMetadata()
@@ -1318,7 +1329,40 @@ class J_SdpPluginMetadata
      * Both menus are shown/hidden by the menu switch id.
      * @type {boolean}
      */
-    this.jabsShowInBothMenus = this.parsedPluginParameters['showInBoth'] === "true";
+    this.jabsShowInBothMenus = this.parsedPluginParameters['showInBoth'] === 'true';
+  }
+
+  /**
+   * Checks if the BASE plugin meets the minimum version requirement for this plugin.
+   * @return {boolean}
+   */
+  #hasMinimumBaseVersion()
+  {
+    // identify the two versions for comparison.
+    const minimumVersion = this.#minimumBaseVersion();
+    const actualVersion = new PluginVersion(J.BASE.Metadata.Version);
+
+    // check if we meet the minimum version threshold.
+    const meetsThreshold = actualVersion.satisfiesPluginVersion(minimumVersion);
+
+    // if the version isn't high enough, then we cannot proceed.
+    if (!meetsThreshold) return false;
+
+    // we're good!
+    return true;
+  }
+
+  /**
+   * Gets the current minimum version of the J-BASE system this plugin requires.
+   * @returns {PluginVersion}
+   */
+  #minimumBaseVersion()
+  {
+    return PluginVersion.builder
+      .major('2')
+      .minor('3')
+      .patch('1')
+      .build();
   }
 }
 
@@ -1329,19 +1373,6 @@ class J_SdpPluginMetadata
  */
 var J = J || {};
 
-//region version checks
-(() =>
-{
-  // Check to ensure we have the minimum required version of the J-Base plugin.
-  const requiredBaseVersion = '2.1.3';
-  const hasBaseRequirement = J.BASE.Helpers.satisfies(J.BASE.Metadata.Version, requiredBaseVersion);
-  if (!hasBaseRequirement)
-  {
-    throw new Error(`Either missing J-Base or has a lower version than the required: ${requiredBaseVersion}`);
-  }
-})();
-//endregion version check
-
 /**
  * The plugin umbrella that governs all things related to this plugin.
  */
@@ -1350,7 +1381,7 @@ J.SDP = {};
 /**
  * The metadata associated with this plugin.
  */
-J.SDP.Metadata = new J_SdpPluginMetadata('J-SDP', '2.1.0');
+J.SDP.Metadata = new J_SdpPluginMetadata('J-SDP', '2.1.1');
 
 /**
  * A collection of all aliased methods for this plugin.

--- a/project/js/plugins/J-SDP.js
+++ b/project/js/plugins/J-SDP.js
@@ -1276,7 +1276,7 @@ class J_SdpPluginMetadata
      */
     this.panelsMap = panelMap;
 
-    if (this.#hasMinimumBaseVersion() && J.BASE.Metadata.ShowExternalFileLoadInfo)
+    if (J_SdpPluginMetadata.#hasMinimumBaseVersion() && J.BASE.Metadata.ShowExternalFileLoadInfo)
     {
       console.log(`loaded:
       - ${this.panels.length} panels
@@ -1336,7 +1336,7 @@ class J_SdpPluginMetadata
    * Checks if the BASE plugin meets the minimum version requirement for this plugin.
    * @return {boolean}
    */
-  #hasMinimumBaseVersion()
+  static #hasMinimumBaseVersion()
   {
     // identify the two versions for comparison.
     const minimumVersion = this.#minimumBaseVersion();
@@ -1356,7 +1356,7 @@ class J_SdpPluginMetadata
    * Gets the current minimum version of the J-BASE system this plugin requires.
    * @returns {PluginVersion}
    */
-  #minimumBaseVersion()
+  static #minimumBaseVersion()
   {
     return PluginVersion.builder
       .major('2')

--- a/project/js/plugins/J-SystemUtilities.js
+++ b/project/js/plugins/J-SystemUtilities.js
@@ -1,7 +1,7 @@
 /*:
  * @target MZ
  * @plugindesc
- * [v1.1.0 UTIL] Various system utilities.
+ * [v1.1.1 UTIL] Various system utilities.
  * @author JE
  * @url https://github.com/je-can-code/rmmz-plugins
  * @base J-Base
@@ -17,6 +17,8 @@
  * - pull up devtools window in background upon testplay (always).
  * ============================================================================
  * CHANGELOG:
+ * - 1.1.1
+ *    Added debugger for gamepad inputs.
  * - 1.1.0
  *    Implements strongly-typed plugin metadata.
  *    Added "pull up devtools upon testplay" functionality.
@@ -86,7 +88,7 @@ J.UTILS = {};
 /**
  * The metadata associated with this plugin, such as name and version.
  */
-J.UTILS.Metadata = new J_UtilsPluginMetadata('J-SystemUtilities', '1.0.1');
+J.UTILS.Metadata = new J_UtilsPluginMetadata('J-SystemUtilities', '1.1.1');
 
 /**
  * A collection of all aliased methods for this plugin.
@@ -94,6 +96,7 @@ J.UTILS.Metadata = new J_UtilsPluginMetadata('J-SystemUtilities', '1.0.1');
 J.UTILS.Aliased = {
   Game_Actor: new Map(),
   Game_Temp: new Map(),
+  Input: new Map(),
   Scene_Base: new Map(),
   Scene_Boot: new Map(),
   Scene_Map: new Map(),
@@ -113,12 +116,102 @@ J.UTILS.Helpers = {};
  * @param {any} o The object to check.
  * @returns {number} Chances are if this returns a number you're fine, otherwise it'll hang.
  */
+/* eslint-disable indent */
 J.UTILS.Helpers.depth = (o) => Object(o) === o
   ? 1 + Math.max(
   -1,
   ...Object.values(o)
-    .map(J.UTILS.Helpers.depth))
+    .map(J.UTILS.Helpers.depth)
+)
   : 0;
+/* eslint-enable indent */
+
+//region gamepad logging
+// create the lightweight gamepad logging namespace.
+J.UTILS.GamepadLog ||= {};
+
+// whether or not logging is enabled (opt-in).
+J.UTILS.GamepadLog.enabled = J.UTILS.GamepadLog.enabled || false;
+
+/**
+ * Enables console logging of fresh gamepad presses.
+ */
+J.UTILS.GamepadLog.enable = function()
+{
+  // mark logging as enabled.
+  this.enabled = true;
+
+  // inform the console that logging is now active.
+  console.log('[InputLog] Enabled.');
+};
+
+/**
+ * Disables console logging of fresh gamepad presses.
+ */
+J.UTILS.GamepadLog.disable = function()
+{
+  // mark logging as disabled.
+  this.enabled = false;
+
+  // inform the console that logging is now inactive.
+  console.log('[InputLog] Disabled.');
+};
+
+/**
+ * Logs only newly-pressed physical inputs resolved through Input.gamepadMapper.
+ * Uses centralized symbols from J.ABS.EXT.INPUT when available.
+ * @param {Gamepad} pad The active gamepad instance.
+ * @param {boolean[]} prev The previous button-state array (by index).
+ * @param {boolean[]} next The new button-state array (by index).
+ */
+J.UTILS.GamepadLog.logFreshPresses = function(pad, prev, next)
+{
+  // do not process if disabled.
+  if (this.enabled === false)
+  {
+    return;
+  }
+
+  // collect mapped symbols that transitioned from false -> true.
+  const symbols = [];
+
+  // iterate over the next-state buttons.
+  for (let i = 0; i < next.length; i++)
+  {
+    // determine current and previous pressed states.
+    const now = next[i] === true;
+    const was = prev[i] === true;
+
+    // only emit fresh presses.
+    if (now && was === false)
+    {
+      // resolve the physical symbol via the centralized mapper.
+      const mapped = Input.gamepadMapper[i];
+
+      // only log if the index is mapped to a known symbol.
+      if (mapped)
+      {
+        // add the resolved symbol to the list.
+        symbols.push(mapped);
+      }
+    }
+  }
+
+  // skip logging when there are no fresh presses.
+  if (symbols.length === 0)
+  {
+    return;
+  }
+
+  // build a concise pad label.
+  const label = pad.id
+    ? `${pad.id} (Index ${pad.index})`
+    : `Gamepad ${pad.index}`;
+
+  // emit a single consolidated log for this frame.
+  console.log(`[InputLog] ${label} pressed:`, symbols.join(', '));
+};
+//endregion gamepad logging
 
 /**
  * Overrides {@link Bitmap#_createCanvas}.<br>
@@ -152,6 +245,26 @@ Input.keyMapper = {
 
   // F6, the volume toggle key.
   117: 'volumeToggle',
+};
+
+/**
+ * Extends/Overrides {@link #_updateGamepadState}.<br/>
+ * Also logs only freshly pressed gamepad buttons/directions.
+ */
+J.UTILS.Aliased.Input.set("_updateGamepadState", Input._updateGamepadState);
+Input._updateGamepadState = function(gamepad)
+{
+  // capture the last known button state array for this pad.
+  const prev = this._gamepadStates[gamepad.index] || [];
+
+  // perform the original update to refresh internal states.
+  J.UTILS.Aliased.Input.get("_updateGamepadState").call(this, gamepad);
+
+  // extract the updated button state array populated by the original logic.
+  const next = this._gamepadStates[gamepad.index] || [];
+
+  // log only fresh presses resolved through the centralized mapper.
+  J.UTILS.GamepadLog.logFreshPresses(gamepad, prev, next);
 };
 //endregion Input
 

--- a/project/js/plugins/abs/J-ABS.js
+++ b/project/js/plugins/abs/J-ABS.js
@@ -238,6 +238,12 @@ class JABS_Action
      * @type {JABS_ActionOptions|null}
      */
     this._actionOptions = null;
+
+    /**
+     * The animation id to play once on the caster when the skill executes (after any casting).
+     * @type {number}
+     */
+    this._onCastAnimationId = this.getBaseSkill().jabsOnCastAnimationId ?? 0;
   }
 
   /**
@@ -444,6 +450,46 @@ class JABS_Action
   }
 
   /**
+   * Gets whether or not this action has an on-cast animation id.
+   * @returns {boolean}
+   */
+  hasOnCastAnimationId()
+  {
+    // non-zero indicates a configured animation.
+    return this.getOnCastAnimationId() !== 0;
+  }
+
+  /**
+   * Gets the on-cast animation id to display on the caster when executing this action.
+   * @returns {number}
+   */
+  getOnCastAnimationId()
+  {
+    // return the cached on-cast animation id.
+    return this._onCastAnimationId;
+  }
+
+  /**
+   * Performs the on-cast animation on the caster.
+   * @param {JABS_Battler=} caster Optional caster override; defaults to this action’s caster.
+   */
+  performOnCastAnimation(caster)
+  {
+    // determine the caster if not provided.
+    const who = caster || this.getCaster();
+
+    // validate a caster exists.
+    if (!who) return;
+
+    // only perform if a valid animation id is defined.
+    if (this.hasOnCastAnimationId())
+    {
+      // request the one-off animation on the caster’s map character.
+      who.getCharacter().requestAnimation(this.getOnCastAnimationId());
+    }
+  }
+
+  /**
    * Gets the `uuid` of this action.
    *
    * If one is not returned, then it is probably a direct action with no event representing it.
@@ -594,7 +640,7 @@ class JABS_Action
    */
   getMaxDuration()
   {
-    return Math.max(this.getBaseSkill().jabsDuration, JABS_Action.getMinimumDuration())
+    return Math.max(this.getBaseSkill().jabsDuration, JABS_Action.getMinimumDuration());
   }
 
   /**
@@ -1849,6 +1895,31 @@ JABS_Aggro.prototype.modAggro = function(modAggro, forced = false)
   this.aggro += modAggro;
   if (this.aggro < 0) this.aggro = 0;
 };
+
+/**
+ * Determines whether or not this aggro is for a living actor.
+ * @returns {boolean}
+ */
+JABS_Aggro.prototype.isForLivingActor = function()
+{
+  // grab the battler for reference.
+  const battler = JABS_AiManager.getBattlerByUuid(this.battlerUuid);
+
+  // if there was no battler by this id, then its not for an actor.
+  if (!battler) return false;
+
+  // if the battler is not an actor, then its not for an actor.
+  if (battler.isActor() !== false) return false;
+
+  // if the actor is dead, then it doesn't count.
+  if (battler.isDead() === true) return false;
+
+  // if the aggro is reset/empty, then it doesn't count.
+  if (this.aggro <= 0) return false;
+
+  // the aggro's target is a living actor.
+  return true;
+};
 //endregion JABS_Aggro
 
 //region JABS_AI
@@ -2521,6 +2592,18 @@ JABS_Battler.prototype.initBattleInfo = function()
    * @type {JABS_Aggro[]}
    */
   this._aggros = [];
+
+  /**
+   * Frames remaining that this battler is considered “in combat”.
+   * @type {number}
+   */
+  this._inCombatCountdown = 0;
+
+  /**
+   * Default window for the in‑combat countdown (60fps × seconds).
+   * @type {number}
+   */
+  this._inCombatWindowMax = 600; // 10s default.
 };
 
 /**
@@ -2589,6 +2672,7 @@ JABS_Battler.prototype.initCooldowns = function()
 //endregion initialize battler
 
 //region reference helpers
+//region else
 /**
  * Reassigns the character to something else.
  * @param {Game_Event|Game_Player|Game_Follower} newCharacter The new character to assign.
@@ -2903,7 +2987,7 @@ JABS_Battler.prototype.addFollower = function(newFollowerUuid)
   const found = this.getFollowerByUuid(newFollowerUuid);
   if (found)
   {
-    console.error("this follower already existed within the follower list.");
+    console.error('this follower already existed within the follower list.');
   }
   else
   {
@@ -2924,7 +3008,7 @@ JABS_Battler.prototype.removeFollower = function(oldFollowerUuid)
   }
   else
   {
-    console.error("could not find follower to remove from the list.", oldFollowerUuid);
+    console.error('could not find follower to remove from the list.', oldFollowerUuid);
   }
 };
 
@@ -2982,7 +3066,7 @@ JABS_Battler.prototype.removeFollowerByUuid = function(uuid)
  */
 JABS_Battler.prototype.clearLeaderData = function()
 {
-  this.setLeader("");
+  this.setLeader('');
   this.clearLeaderDecidedActionsQueue();
 };
 
@@ -3055,7 +3139,7 @@ JABS_Battler.prototype.isPlayer = function()
  */
 JABS_Battler.prototype.isActor = function()
 {
-  return (this.isPlayer() || this.getBattler() instanceof Game_Actor)
+  return (this.isPlayer() || this.getBattler() instanceof Game_Actor);
 };
 
 /**
@@ -4174,6 +4258,129 @@ JABS_Battler.prototype.isShowingAnimation = function()
   return this.getCharacter()
     .isAnimationPlaying();
 };
+
+//endregion rest
+
+//region in-combat
+/**
+ * Flags this battler as in‑combat for the full window.
+ */
+JABS_Battler.prototype.enterCombat = function()
+{
+  // set the in‑combat countdown to the window max.
+  this.setInCombatCountdown(this.getCombatWindowMax());
+};
+
+/**
+ * Gets the remaining frames for the in‑combat countdown.
+ * @returns {number}
+ */
+JABS_Battler.prototype.getInCombatCountdown = function()
+{
+  // return the number of frames remaining while in combat.
+  return this._inCombatCountdown || 0;
+};
+
+/**
+ * Gets the remaining in‑combat time in seconds with one decimal.
+ * @returns {number}
+ */
+JABS_Battler.prototype.getCombatSecondsRemaining = function()
+{
+  // convert remaining frames to seconds (60fps) with one decimal place.
+  const seconds = (this.getInCombatCountdown() / 60).toFixed(1);
+
+  // return the remaining seconds as a number.
+  return parseFloat(seconds);
+};
+
+/**
+ * Gets whether or not this battler is currently considered in‑combat.
+ * @returns {boolean}
+ */
+JABS_Battler.prototype.isInCombat = function()
+{
+  // honor the forced combat flag.
+  if ($jabsEngine.forcedCombat === true) return true;
+
+  // a positive countdown means still in combat.
+  if (this._inCombatCountdown > 0) return true;
+
+  // nothing combat-related is happening.
+  return false;
+};
+
+/**
+ * Gets the default in‑combat window duration.
+ * @returns {number}
+ */
+JABS_Battler.prototype.getCombatWindowMax = function()
+{
+  // return the configured max (fallback guards against legacy saves).
+  return this._inCombatWindowMax || 600;
+};
+
+/**
+ * Sets the default in‑combat window duration.
+ * @param {number} frames The number of frames to use for the window.
+ */
+JABS_Battler.prototype.setCombatWindowMax = function(frames)
+{
+  // clamp to zero minimum.
+  this._inCombatWindowMax = Math.max(0, frames);
+};
+
+/**
+ * Sets the current in‑combat countdown window.
+ * @param {number} frames The number of frames remaining.
+ */
+JABS_Battler.prototype.setInCombatCountdown = function(frames)
+{
+  // clamp to zero minimum.
+  this._inCombatCountdown = Math.max(0, frames);
+};
+
+/**
+ * Counts down the in‑combat timer.
+ */
+JABS_Battler.prototype.countdownCombat = function()
+{
+  // stop counting if finished.
+  if (this._inCombatCountdown <= 0)
+  {
+    this._inCombatCountdown = 0;
+    return;
+  }
+
+  // opportunistically compress the countdown when combat is truly clear.
+  // This reduces long tails after one‑shot wipes or non-retaliated kills.
+  // Tail length is 120 frames (2.0s) by default.
+  this._maybeShortenCombatTail(120);
+
+  // tick the countdown.
+  this._inCombatCountdown--;
+};
+
+/**
+ * Optionally clamps the in‑combat countdown to a short tail when there are
+ * no living enemies with aggro on the party.
+ * @param {number} tailFrames The maximum tail to leave when calm (in frames).
+ */
+JABS_Battler.prototype._maybeShortenCombatTail = function(tailFrames)
+{
+  // do not lengthen; only clamp if the window is larger than our tail.
+  if (this._inCombatCountdown <= tailFrames)
+  {
+    return;
+  }
+
+  // if nobody is aggroed to the party, compress the combat tail.
+  if (JABS_AiManager.anyLivingEnemiesAggroedToParty() === false)
+  {
+    this._inCombatCountdown = tailFrames;
+  }
+};
+//endregion in-combat
 //endregion reference helpers
 
 //region statics
@@ -4410,7 +4617,7 @@ JABS_Battler.prototype.update = function()
   this.updateCooldowns();
   this.updateTimers();
   this.updateEngagement();
-  this.updateRG();
+  this.updateRegen();
   this.updateDodging();
   this.updateDeathHandling();
 };
@@ -4441,7 +4648,9 @@ JABS_Battler.prototype.processQueuedActions = function()
     const options = primaryAction.getActionOptions();
 
     // try to read a frozen target location from the options.
-    const loc = options ? options.getTargetLocation() : null;
+    const loc = options
+      ? options.getTargetLocation()
+      : null;
 
     // if a frozen location exists, extract coordinates from it.
     if (loc)
@@ -4652,6 +4861,7 @@ JABS_Battler.prototype.updateTimers = function()
   this.processAlertTimer();
   this.processParryTimer();
   this.processLastHitTimer();
+  this.processCombatTimer();
   this.processCastingTimer();
   this.processEngagementTimer();
 };
@@ -4699,6 +4909,18 @@ JABS_Battler.prototype.processLastHitTimer = function()
   if (this.hasBattlerLastHit())
   {
     this.countdownLastHit();
+  }
+};
+
+/**
+ * Updates the timer for "in combat".
+ */
+JABS_Battler.prototype.processCombatTimer = function()
+{
+  // if in combat, update the combat timer.
+  if (this.isInCombat())
+  {
+    this.countdownCombat();
   }
 };
 
@@ -7044,10 +7266,10 @@ JABS_Battler.prototype.canPaySkillCost = function(skillId)
 /**
  * Updates all regenerations and ticks four times per second.
  */
-JABS_Battler.prototype.updateRG = function()
+JABS_Battler.prototype.updateRegen = function()
 {
   // check if we are able to update the RG.
-  if (!this.canUpdateRG()) return;
+  if (!this.canUpdateRegen()) return;
 
   //
   this.performRegeneration();
@@ -7058,7 +7280,7 @@ JABS_Battler.prototype.updateRG = function()
  * Determines whether or not the regeneration can be updated.
  * @returns {boolean}
  */
-JABS_Battler.prototype.canUpdateRG = function()
+JABS_Battler.prototype.canUpdateRegen = function()
 {
   // check if the regen is even ready for this battler.
   if (!this.isRegenReady()) return false;
@@ -7154,8 +7376,6 @@ JABS_Battler.prototype.processNaturalRegens = function()
   // process the natural hp/mp regens, possibly reduced.
   this.processNaturalHpRegen(isReduced);
   this.processNaturalMpRegen(isReduced);
-
-  // natural TP regen is never reduced.
   this.processNaturalTpRegen(isReduced);
 };
 
@@ -7168,12 +7388,11 @@ JABS_Battler.prototype.isNaturalRegenReduced = function()
   // enemies are not impacted by reduced natural regen.
   if (this.isEnemy()) return false;
 
-  // in-combat players will have a "last battler hit" tracked. Once that fades, they aren't in combat.
-  // TODO: may need to add a "i was last hit in the last 10 seconds" tracker.
-  if (this.isPlayer() && this.getBattlerLastHit() !== null) return true;
+  // if combat is globally forced (boss phases, etc), always reduced for non‑enemies.
+  if ($jabsEngine.forcedCombat === true) return true;
 
   // in-combat allies will be actors that are presently engaged.
-  if (this.isActor() && this.isEngaged()) return true;
+  if (this.isActor() && this.isInCombat()) return true;
 
   // no reason to reduce natural regen.
   return false;
@@ -7544,7 +7763,7 @@ JABS_Battler.prototype.slipEval = function(formula, sourceBattler, afflictedBatt
     if (!Number.isFinite(result))
     {
       // throw, and then catch to properly log in the next block.
-      throw new Error("Invalid formula.")
+      throw new Error('Invalid formula.');
     }
   }
   catch (err)
@@ -12810,6 +13029,11 @@ class JABS_Timer
  * JABS lives at the top instead of the bottom like the rest of my plugins.
  *
  * CHANGELOG:
+ * - 4.3.0
+ *    Unified sprint and dash as one alter-action.
+ *    Added a notion of "being in combat" based on hitting or being hit.
+ *    Force dash function to change to mobility skill while "in combat".
+ *    Added "on cast animation" that plays once a skill is done casting.
  * - 4.2.0
  *    Split projectile count from projectile formation.
  * - 4.1.1
@@ -14765,7 +14989,7 @@ var J = J || {};
 (() =>
 {
   // Check to ensure we have the minimum required version of the J-Base plugin.
-  const requiredBaseVersion = '2.1.3';
+  const requiredBaseVersion = '2.3.1';
   const hasBaseRequirement = J.BASE.Helpers.satisfies(J.BASE.Metadata.Version, requiredBaseVersion);
   if (!hasBaseRequirement)
   {
@@ -14783,7 +15007,7 @@ J.ABS = {};
 /**
  * The parent namespace for all JABS extensions.
  */
-J.ABS.EXT = {}
+J.ABS.EXT = {};
 
 //region helpers
 /**
@@ -14805,17 +15029,17 @@ J.ABS.Helpers.PluginManager.TranslateOptionToSlot = slot =>
 {
   switch (slot)
   {
-    case "Tool":
+    case 'Tool':
       return JABS_Button.Tool;
-    case "Dodge":
+    case 'Dodge':
       return JABS_Button.Dodge;
-    case "L1A":
+    case 'L1A':
       return JABS_Button.CombatSkill1;
-    case "L1B":
+    case 'L1B':
       return JABS_Button.CombatSkill2;
-    case "L1X":
+    case 'L1X':
       return JABS_Button.CombatSkill3;
-    case "L1Y":
+    case 'L1Y':
       return JABS_Button.CombatSkill4;
   }
 };
@@ -14853,7 +15077,7 @@ J.ABS.Helpers.PluginManager.TranslateElementalIcons = obj =>
  */
 J.ABS.Metadata = {};
 J.ABS.Metadata.Name = 'J-ABS';
-J.ABS.Metadata.Version = '4.2.0';
+J.ABS.Metadata.Version = '4.3.0';
 
 /**
  * The actual `plugin parameters` extracted from RMMZ.
@@ -14881,14 +15105,14 @@ J.ABS.Metadata.DefaultEnemyPursuitRange = Number(J.ABS.PluginParameters['default
 J.ABS.Metadata.DefaultEnemyAlertedSightBoost = Number(J.ABS.PluginParameters['defaultEnemyAlertedSightBoost']);
 J.ABS.Metadata.DefaultEnemyAlertedPursuitBoost = Number(J.ABS.PluginParameters['defaultEnemyAlertedPursuitBoost']);
 J.ABS.Metadata.DefaultEnemyAlertDuration = Number(J.ABS.PluginParameters['defaultEnemyAlertDuration']);
-J.ABS.Metadata.DefaultEnemyCanIdle = Boolean(J.ABS.PluginParameters['defaultEnemyCanIdle'] === "true");
-J.ABS.Metadata.DefaultEnemyShowHpBar = Boolean(J.ABS.PluginParameters['defaultEnemyShowHpBar'] === "true");
-J.ABS.Metadata.DefaultEnemyShowBattlerName = Boolean(J.ABS.PluginParameters['defaultEnemyShowBattlerName'] === "true");
-J.ABS.Metadata.DefaultEnemyIsInvincible = Boolean(J.ABS.PluginParameters['defaultEnemyIsInvincible'] === "true");
-J.ABS.Metadata.DefaultEnemyIsInanimate = Boolean(J.ABS.PluginParameters['defaultEnemyIsInanimate'] === "true");
+J.ABS.Metadata.DefaultEnemyCanIdle = Boolean(J.ABS.PluginParameters['defaultEnemyCanIdle'] === 'true');
+J.ABS.Metadata.DefaultEnemyShowHpBar = Boolean(J.ABS.PluginParameters['defaultEnemyShowHpBar'] === 'true');
+J.ABS.Metadata.DefaultEnemyShowBattlerName = Boolean(J.ABS.PluginParameters['defaultEnemyShowBattlerName'] === 'true');
+J.ABS.Metadata.DefaultEnemyIsInvincible = Boolean(J.ABS.PluginParameters['defaultEnemyIsInvincible'] === 'true');
+J.ABS.Metadata.DefaultEnemyIsInanimate = Boolean(J.ABS.PluginParameters['defaultEnemyIsInanimate'] === 'true');
 
 // custom data configurations.
-J.ABS.Metadata.UseElementalIcons = J.ABS.PluginParameters['useElementalIcons'] === "true";
+J.ABS.Metadata.UseElementalIcons = J.ABS.PluginParameters['useElementalIcons'] === 'true';
 J.ABS.Metadata.ElementalIcons = J.ABS.Helpers.PluginManager.TranslateElementalIcons(J.ABS.PluginParameters['elementalIconData']);
 
 // action decided configurations.
@@ -14920,10 +15144,10 @@ J.ABS.Metadata.DefaultStateLoseAllStacksAtOnce = (J.ABS.PluginParameters['defaul
 
 // miscellaneous configurations.
 J.ABS.Metadata.LootPickupRange = Number(J.ABS.PluginParameters['lootPickupDistance']);
-J.ABS.Metadata.DisableTextPops = Boolean(J.ABS.PluginParameters['disableTextPops'] === "true");
+J.ABS.Metadata.DisableTextPops = Boolean(J.ABS.PluginParameters['disableTextPops'] === 'true');
 J.ABS.Metadata.AllyRubberbandAdjustment = Number(J.ABS.PluginParameters['allyRubberbandAdjustment']);
 J.ABS.Metadata.DashSpeedBoost = Number(J.ABS.PluginParameters['dashSpeedBoost']);
-J.ABS.Metadata.HitboxOverlaysInitiallyVisible = (J.ABS.PluginParameters['hitboxOverlaysInitiallyVisible'] === "true");
+J.ABS.Metadata.HitboxOverlaysInitiallyVisible = (J.ABS.PluginParameters['hitboxOverlaysInitiallyVisible'] === 'true');
 
 // quick menu commands configurations.
 J.ABS.Metadata.EquipCombatSkillsText = J.ABS.PluginParameters['equipCombatSkillsText'];
@@ -14976,8 +15200,12 @@ J.ABS.Metadata.HitboxStyles = {
   // Battler overrides by kind (player/follower/battler)
   byKind:
     {
-      player:  { fillColor: 0x4DA3FF, lineColor: 0x2368CC, fillAlpha: 0.25 },
-      follower:{ fillColor: 0x9B59B6 },
+      player: {
+        fillColor: 0x4DA3FF,
+        lineColor: 0x2368CC,
+        fillAlpha: 0.25
+      },
+      follower: { fillColor: 0x9B59B6 },
       battler: { fillColor: 0x2ECC71 },
     },
 
@@ -15087,9 +15315,9 @@ J.ABS.Globals = {};
  *
  * * TODO: implement the global cooldown blocking other cooldowns.
  * * TODO: alternatively, consider applying cooldowns against global to all slots on a battler.
- * @type {"global"}
+ * @type {'global'}
  */
-J.ABS.Globals.GlobalCooldownKey = "global";
+J.ABS.Globals.GlobalCooldownKey = 'global';
 
 /**
  * A collection of helpful mappings for emoji balloons
@@ -15214,42 +15442,42 @@ J.ABS.Shapes = {
   /**
    * A circle shaped hitbox.
    */
-  Circle: "circle",
+  Circle: 'circle',
 
   /**
    * A rhombus (aka diamond) shaped hitbox.
    */
-  Rhombus: "rhombus",
+  Rhombus: 'rhombus',
 
   /**
    * A square around the target hitbox.
    */
-  Square: "square",
+  Square: 'square',
 
   /**
    *  A square in front of the target hitbox.
    */
-  FrontSquare: "frontsquare",
+  FrontSquare: 'frontsquare',
 
   /**
    * A line from the target hitbox.
    */
-  Line: "line",
+  Line: 'line',
 
   /**
    * An arc shape hitbox in front of the action.
    */
-  Arc: "arc",
+  Arc: 'arc',
 
   /**
    * A wall in front of the target hitbox.
    */
-  Wall: "wall",
+  Wall: 'wall',
 
   /**
    * A cross from the target hitbox.
    */
-  Cross: "cross"
+  Cross: 'cross'
 };
 
 /**
@@ -15257,19 +15485,19 @@ J.ABS.Shapes = {
  */
 J.ABS.ProjectileFormations = {
   /** A single spoke in the forward direction. */
-  Line: "line",
+  Line: 'line',
 
   /** Three spokes: forward, forward-left, forward-right. */
-  Spray: "spray",
+  Spray: 'spray',
 
   /** Four cardinals: up, right, down, left. */
-  Cross: "cross",
+  Cross: 'cross',
 
   /** Four diagonals: up-right, down-right, down-left, up-left. */
-  Xburst: "xburst",
+  Xburst: 'xburst',
 
   /** All eight directions: cardinals + diagonals. */
-  Nova: "nova",
+  Nova: 'nova',
 };
 
 /**
@@ -15278,9 +15506,9 @@ J.ABS.ProjectileFormations = {
  */
 J.ABS.Notetags = {
   MoveType: {
-    Forward: "forward",
-    Backward: "backward",
-    Directional: "directional",
+    Forward: 'forward',
+    Backward: 'backward',
+    Directional: 'directional',
   }
 };
 
@@ -15319,6 +15547,7 @@ J.ABS.RegExp = {
 
   // animation-related.
   SelfAnimationId: /<selfAnimationId:[ ]?(\d+)>/gi,
+  OnCastAnimationId: /<onCastAnimationId:[ ]?(\d+)>/gi,
 
   // combo-related.
   ComboAction: /<combo:[ ]?(\[\d+,[ ]?\d+])>/gi,
@@ -15480,10 +15709,10 @@ J.ABS.RegExp.VisDebug = /<visDebug>/gi; // show visual center/debug gizmo
  * Cardinal: U/D/L/R
  * Optional diagonals: UR/UL/DR/DL
  */
-J.ABS.RegExp.VisOffsetU  = /<visOffsetU:[ ]?(\[-?\d+,[ ]?-?\d+])>/gi;  // [x, y]
-J.ABS.RegExp.VisOffsetD  = /<visOffsetD:[ ]?(\[-?\d+,[ ]?-?\d+])>/gi;  // [x, y]
-J.ABS.RegExp.VisOffsetL  = /<visOffsetL:[ ]?(\[-?\d+,[ ]?-?\d+])>/gi;  // [x, y]
-J.ABS.RegExp.VisOffsetR  = /<visOffsetR:[ ]?(\[-?\d+,[ ]?-?\d+])>/gi;  // [x, y]
+J.ABS.RegExp.VisOffsetU = /<visOffsetU:[ ]?(\[-?\d+,[ ]?-?\d+])>/gi;  // [x, y]
+J.ABS.RegExp.VisOffsetD = /<visOffsetD:[ ]?(\[-?\d+,[ ]?-?\d+])>/gi;  // [x, y]
+J.ABS.RegExp.VisOffsetL = /<visOffsetL:[ ]?(\[-?\d+,[ ]?-?\d+])>/gi;  // [x, y]
+J.ABS.RegExp.VisOffsetR = /<visOffsetR:[ ]?(\[-?\d+,[ ]?-?\d+])>/gi;  // [x, y]
 
 // Optional diagonals for future use.
 J.ABS.RegExp.VisOffsetUR = /<visOffsetUR:[ ]?(\[-?\d+,[ ]?-?\d+])>/gi; // [x, y]
@@ -17939,6 +18168,40 @@ RPG_Skill.prototype.extractJabsSelfAnimationId = function()
 };
 //endregion range
 
+//region onCastAnimation
+/**
+ * The animation id to play on the caster once when the skill actually executes.
+ * @type {number}
+ */
+Object.defineProperty(RPG_Skill.prototype, 'jabsOnCastAnimationId', {
+  get: function()
+  {
+    // retrieve the parsed on-cast animation id from notes.
+    return this.getJabsOnCastAnimationId();
+  },
+});
+
+/**
+ * Gets the on-cast animation id for this skill.
+ * @returns {number}
+ */
+RPG_Skill.prototype.getJabsOnCastAnimationId = function()
+{
+  // parse and return the value from notes.
+  return this.extractJabsOnCastAnimationId();
+};
+
+/**
+ * Extracts the on-cast animation id for this skill from its notes.
+ * @returns {number}
+ */
+RPG_Skill.prototype.extractJabsOnCastAnimationId = function()
+{
+  // use the shared regex dictionary to pull the integer.
+  return this.getNumberFromNotesByRegex(J.ABS.RegExp.OnCastAnimationId, true);
+};
+//endregion onCastAnimation
+
 //region delay
 /**
  * The JABS delay data for this skill.
@@ -19738,7 +20001,7 @@ class JABS_AiManager
    */
   constructor()
   {
-    throw new Error("This is a static class.");
+    throw new Error('This is a static class.');
   }
 
   //region get battlers
@@ -20055,6 +20318,38 @@ class JABS_AiManager
     return battlers.sort(comparing);
   }
 
+  /**
+   * Determines whether any living enemy currently has aggro on any party member.
+   * @returns {boolean}
+   */
+  static anyLivingEnemiesAggroedToParty()
+  {
+    // get all tracked enemy battlers from your registry.
+    const enemies = JABS_AiManager.getEnemyBattlers();
+
+    // if there are no enemies, then there is no aggro.
+    if (!enemies.length) return false;
+
+    // iterate for any enemy who is alive and has aggro on a party target.
+    const hasAggroOnParty = enemies.some(enemy =>
+    {
+      // grab all the aggros for this enemy for reference.
+      const aggros = enemy.getAllAggros();
+
+      // if there are no aggros, then this enemy has no aggro for the party.
+      if (aggros.length === 0) return false;
+
+      // return whether or not there are active aggros for a living actor.
+      return aggros.some(aggro => aggro.isForLivingActor());
+    });
+
+    // one or more of the enemies has active aggro on the party.
+    if (hasAggroOnParty) return true;
+
+    // nobody has aggro on the party.
+    return false;
+  }
+
   //endregion get battlers
 
   //region manage battlers
@@ -20178,7 +20473,7 @@ class JABS_AiManager
     this.postConvertMutate(battler, jabsBattler);
 
     // if there is something affecting max hp- such as natural growths- they should be fully healed on-creation.
-    battler.recoverAll()
+    battler.recoverAll();
 
     // return the newly created battler.
     return jabsBattler;
@@ -20260,7 +20555,7 @@ class JABS_AiManager
     if (J.ABS.EXT.DANGER)
     {
       // never show the danger indicator for allies.
-      builder.setShowDangerIndicator(false)
+      builder.setShowDangerIndicator(false);
     }
 
     // build the core data.
@@ -20427,7 +20722,8 @@ class JABS_AiManager
     // grab all available battlers within a fixed range.
     const battlers = this.getAllBattlersWithinRangeSortedByDistance(
       $jabsEngine.getPlayer1(),
-      J.ABS.Metadata.MaxAiUpdateRange);
+      J.ABS.Metadata.MaxAiUpdateRange
+    );
 
     // if we have no battlers, then do not process AI.
     if (!battlers.length) return;
@@ -21137,13 +21433,13 @@ class JABS_AiManager
     if (action.isSupportAction())
     {
       // show the "support decision" animation on the battler.
-      battler.showAnimation(J.ABS.Metadata.SupportDecidedAnimationId)
+      battler.showAnimation(J.ABS.Metadata.SupportDecidedAnimationId);
     }
     // the action is not a support action.
     else
     {
       // show the "attack decision" animation on the battler.
-      battler.showAnimation(J.ABS.Metadata.AttackDecidedAnimationId)
+      battler.showAnimation(J.ABS.Metadata.AttackDecidedAnimationId);
     }
   }
 
@@ -21421,6 +21717,12 @@ class JABS_Engine
    */
   hitboxOverlaysVisible = false;
 
+  /**
+   * When `true`, all non‑enemies are considered in combat (UI and mechanics that consult the engine).
+   * Useful for boss phases or scripted moments.
+   * @type {boolean}
+   */
+  forcedCombat = false;
   //endregion properties
 
   /**
@@ -22636,6 +22938,9 @@ class JABS_Engine
     // handle the cast animation for this action.
     this.handleActionCastAnimation(caster, action);
 
+    // handle the one-off on-cast animation on the caster at execution time.
+    this.handleActionOnCastAnimation(caster, action);
+
     // handle the generation of the action on the map.
     this.handleActionGeneration(caster, action, targetX, targetY);
   }
@@ -22669,6 +22974,21 @@ class JABS_Engine
       // execute the cast animation.
       caster.getCharacter()
         .requestAnimation(casterAnimation);
+    }
+  }
+
+  /**
+   * Handles the single-fire, on-cast animation on the caster at execution time.
+   * @param {JABS_Battler} caster The `JABS_Battler` executing the JABS action.
+   * @param {JABS_Action} action The JABS action to execute.
+   */
+  handleActionOnCastAnimation(caster, action)
+  {
+    // only perform if an on-cast animation id is configured.
+    if (action.hasOnCastAnimationId())
+    {
+      // play it once on the caster’s character.
+      action.performOnCastAnimation(caster);
     }
   }
 
@@ -23715,9 +24035,19 @@ class JABS_Engine
     this.triggerAlert(caster, target);
 
     // if the attacker and the target are the same team, then don't set that as "last hit".
-    if (!(caster.isSameTeam(target.getTeam())))
+    if ((caster.isSameTeam(target.getTeam())) === false)
     {
       caster.setBattlerLastHit(target);
+
+      // refresh in‑combat timers on real engagements only.
+      const isHealing = action.isHealing();
+      const hitOrParry = (result.isHit() || result.parried);
+      if (hitOrParry && isHealing === false && target.isInanimate() === false)
+      {
+        // both sides are considered engaged.
+        caster.enterCombat();
+        target.enterCombat();
+      }
     }
   }
 
@@ -31792,6 +32122,31 @@ Game_Party.prototype.leaderJabsBattler = function()
   // return the leader's battler.
   return JABS_AiManager.getBattlerByUuid(leaderUuid);
 };
+
+/**
+ * Gets whether any current party battle member is in combat.
+ * @returns {boolean}
+ */
+Game_Party.prototype.anyMemberInCombat = function()
+{
+  // if globally forced, then the party is in combat.
+  if ($jabsEngine.forcedCombat === true) return true;
+
+  // check each battle member for a tracked JABS battler that is in combat.
+  const members = this.battleMembers();
+  for (let i = 0; i < members.length; i++)
+  {
+    const actor = members[i];
+    const jabsBattler = JABS_AiManager.getBattlerByUuid(actor.getUuid());
+    if (jabsBattler && jabsBattler.isInCombat())
+    {
+      return true;
+    }
+  }
+
+  // nobody is in combat.
+  return false;
+};
 //endregion Game_Party
 
 //region Game_Player
@@ -31856,6 +32211,25 @@ Game_Player.prototype.canMove = function()
 };
 
 /**
+ * Extends/Overrides {@link #isDashing}.<br/>
+ * Disables engine dash while the player is in JABS combat.
+ */
+J.ABS.Aliased.Game_Player.set("isDashing", Game_Player.prototype.isDashing);
+Game_Player.prototype.isDashing = function()
+{
+  // if JABS says the party is in combat, engine-style dashing is disabled.
+  const inCombat = $gameParty.anyMemberInCombat();
+  if (inCombat)
+  {
+    // force no dash during combat so sprint cannot re-assert itself.
+    return false;
+  }
+
+  // otherwise, perform original engine logic.
+  return J.ABS.Aliased.Game_Player.get("isDashing").call(this);
+};
+
+/**
  * Initializes the player's `JABS_Battler` if it was not already initialized.
  */
 J.ABS.Aliased.Game_Player.set('refresh', Game_Player.prototype.refresh);
@@ -31886,6 +32260,7 @@ Game_Player.prototype.updateMove = function()
   this.checkForLoot();
 };
 
+//region loot
 /**
  * Checks to see if the player coordinates are intercepting with any loot
  * currently on the ground.
@@ -32050,6 +32425,7 @@ Game_Player.prototype.removeLoot = function(lootEvent)
   lootEvent.setLootNeedsRemoving(true);
   $jabsEngine.requestClearLoot = true;
 };
+//endregion loot
 //endregion Game_Player
 
 //region Game_Switches

--- a/project/js/plugins/abs/ext/J-ABS-InputManager.js
+++ b/project/js/plugins/abs/ext/J-ABS-InputManager.js
@@ -2,7 +2,7 @@
 /*:
  * @target MZ
  * @plugindesc
- * [v2.1.1 INPUT] A manager for overseeing the input of JABS.
+ * [v2.2.0 INPUT] A manager for overseeing the input of JABS.
  * @author JE
  * @url https://github.com/je-can-code/rmmz-plugins
  * @base J-ABS
@@ -38,6 +38,10 @@
  * ============================================================================
  * CHANGELOG
  * ----------------------------------------------------------------------------
+ * - 2.2.0
+ *    Removed independent remappability of sprint and mobility.
+ *    Added support for tracking "in combat" to handle dash/mobility switching.
+ *    Updated sprint input to switch to mobility skill while "in combat".
  * - 2.1.1
  *    Fixed typo in custom input mapping.
  * - 2.1.0
@@ -60,7 +64,7 @@ var J = J || {};
 (() =>
 {
   // Check to ensure we have the minimum required version of the J-Base plugin.
-  const requiredBaseVersion = '2.1.0';
+  const requiredBaseVersion = '2.3.1';
   const hasBaseRequirement = J.BASE.Helpers.satisfies(J.BASE.Metadata.Version, requiredBaseVersion);
   if (!hasBaseRequirement)
   {
@@ -80,7 +84,7 @@ J.ABS.EXT.INPUT = {};
  */
 J.ABS.EXT.INPUT = {};
 J.ABS.EXT.INPUT.Metadata = {};
-J.ABS.EXT.INPUT.Metadata.Version = '2.1.1';
+J.ABS.EXT.INPUT.Metadata.Version = '2.2.0';
 J.ABS.EXT.INPUT.Metadata.Name = `J-ABS-InputManager`;
 
 /**
@@ -287,7 +291,7 @@ class JABS_Button
     // the valid set of assignable inputs.
     const okInputs = [
       // primary
-      this.Mainhand, this.Offhand, this.Tool, this.Dodge,
+      this.Mainhand, this.Offhand, this.Tool,
 
       // modifiers & mobility
       this.SkillTrigger, this.Sprint, this.Strafe, this.Rotate,
@@ -389,6 +393,14 @@ class JABS_StandardController
      * @type {Map<string, string[]>}
      */
     this.inputMapping = new Map();
+
+    /**
+     * Tracks whether the last-processed frame was considered in combat.
+     * Used for treating a hold across the boundary (exploration → combat)
+     * as a single edge-press for Mobility.
+     * @type {boolean}
+     */
+    this._lastInCombat = false;
   }
 
   /**
@@ -405,7 +417,8 @@ class JABS_StandardController
     this.inputMapping.set(JABS_Button.Mainhand, [ J.ABS.EXT.INPUT.Symbols.Mainhand ]);
     this.inputMapping.set(JABS_Button.Offhand, [ J.ABS.EXT.INPUT.Symbols.Offhand ]);
     this.inputMapping.set(JABS_Button.Tool, [ J.ABS.EXT.INPUT.Symbols.Tool ]);
-    this.inputMapping.set(JABS_Button.Dodge, [ J.ABS.EXT.INPUT.Symbols.MobilitySkill ]);
+
+    // NOTE: Dodge is intentionally not seeded; Sprint handles mobility contextually.
 
     // seed mobility & modifiers.
     this.inputMapping.set(JABS_Button.Sprint, [ J.ABS.EXT.INPUT.Symbols.Dash ]);
@@ -414,7 +427,7 @@ class JABS_StandardController
     this.inputMapping.set(JABS_Button.Guard, [ J.ABS.EXT.INPUT.Symbols.GuardTrigger ]);
     this.inputMapping.set(JABS_Button.SkillTrigger, [ J.ABS.EXT.INPUT.Symbols.SkillTrigger ]);
 
-    // seed L1 + buttons (combat skills).
+    // seed L1+ face shortcuts (keyboard direct shortcuts available separately).
     this.inputMapping.set(JABS_Button.CombatSkill1, [ J.ABS.EXT.INPUT.Symbols.CombatSkill1 ]);
     this.inputMapping.set(JABS_Button.CombatSkill2, [ J.ABS.EXT.INPUT.Symbols.CombatSkill2 ]);
     this.inputMapping.set(JABS_Button.CombatSkill3, [ J.ABS.EXT.INPUT.Symbols.CombatSkill3 ]);
@@ -642,7 +655,7 @@ class JABS_StandardController
     this.updateMainhandAction();
     this.updateOffhandAction();
     this.updateToolAction();
-    this.updateDodgeAction();
+    this.updateSprintCommand();
 
     // update input for multi-button actions.
     this.updateCombatAction1();
@@ -651,7 +664,6 @@ class JABS_StandardController
     this.updateCombatAction4();
 
     // update input for the pressed(held down)-button actions.
-    this.updateSprintCommand();
     this.updateGuardCommand();
     this.updateStrafeCommand();
     this.updateRotateCommand();
@@ -871,27 +883,61 @@ class JABS_StandardController
 
   /**
    * Checks the inputs of the sprint action currently assigned (Shift default).
+   * Context-aware:
+   * - Out of combat: treat Sprint as a held input (classic run).
+   * - In combat: treat Sprint strictly as an edge-trigger (for Mobility/Dodge).
    * @returns {boolean}
    */
   isSprintActionTriggered()
   {
-    // this action requires Sprint to be pressed.
-    if (this.isActionPressed(JABS_Button.Sprint))
+    // grab the battler for reference.
+    const battler = this.getBattler();
+
+    // determine if the battler is in combat.
+    const inCombat = battler.isInCombat();
+
+    // if in combat, only a new press (edge) should trigger mobility.
+    if (inCombat)
     {
-      return true;
+      // update last-known combat state for subsequent frames.
+      this._lastInCombat = true;
+
+      // return whether Sprint was newly triggered this frame.
+      return this.isActionTriggered(JABS_Button.Sprint);
     }
 
-    // Sprint is not being pressed.
-    return false;
+    // not in combat → classic sprint is a held input.
+    // update last-known combat state before returning.
+    this._lastInCombat = false;
+
+    // return whether Sprint is currently held.
+    return this.isActionPressed(JABS_Button.Sprint);
   }
 
   /**
-   * Enables sprinting for this controller's battler.
+   * Enables sprinting for this controller's battler when out of combat.
+   * In combat, Sprint becomes the Mobility/Dodge action instead.
    */
   performSprintAction()
   {
-    // perform sprint enable for this controller's battler.
-    JABS_InputAdapter.performSprint(true, this.battler);
+    // grab the battler for reference.
+    const battler = this.getBattler();
+
+    // check if the battler is in combat.
+    if (battler.isInCombat())
+    {
+      // proactively disable exploration sprint when entering combat.
+      JABS_InputAdapter.performSprint(false, battler);
+
+      // perform the dodge action for this controller's battler.
+      JABS_InputAdapter.performDodgeAction(battler);
+
+      // end early; no sprint toggling while in combat.
+      return;
+    }
+
+    // not in combat → enable classic sprint while the input is held.
+    JABS_InputAdapter.performSprint(true, battler);
   }
 
   /**
@@ -899,9 +945,19 @@ class JABS_StandardController
    */
   performSprintAlterAction()
   {
-    // perform sprint disable for this controller's battler.
-    JABS_InputAdapter.performSprint(false, this.battler);
+    // grab the battler for reference.
+    const battler = this.getBattler();
+
+    // check if the battler is in combat.
+    if (battler.isInCombat())
+    {
+      return;
+    }
+
+    // not in combat → disable sprint when the input is released.
+    JABS_InputAdapter.performSprint(false, battler);
   }
+
   //endregion sprint
 
   //region tool
@@ -951,48 +1007,6 @@ class JABS_StandardController
   }
 
   //endregion tool
-
-  //region dodge
-  /**
-   * Monitors and takes action based on player input regarding the dodge action.
-   * This is `R2` on the gamepad by default.
-   */
-  updateDodgeAction()
-  {
-    // check if the action's input requirements have been met.
-    if (this.isDodgeActionTriggered())
-    {
-      // execute the action.
-      this.performDodgeAction();
-    }
-  }
-
-  /**
-   * Checks the inputs of the dodge action currently assigned (R2 default).
-   * @returns {boolean}
-   */
-  isDodgeActionTriggered()
-  {
-    // this action requires the logical Dodge to be triggered.
-    if (this.isActionTriggered(JABS_Button.Dodge))
-    {
-      return true;
-    }
-
-    // Dodge is not being triggered.
-    return false;
-  }
-
-  /**
-   * Executes the currently assigned dodge action (R2 default).
-   */
-  performDodgeAction()
-  {
-    // perform the dodge action for this controller's battler.
-    JABS_InputAdapter.performDodgeAction(this.getBattler());
-  }
-
-  //endregion dodge
 
   //region combat actions
   /**
@@ -1135,7 +1149,7 @@ class JABS_StandardController
     if (this.isCombatSkillUsageEnabled())
     {
       // ...and Dodge is triggered this frame, then combat action 3 should fire.
-      if (this.isActionTriggered(JABS_Button.Dodge))
+      if (this.isActionTriggered(JABS_Button.Sprint))
       {
         return true;
       }
@@ -1958,31 +1972,42 @@ Input.getRemapCaptureSymbols = function()
  */
 Input.ensureRemapBootstrapped = function()
 {
+  // if already bootstrapped for this session, do nothing.
   if (Input._jRegistries.bootstrapped === true)
   {
-    return; // already bootstrapped for this session
+    return;
   }
 
   // Seed JABS defaults (logical actions -> physical symbols).
   const d = {};
+
+  // functionality
   d[JABS_Button.Menu] = [ J.ABS.EXT.INPUT.Symbols.Quickmenu ];
   d[JABS_Button.Select] = [ J.ABS.EXT.INPUT.Symbols.PartyCycle ];
+
+  // primary actions
   d[JABS_Button.Mainhand] = [ J.ABS.EXT.INPUT.Symbols.Mainhand ];
   d[JABS_Button.Offhand] = [ J.ABS.EXT.INPUT.Symbols.Offhand ];
   d[JABS_Button.Tool] = [ J.ABS.EXT.INPUT.Symbols.Tool ];
-  d[JABS_Button.Dodge] = [ J.ABS.EXT.INPUT.Symbols.MobilitySkill ];
+
+  // mobility & modifiers
+  // IMPORTANT: No default binding for Dodge; Sprint handles mobility contextually.
+  // d[JABS_Button.Dodge] is intentionally omitted.
   d[JABS_Button.Sprint] = [ J.ABS.EXT.INPUT.Symbols.Dash ];
   d[JABS_Button.Strafe] = [ J.ABS.EXT.INPUT.Symbols.StrafeTrigger ];
   d[JABS_Button.Rotate] = [ J.ABS.EXT.INPUT.Symbols.GuardTrigger ];
   d[JABS_Button.Guard] = [ J.ABS.EXT.INPUT.Symbols.GuardTrigger ];
   d[JABS_Button.SkillTrigger] = [ J.ABS.EXT.INPUT.Symbols.SkillTrigger ];
+
+  // L1 + buttons (keyboard shortcuts available separately)
   d[JABS_Button.CombatSkill1] = [ J.ABS.EXT.INPUT.Symbols.CombatSkill1 ];
   d[JABS_Button.CombatSkill2] = [ J.ABS.EXT.INPUT.Symbols.CombatSkill2 ];
   d[JABS_Button.CombatSkill3] = [ J.ABS.EXT.INPUT.Symbols.CombatSkill3 ];
   d[JABS_Button.CombatSkill4] = [ J.ABS.EXT.INPUT.Symbols.CombatSkill4 ];
 
+  // register the defaults and ensure live bindings are initialized.
   Input.seedDefaultBindings('JABS', d);
-  Input.getAllBindings('JABS'); // lazy-init live bindings
+  Input.getAllBindings('JABS');
 
   // friendly labels for some common symbols.
   Input.registerSymbolLabel(J.ABS.EXT.INPUT.Symbols.L3, 'L3');
@@ -1993,7 +2018,7 @@ Input.ensureRemapBootstrapped = function()
   Input.registerSymbolLabel(J.ABS.EXT.INPUT.Symbols.DPadLeft, 'D-Pad Left');
   Input.registerSymbolLabel(J.ABS.EXT.INPUT.Symbols.DPadRight, 'D-Pad Right');
 
-  // Allow these symbols to be captured in the prompt if desired.
+  // allow these symbols to be captured in the prompt if desired.
   Input.registerRemapCaptureSymbol(J.ABS.EXT.INPUT.Symbols.L3);
   Input.registerRemapCaptureSymbol(J.ABS.EXT.INPUT.Symbols.R3);
   Input.registerRemapCaptureSymbol(J.ABS.EXT.INPUT.Symbols.DPadUp);
@@ -2001,11 +2026,41 @@ Input.ensureRemapBootstrapped = function()
   Input.registerRemapCaptureSymbol(J.ABS.EXT.INPUT.Symbols.DPadLeft);
   Input.registerRemapCaptureSymbol(J.ABS.EXT.INPUT.Symbols.DPadRight);
 
-  // NEW: expose all non-engine keyboard keys for capture/binding.
+  // expose all non-engine keyboard keys for capture/binding.
   Input.bootstrapAllKeyboardKeysForCapture();
 
-  // Mark as bootstrapped for this runtime session.
+  // SAFETY: strip deprecated Dodge bindings from existing saves/config.
+  Input.removeDeprecatedDodgeBindings();
+
+  // mark as bootstrapped for this runtime session.
   Input._jRegistries.bootstrapped = true;
+};
+
+/**
+ * Removes any live/default bindings for the deprecated standalone Dodge action.
+ * This is a migration helper and may be removed in a future version.
+ */
+Input.removeDeprecatedDodgeBindings = function()
+{
+
+  // TODO: remove this function in some later patch after 2.0.2.
+
+
+  // read live bindings for JABS and clear Dodge if present.
+  const live = Input.getAllBindings('JABS');
+  if (live && Object.hasOwn(live, JABS_Button.Dodge))
+  {
+    // clear the list of physical symbols bound to Dodge.
+    live[JABS_Button.Dodge] = [];
+  }
+
+  // also clear from defaults if present (legacy boot sequences).
+  const defs = Input._jRegistries.defaults['JABS'];
+  if (defs && Object.hasOwn(defs, JABS_Button.Dodge))
+  {
+    // clear any default mapping that may have been serialized previously.
+    defs[JABS_Button.Dodge] = [];
+  }
 };
 
 /**
@@ -2017,9 +2072,7 @@ Input.bootstrapAllKeyboardKeysForCapture = function()
   // collect a snapshot of engine/core-reserved symbols to avoid overriding them.
   const reserved = new Set([
     // core engine actions and directions.
-    'ok', 'cancel', 'menu', 'escape',
-    'tab', 'pageup', 'pagedown', 'shift', 'control',
-    'up', 'down', 'left', 'right',
+    'ok', 'cancel', 'menu', 'escape', 'tab', 'pageup', 'pagedown', 'shift', 'control', 'up', 'down', 'left', 'right',
   ]);
 
   // also consider whatever the current keyMapper already resolves to.
@@ -3212,7 +3265,7 @@ class Scene_JabsRemap
   topHelpWindowRectangle()
   {
     // determine the height for the top help window (single row).
-    const wh = this.calcWindowHeight(1.8, true);
+    const wh = this.calcWindowHeight(1.6, true);
 
     // compute the total width for the centered middle group.
     const ww = Math.floor(Graphics.boxWidth * 0.60);

--- a/project/js/plugins/hud/ext/J-HUD-InputFrame.js
+++ b/project/js/plugins/hud/ext/J-HUD-InputFrame.js
@@ -2,14 +2,14 @@
 /*:
  * @target MZ
  * @plugindesc
- * [v1.0.0 HUD-INPUT] A HUD frame that displays your leader's buttons data.
+ * [v1.1.0 HUD-INPUT] A HUD frame that displays your leader's buttons data.
  * @author JE
  * @url https://github.com/je-can-code/rmmz-plugins
- * @base J-ABS
  * @base J-Base
+ * @base J-ABS
  * @base J-HUD
- * @orderAfter J-ABS
  * @orderAfter J-Base
+ * @orderAfter J-ABS
  * @orderAfter J-HUD
  * @help
  * ============================================================================
@@ -19,11 +19,23 @@
  * This is the Input Frame, which displays the various action keys and their
  * corresponding cooldown and cost data points for the leader of the party.
  *
+ * This plugin requires JABS.
+ * This plugin requires the base HUD.
+ * This plugin has no additional configuration required.
+ * ----------------------------------------------------------------------------
+ * DETAILS:
  * This includes the following data points for the currently selected leader:
- * - main and offhand action keys
- * - tool and dodge action keys
- * - ability keys (L1 + A/B/X/Y) action keys
- * - ability costs for all action keys, or item count remaining for tool.
+ * - mainhand, offhand, tool, and dodge/sprint action keys.
+ * - while holding the skill trigger, skill keys show instead.
+ * - ability costs for all keys, or item count remaining for tool.
+ * ============================================================================
+ * CHANGELOG
+ * ----------------------------------------------------------------------------
+ * - 1.1.0
+ *    Changed input to reflect a switch-view diamond in the center.
+ *    Retroactively added this changelog.
+ * - 1.0.0
+ *    Initial release.
  * ============================================================================
  */
 
@@ -36,7 +48,7 @@ var J = J || {};
 (() =>
 {
   // Check to ensure we have the minimum required version of the J-Base plugin.
-  const requiredBaseVersion = '2.1.2';
+  const requiredBaseVersion = '2.3.1';
   const hasBaseRequirement = J.BASE.Helpers.satisfies(J.BASE.Metadata.Version, requiredBaseVersion);
   if (!hasBaseRequirement)
   {
@@ -56,17 +68,8 @@ J.HUD.EXT.INPUT = {};
  */
 J.HUD.EXT.INPUT = {};
 J.HUD.EXT.INPUT.Metadata = {};
-J.HUD.EXT.INPUT.Metadata.Version = '1.0.0';
+J.HUD.EXT.INPUT.Metadata.Version = '1.1.0';
 J.HUD.EXT.INPUT.Metadata.Name = `J-HUD-InputFrame`;
-
-/**
- * The actual `plugin parameters` extracted from RMMZ.
- */
-J.HUD.EXT.INPUT.PluginParameters = PluginManager.parameters(J.HUD.EXT.INPUT.Metadata.Name);
-
-J.HUD.EXT.INPUT.Metadata.InputFrameX = Number(J.HUD.EXT.INPUT.PluginParameters['inputFrameX']);
-J.HUD.EXT.INPUT.Metadata.InputFrameY = Number(J.HUD.EXT.INPUT.PluginParameters['inputFrameY']);
-J.HUD.EXT.INPUT.Metadata.UseGamepadLayout = false;
 
 /**
  * A collection of all aliased methods for this plugin.
@@ -139,7 +142,7 @@ Scene_Map.prototype.buildInputFrameWindow = function()
 
   // return the built and configured window.
   return window;
-}
+};
 
 /**
  * Creates the rectangle representing the window for the input frame.
@@ -147,29 +150,33 @@ Scene_Map.prototype.buildInputFrameWindow = function()
  */
 Scene_Map.prototype.inputFrameWindowRect = function()
 {
-  // if using the keyboard layout, apply a modifier against the width.
-  const usingKeyboardWidthModifier = J.HUD.EXT.INPUT.Metadata.UseGamepadLayout
-    ? 0     // no bonus for gamepads.
-    : 220;  // bonus width for all-in-one row.
+  // Match Window_InputFrame’s key geometry.
+  const ikw = 72;
+  const ikh = 72;
 
-  // define the width of the window.
-  const width = 500 + usingKeyboardWidthModifier;
+  // Use the same diamond gap as the window, for perfect alignment.
+  const bodyGap = Window_InputFrame.DiamondGap;
 
-  // if using the keyboard layout, apply a modifier against the height.
-  const usingKeyboardHeightModifier = J.HUD.EXT.INPUT.Metadata.UseGamepadLayout
-    ? 0
-    : -60;
+  // Visual span.
+  const diamondBodyWidth = (3 * ikw) + (2 * bodyGap);
+  const diamondBodyHeight = (2 * ikh) + bodyGap;
 
-  // define the height of the window.
-  const height = 160 + usingKeyboardHeightModifier;
+  // Reserve horizontal space for the labels (“Actions” left, “Skills” right).
+  const labelReserveEachSide = 48;
 
-  // define the origin x of the window.
-  const x = Graphics.boxWidth - width;
+  // Add small margins to avoid clipping gradients/labels.
+  const marginX = 24;
+  const marginY = 24;
 
-  // define the origin y of the window.
+  // Final window size: body span + label reserves + visual margins.
+  const width = Math.ceil(diamondBodyWidth + (labelReserveEachSide * 2) + marginX);
+  const height = Math.ceil(diamondBodyHeight + marginY);
+
+  // Center horizontally; anchor bottom.
+  const x = Math.floor((Graphics.boxWidth - width) / 2);
   const y = Graphics.boxHeight - height;
 
-  // return the built rectangle.
+  // Build and return the rectangle.
   return new Rectangle(x, y, width, height);
 };
 
@@ -180,7 +187,7 @@ Scene_Map.prototype.inputFrameWindowRect = function()
 Scene_Map.prototype.getInputFrameWindow = function()
 {
   return this._j._hud._inputFrame;
-}
+};
 
 /**
  * Set the currently tracked input frame window to the given window.
@@ -189,7 +196,7 @@ Scene_Map.prototype.getInputFrameWindow = function()
 Scene_Map.prototype.setInputFrameWindow = function(window)
 {
   this._j._hud._inputFrame = window;
-}
+};
 //endregion input frame
 
 /**
@@ -870,17 +877,8 @@ Sprite_CooldownTimer.prototype.updateCooldownText = function()
   const cooldownBaseText = baseCooldown > 0
     ? baseCooldown
     : String.empty;
-  const cooldownComboText = (cooldownBaseText > 0 && this._j._cooldownData.comboNextActionId !== 0)
-    ? "COMBO!"
-    : "❌";
 
   this.bitmap.drawText(cooldownBaseText, 0, 0, this.bitmapWidth(), this.bitmapHeight(), "center");
-  this.bitmap.fontSize = this.fontSize() - 8;
-  this.bitmap.fontItalic = true;
-  this.bitmap.drawText(cooldownComboText, 0, this.fontSize(), this.bitmapWidth(), this.bitmapHeight(), "center");
-  this.bitmap.fontSize = this.fontSize();
-  this.bitmap.fontItalic = false;
-
 }
 
 /**
@@ -1115,6 +1113,8 @@ class Sprite_InputKeySlot
 
     // grab the leader and their battler for doing things.
     const leader = $gameParty.leader();
+
+    // TODO: implement.
   }
 
   /**
@@ -1269,7 +1269,7 @@ class Sprite_InputKeySlot
    * @param {boolean} isItem Whether or not this cooldown timer is for the item slot.
    * @returns {string}
    */
-  makeInputKeyCooldowntTimerSpriteKey(cooldownData, inputType, isItem)
+  makeInputKeyCooldownTimerSpriteKey(cooldownData, inputType, isItem)
   {
     return `cooldown-${this.battler()
       .name()}-${this.battler()
@@ -1288,7 +1288,7 @@ class Sprite_InputKeySlot
     const isItem = inputType === JABS_Button.Tool;
 
     // determine the key for this sprite.
-    const key = this.makeInputKeyCooldowntTimerSpriteKey(cooldownData, inputType, isItem);
+    const key = this.makeInputKeyCooldownTimerSpriteKey(cooldownData, inputType, isItem);
 
     // check if the key already maps to a cached sprite.
     if (this._j._spriteCache.has(key))
@@ -1616,7 +1616,7 @@ class Sprite_InputKeySlot
     // relocate the sprite.
     const sprite = this.getOrCreateInputKeySkillCostSprite(skillSlot, Sprite_SkillCost.Types.Item, inputType);
     sprite.show();
-    sprite.move(x + 36, y + 10);
+    sprite.move(x + 42, y + 24);
   }
 
   /**
@@ -2124,6 +2124,27 @@ class Window_InputFrame
   extends Window_Frame
 {
   /**
+   * Modes for how the input diamond should render.
+   * @type {{ Base: string, Skills: string }}
+   */
+  static Modes = {
+    Base: 'base',
+    Skills: 'skills',
+  };
+
+  /**
+   * The visual gap (in pixels) between the top and bottom bodies of the diamond.
+   * Also used by the scene’s window sizing to keep things in sync.
+   * Tweak this to 4/6/etc to fiddle the spacing.
+   * @returns {number}
+   */
+  static get DiamondGap()
+  {
+    // default was 2; try 4 or 6 to taste.
+    return 6;
+  }
+
+  /**
    * Constructor.
    * @param {Rectangle} rect The shape of this window.
    */
@@ -2132,6 +2153,25 @@ class Window_InputFrame
     super(rect);
   }
 
+  /**
+   * The rough estimate of width for a single input key and all its subsprites.
+   * @returns {number}
+   */
+  inputKeyWidth()
+  {
+    return 72;
+  }
+
+  /**
+   * The rough estimate of height for a single input key and all its subsprites.
+   * @returns {number}
+   */
+  inputKeyHeight()
+  {
+    return 72;
+  }
+
+  //region state
   /**
    * Initializes all members of this class.
    */
@@ -2153,7 +2193,160 @@ class Window_InputFrame
      * @type {boolean}
      */
     this._j._needsRefresh = true;
+
+    /**
+     * A grouping for tracking last-known values used to determine
+     * if this HUD requires a refresh.
+     */
+    this._j._last ||= {};
+
+    /**
+     * Tracks whether SkillTrigger was held on the last processed frame.
+     * Used to request refreshes only when the held state changes so we
+     * preserve the "draw only when needed" behavior.
+     * @type {boolean}
+     */
+    this._j._last._skillTriggerHeld = false;
+
+    /**
+     * Tracks whether the party was considered in combat on the last processed frame.
+     * Used to request refresh on combat context changes so the left node can
+     * swap between Sprint (out of combat) and Mobility/Dodge (in combat).
+     * @type {boolean}
+     */
+    this._j._last._partyInCombat = false;
+
+    /**
+     * A grouping for tracking the flip progress and direction.
+     */
+    this._j._flip ||= {};
+
+    /**
+     * The current progress for the flip animation.
+     * @type {number}
+     */
+    this._j._flip._progress = 0;
+
+    /**
+     * The maximum duration for the flip animation.
+     * @type {number}
+     */
+    this._j._flip._max = 10;
+
+    /**
+     * The current direction of the flip animation.
+     * @type {number}
+     */
+    this._j._flip._direction = 0;
   }
+
+  /**
+   * Gets whether or not the skill trigger is held.
+   * @returns {boolean}
+   */
+  skillTriggerHeld()
+  {
+    return this._j._last._skillTriggerHeld;
+  }
+
+  /**
+   * Sets whether or not the skill trigger is held.
+   * @param {boolean} value True if the skill trigger is held, false otherwise.
+   */
+  setSkillTriggerHeld(value)
+  {
+    this._j._last._skillTriggerHeld = value;
+  }
+
+  /**
+   * Gets whether or not the party is in combat.
+   * @returns {boolean}
+   */
+  partyInCombat()
+  {
+    return this._j._last._partyInCombat;
+  }
+
+  /**
+   * Sets whether or not the party is in combat.
+   * @param {boolean} value True if the party is in combat, false otherwise.
+   */
+  setPartyInCombat(value)
+  {
+    this._j._last._partyInCombat = value;
+  }
+
+  /**
+   * Gets the current flip progress (0..max).
+   * @returns {number}
+   */
+  getFlipProgress()
+  {
+    // store under a dedicated bag to avoid accidental overlap.
+    return this._j._flip._progress;
+  }
+
+  /**
+   * Sets the current flip progress (0..max).
+   * @param {number} value The new progress.
+   */
+  setFlipProgress(value)
+  {
+    this._j._flip._progress = Math.max(0, value);
+  }
+
+  /**
+   * Gets the maximum flip duration in frames.
+   * @returns {number}
+   */
+  getFlipMax()
+  {
+    return this._j._flip._max;
+  }
+
+  /**
+   * Sets the maximum flip duration in frames.
+   * @param {number} value The new max duration.
+   */
+  setFlipMax(value)
+  {
+    this._j._flip._max = Math.max(0, value);
+  }
+
+  /**
+   * Gets the current flip direction (-1, 0, +1).
+   * @returns {number}
+   */
+  getFlipDirection()
+  {
+    return this._j._flip._direction;
+  }
+
+  /**
+   * Sets the current flip direction (-1, 0, +1).
+   * @param {number} value The new direction.
+   */
+  setFlipDirection(value)
+  {
+    // cache the numeric direction requested.
+    const dir = value;
+
+    // normalize to -1, 0, or +1 only.
+    if (dir < 0)
+    {
+      this._j._flip._direction = -1;
+    }
+    else if (dir > 0)
+    {
+      this._j._flip._direction = 1;
+    }
+    else
+    {
+      this._j._flip._direction = 0;
+    }
+  }
+
+  //endregion state
 
   /**
    * Executes any one-time configuration required for this window.
@@ -2164,32 +2357,7 @@ class Window_InputFrame
     super.configure();
 
     // remove opacity for completely transparent window.
-    this.opacity = 0;
-  }
-
-  /**
-   * Requests this window to clear and redraw its contents.
-   */
-  requestInternalRefresh()
-  {
-    this._j._needsRefresh = true;
-  }
-
-  /**
-   * Gets whether or not this window needs refresh.
-   * @returns {boolean}
-   */
-  needsInternalRefresh()
-  {
-    return this._j._needsRefresh;
-  }
-
-  /**
-   * Flags internally this window for successfully refreshing text.
-   */
-  acknowledgeInternalRefresh()
-  {
-    this._j._needsRefresh = false;
+    this.opacity = 32;
   }
 
   //region caching
@@ -2250,6 +2418,32 @@ class Window_InputFrame
 
   //endregion caching
 
+  //region refresh
+  /**
+   * Requests this window to clear and redraw its contents.
+   */
+  requestInternalRefresh()
+  {
+    this._j._needsRefresh = true;
+  }
+
+  /**
+   * Gets whether or not this window needs refresh.
+   * @returns {boolean}
+   */
+  needsInternalRefresh()
+  {
+    return this._j._needsRefresh;
+  }
+
+  /**
+   * Flags internally this window for successfully refreshing text.
+   */
+  acknowledgeInternalRefresh()
+  {
+    this._j._needsRefresh = false;
+  }
+
   /**
    * Refreshes the contents of this window.
    */
@@ -2261,6 +2455,8 @@ class Window_InputFrame
     // rebuilds the contents of the window.
     this.requestInternalRefresh();
   }
+
+  //endregion refresh
 
   /**
    * Hide all sprites for the hud.
@@ -2284,8 +2480,60 @@ class Window_InputFrame
     // handle the visibility of the hud for dynamic interferences.
     this.manageVisibility();
 
+    // check if the player is holding the skill trigger.
+    this.checkSkillTrigger();
+
+    // check if the party combat context changed and request redraw if so.
+    this.checkCombatContext();
+
+    // advance the crossfade animator when active (using accessors only).
+    this.advanceFlipAnimator();
+
     // draw the contents.
     this.drawInputFrame();
+  }
+
+  /**
+   * Checks if the player is holding the SkillTrigger and updates the internal state accordingly.
+   */
+  checkSkillTrigger()
+  {
+    // determine whether the SkillTrigger is currently held.
+    const currentlyHeld = this.isSkillTriggerHeld();
+
+    // if the held state changed since last frame, request a redraw.
+    if (this.skillTriggerHeld() !== currentlyHeld)
+    {
+      // update last-known held state.
+      this.setSkillTriggerHeld(currentlyHeld);
+
+      // kick the flip animator in the correct direction via setter only.
+      this.setFlipDirection(currentlyHeld
+        ? +1
+        : -1);
+
+      // redraw is required to flip between views.
+      this.requestInternalRefresh();
+    }
+  }
+
+  /**
+   * Checks if the party combat context changed and updates internal state.
+   */
+  checkCombatContext()
+  {
+    // determine whether the party is currently considered in combat.
+    const currentlyInCombat = $gameParty.anyMemberInCombat();
+
+    // if the combat context changed since last frame, request a redraw.
+    if (this.partyInCombat() !== currentlyInCombat)
+    {
+      // update last-known in-combat state.
+      this.setPartyInCombat(currentlyInCombat);
+
+      // redraw is required to swap the left node (Sprint ↔ Mobility).
+      this.requestInternalRefresh();
+    }
   }
 
   //region visibility
@@ -2383,19 +2631,78 @@ class Window_InputFrame
   //endregion visibility
 
   /**
-   * The rough estimate of width for a single input key and all its subsprites.
-   * @returns {number}
+   * Advances the flip animator when active; requests refresh while animating.
+   * Uses only accessors for state changes.
    */
-  inputKeyWidth()
+  advanceFlipAnimator()
   {
-    return 72;
+    // if idle, nothing to do.
+    if (this.getFlipDirection() === 0)
+    {
+      return;
+    }
+
+    // compute new progress.
+    const next = this.getFlipProgress() + this.getFlipDirection();
+    const max = this.getFlipMax();
+
+    // clamp into [0, max].
+    if (next <= 0)
+    {
+      this.setFlipProgress(0);
+      this.setFlipDirection(0);
+    }
+    else if (next >= max)
+    {
+      this.setFlipProgress(max);
+      this.setFlipDirection(0);
+    }
+    else
+    {
+      this.setFlipProgress(next);
+    }
+
+    // while animating, ensure redraw continues.
+    this.requestInternalRefresh();
   }
 
-  inputKeyHeight()
+  /**
+   * Computes current alphas for base and skills diamonds from the flip animator.
+   * @returns {{alphaBase:number, alphaSkills:number}}
+   */
+  computeFlipAlphas()
   {
-    return 96;
+    // if animator is idle, snap to whichever mode is active.
+    if (this.getFlipDirection() === 0)
+    {
+      const skillsActive = this.isSkillTriggerHeld();
+      return {
+        alphaBase: skillsActive
+          ? 0
+          : 255,
+        alphaSkills: skillsActive
+          ? 255
+          : 0,
+      };
+    }
+
+    // blend based on normalized progress.
+    const max = this.getFlipMax();
+    const prog = this.getFlipProgress();
+    const t = max > 0
+      ? (prog / max)
+      : 1;
+
+    // direction +1 means transitioning to Skills; -1 to Actions.
+    const alphaSkills = Math.round(255 * t);
+    const alphaBase = 255 - alphaSkills;
+    return {
+      alphaBase,
+      alphaSkills
+    };
   }
 
+  //region draw
   /**
    * Draws the input frame window in its entirety.
    */
@@ -2406,24 +2713,47 @@ class Window_InputFrame
 
     // wipe the drawn contents.
     this.contents.clear();
+    this.contentsBack.clear();
 
-    // hide all the sprites.
+    // hide all the sprites and let each update its own bitmap.
     this._j._spriteCache.forEach((sprite =>
     {
       sprite.hide();
       sprite.drawInputKey();
     }));
 
-    if (J.HUD.EXT.INPUT.Metadata.UseGamepadLayout)
+    // compute blend alphas between modes (0..255 each) using accessors.
+    const alphas = this.computeFlipAlphas();
+    const {
+      alphaBase,
+      alphaSkills
+    } = alphas;
+
+    // draw Actions (base) with its alpha when non-zero.
+    if (alphaBase > 0)
     {
-      // draw the inputs.
-      this.drawGamepadStyleInputKeys();
+      // apply paint opacity for gradients/text.
+      this.contents.paintOpacity = alphaBase;
+
+      // pass the same alpha down so child slot sprites also fade.
+      this.drawDiamond(Window_InputFrame.Modes.Base, alphaBase);
     }
-    else
+
+    // draw Skills with its alpha when non-zero.
+    if (alphaSkills > 0)
     {
-      // draw the inputs.
-      this.drawKeyboardStyleInputKeys();
+      // apply paint opacity for gradients/text.
+      this.contents.paintOpacity = alphaSkills;
+
+      // pass the same alpha down so child slot sprites also fade.
+      this.drawDiamond(Window_InputFrame.Modes.Skills, alphaSkills);
     }
+
+    // reset paint opacity for any future draws this frame.
+    this.contents.paintOpacity = 255;
+
+    // draw the mode labels with their own fading alphas.
+    this.drawModeLabels(alphaBase, alphaSkills);
 
     // flags that this has been refreshed.
     this.acknowledgeInternalRefresh();
@@ -2449,105 +2779,376 @@ class Window_InputFrame
   }
 
   /**
-   * Draws the inputs to be more console-style with a gamepad layout.
+   * Checks the current bindings for SkillTrigger and returns true if any bound
+   * physical symbol is currently pressed. This is remap‑aware.
+   * @returns {boolean}
    */
-  drawGamepadStyleInputKeys()
+  isSkillTriggerHeld()
   {
-    // our origin x:y coordinates.
-    const x = 0;
-    const y = 0;
+    // get JABS bindings and the physical symbols for the logical SkillTrigger.
+    const allBindings = Input.getAllBindings('JABS');
+    const bound = allBindings && allBindings[JABS_Button.SkillTrigger]
+      ? allBindings[JABS_Button.SkillTrigger]
+      : [];
 
-    // draw the primary section of our input.
-    this.drawGamepadPrimaryInputKeys(x, y);
+    // if any symbol bound to SkillTrigger is held, return true.
+    for (let i = 0; i < bound.length; i++)
+    {
+      const symbol = bound[i];
+      if (Input.isPressed(symbol))
+      {
+        return true;
+      }
+    }
 
-    // draw the secondary section of our input.
-    this.drawGamepadSecondaryInputKeys(x + 250, y);
+    // none of the bound symbols are pressed.
+    return false;
   }
 
   /**
-   * Draws the inputs to be more PC-style with a keyboard layout.
+   * Draws the “Actions” and “Skills” labels with matching crossfade alphas.
+   * @param {number} alphaBase The opacity (0..255) for the Actions label.
+   * @param {number} alphaSkills The opacity (0..255) for the Skills label.
    */
-  drawKeyboardStyleInputKeys()
+  drawModeLabels(alphaBase, alphaSkills)
   {
-    // our origin x:y coordinates.
-    const ikw = this.inputKeyWidth();
-    const x = 0;
-    const y = 0;
+    // cache base font settings to restore afterward.
+    const prevSize = this.contents.fontSize;
+    const prevOutlineW = this.contents.outlineWidth;
+    const prevOutlineC = this.contents.outlineColor;
+    const prevPaint = this.contents.paintOpacity;
 
-    // draw the primary section of our input.
-    this.drawKeyboardPrimaryInputKeys(x, y);
+    // choose a slightly larger, bold-ish readable style.
+    this.contents.fontSize = prevSize + 2;
+    this.contents.outlineWidth = 4;
+    this.contents.outlineColor = 'rgba(0, 0, 0, 0.85)';
 
-    // draw the secondary section of our input.
-    const keyboardSecondaryX = x + (ikw * 4) + 24;
-    this.drawKeyboardSecondaryInputKeys(keyboardSecondaryX, y);
+    // compute margins for label placement inside contents space.
+    const leftMargin = 8;
+    const rightMargin = 8;
+    const topMargin = 2;
+
+    // draw "Actions" in the upper-left, using the base alpha.
+    if (alphaBase > 0)
+    {
+      // apply the alpha for this pass.
+      this.contents.paintOpacity = alphaBase;
+
+      // define text and measure for any future adjustments if needed.
+      const text = 'Actions';
+
+      // draw the text left-aligned at the top-left margin.
+      this.drawText(text, leftMargin, topMargin, 160, 'left');
+    }
+
+    // draw "Skills" in the upper-right, using the skills alpha.
+    if (alphaSkills > 0)
+    {
+      // apply the alpha for this pass.
+      this.contents.paintOpacity = alphaSkills;
+
+      // define text and measure its width.
+      const text = 'Skills';
+      const tw = this.textSizeEx(text).width; // consistent with Window_Base API.
+
+      // compute x so the right edge sits at contentsWidth - rightMargin.
+      const x = Math.max(0, this.contentsWidth() - rightMargin - tw);
+
+      // draw the text right-aligned at the top-right margin.
+      this.drawText(text, x, topMargin, tw, 'right');
+    }
+
+    // restore font and opacity.
+    this.contents.fontSize = prevSize;
+    this.contents.outlineWidth = prevOutlineW;
+    this.contents.outlineColor = prevOutlineC;
+    this.contents.paintOpacity = prevPaint;
   }
 
   /**
-   * Draws the primary set of input keys.
-   * This includes: mainhand, offhand, dodge, and tool input keys.
-   * @param {number} x The x coordinate.
-   * @param {number} y The y coordinate.
+   * Draws a multi-layer HUD panel background that looks richer than a flat gradient.
+   * Renders shadow to contentsBack, then gradient/border/gloss/tint to contents.
+   * @param {number} x The left of the panel (contents space).
+   * @param {number} y The top of the panel (contents space).
+   * @param {number} w The width of the panel.
+   * @param {number} h The height of the panel.
+   * @param {{
+   *   tint?: string,
+   *   tintAlpha?: number,
+   *   cornerPad?: number,
+   * }} [options] Optional styling overrides.
    */
-  drawGamepadPrimaryInputKeys(x, y)
+  drawHudPanelFancy(x, y, w, h, options)
   {
-    // shorthand the variables for re-use.
-    const ikw = this.inputKeyWidth();
-    const baseX = x + 16;
-    const baseY = y + 8;
+    // configure options w/ reasonable defaults.
+    const opts = options || {};
+    const tint = opts.tint || null;             // e.g., 'rgba(255,64,64,1.0)'
+    const tintAlpha = Number(opts.tintAlpha || 0); // 0..1
+    const radius = Math.max(0, Number(opts.cornerPad || 0));
 
-    // draw the four basic core functions of JABS.
-    this.drawInputKey(JABS_Button.Mainhand, baseX + ikw * 0, baseY + 32);
-    this.drawInputKey(JABS_Button.Offhand, baseX + (ikw * 1), baseY + 32);
-    this.drawInputKey(JABS_Button.Dodge, baseX + (ikw * 2), baseY + 64);
-    this.drawInputKey(JABS_Button.Tool, baseX + (ikw * 2), baseY);
+    // colors from theme (same family your old panels used).
+    const back1 = ColorManager.itemBackColor1(); // darker
+    const back2 = ColorManager.itemBackColor2(); // lighter
+
+    // quick guards.
+    if (w <= 0 || h <= 0) return;
+
+    // helpers to draw a rounded-rect path into a 2D context.
+    const roundRectPath = (ctx, rx, ry, rw, rh, r) =>
+    {
+      const rr = Math.min(r, Math.floor(Math.min(rw, rh) / 2));
+      if (rr <= 0)
+      {
+        ctx.rect(rx, ry, rw, rh);
+        return;
+      }
+      const r2 = rr * 2;
+      ctx.moveTo(rx + rr, ry);
+      ctx.lineTo(rx + rw - rr, ry);
+      ctx.arc(rx + rw - rr, ry + rr, rr, Math.PI * 1.5, 0);
+      ctx.lineTo(rx + rw, ry + rh - rr);
+      ctx.arc(rx + rw - rr, ry + rh - rr, rr, 0, Math.PI * 0.5);
+      ctx.lineTo(rx + rr, ry + rh);
+      ctx.arc(rx + rr, ry + rh - rr, rr, Math.PI * 0.5, Math.PI);
+      ctx.lineTo(rx, ry + rr);
+      ctx.arc(rx + rr, ry + rr, rr, Math.PI, Math.PI * 1.5);
+    };
+
+    // 1) soft shadow to contentsBack (subtle, non-accumulating because we clear each refresh).
+    {
+      const sb = this.contentsBack;
+      const ctx = sb.context;
+      ctx.save();
+      ctx.fillStyle = 'rgba(0, 0, 0, 0.28)';
+      for (let i = 1; i <= 3; i++)
+      {
+        ctx.beginPath();
+        roundRectPath(ctx, x + i, y + i + 1, w, h, radius);
+        ctx.fill();
+      }
+      ctx.restore();
+      sb._baseTexture.update();
+    }
+
+    // 2) main body gradient fill to contents (3-stop vertical feel).
+    const c = this.contents;
+    const ctx = c.context;
+    ctx.save();
+    const grad = ctx.createLinearGradient(0, y + h, 0, y);
+    grad.addColorStop(0.00, back1);
+    grad.addColorStop(0.50, back2);
+    grad.addColorStop(1.00, back1);
+    ctx.fillStyle = grad;
+    ctx.beginPath();
+    roundRectPath(ctx, x, y, w, h, radius);
+    ctx.fill();
+
+    // mid highlight band (very soft)
+    const midH = Math.max(6, Math.floor(h * 0.25));
+    const midY = y + Math.floor((h - midH) / 2);
+    const midGrad = ctx.createLinearGradient(0, midY + midH, 0, midY);
+    midGrad.addColorStop(0.00, 'rgba(255,255,255,0.00)');
+    midGrad.addColorStop(1.00, 'rgba(255,255,255,0.06)');
+    ctx.fillStyle = midGrad;
+    ctx.beginPath();
+    roundRectPath(ctx, x + 1, midY, w - 2, midH, Math.max(0, radius - 1));
+    ctx.fill();
+
+    // 3) inner border (crisper than before).
+    ctx.lineWidth = 1.0;
+    ctx.strokeStyle = 'rgba(255, 255, 255, 0.12)';
+    ctx.beginPath();
+    roundRectPath(ctx, x + 0.5, y + 0.5, w - 1, h - 1, Math.max(0, radius - 0.5));
+    ctx.stroke();
+
+    // 4) top gloss band for a gentle sheen.
+    const glossH = Math.max(4, Math.floor(h * 0.20));
+    const glossGrad = ctx.createLinearGradient(0, y + glossH, 0, y);
+    glossGrad.addColorStop(0.00, 'rgba(255,255,255,0.18)');
+    glossGrad.addColorStop(1.00, 'rgba(255,255,255,0.00)');
+    ctx.fillStyle = glossGrad;
+    ctx.beginPath();
+    roundRectPath(ctx, x + 1, y + 1, w - 2, glossH, Math.max(0, radius - 1));
+    ctx.fill();
+
+    // 5) optional tint overlay (context-aware color).
+    if (tint && tintAlpha > 0)
+    {
+      ctx.globalAlpha = Math.max(0, Math.min(1, tintAlpha));
+      ctx.fillStyle = tint;
+      ctx.beginPath();
+      roundRectPath(ctx, x, y, w, h, radius);
+      ctx.fill();
+    }
+
+    ctx.restore();
+    c._baseTexture.update();
+
   }
 
   /**
-   * Draws the primary set of input keys.
-   * This includes: all L1 and R1 combo inputs.
-   * @param {number} x The x coordinate.
-   * @param {number} y The y coordinate.
+   * Renders a diamond from the window's upper-left using shared coordinates.
+   * The parent computes x/y once per node and draws exactly four buttons.
+   * @param {string} mode One of {@link Window_InputFrame.Modes}.
+   * @param {number} slotOpacity The opacity to apply to slot sprites (0..255).
    */
-  drawGamepadSecondaryInputKeys(x, y)
+  drawDiamond(mode, slotOpacity)
   {
-    // shorthand the variables for re-use.
+    // shared key sizes.
     const ikw = this.inputKeyWidth();
-    const baseX = x + 16;
-    const baseY = y + 8;
+    const ikh = this.inputKeyHeight();
 
-    // draw the combat skills equipped for JABS.
-    this.drawInputKey(JABS_Button.CombatSkill3, baseX + ikw * 0, baseY + 32);
-    this.drawInputKey(JABS_Button.CombatSkill4, baseX + (ikw * 1), baseY);
-    this.drawInputKey(JABS_Button.CombatSkill1, baseX + (ikw * 1), baseY + 64);
-    this.drawInputKey(JABS_Button.CombatSkill2, baseX + (ikw * 2), baseY + 32);
+    // diamond geometry (centered in the window box; matches Scene sizing math).
+    const cx = Math.floor(this.width / 2) + 4;
+    const cy = Math.floor(this.height / 2) - 10;
+
+    // use a single desired body-to-body gap in BOTH axes.
+    const desiredGap = Window_InputFrame.DiamondGap; // applies horizontally AND vertically
+
+    // half-sizes for converting between centers and sprite origins.
+    const halfIkw = Math.floor(ikw / 2);
+    const halfIkh = Math.floor(ikh / 2);
+
+    // VERTICAL: distance between centers of top and bottom bodies so that
+    // the visible body gap equals desiredGap.
+    const verticalCenterDistance = ikh + desiredGap;
+
+    // compute the visual centers for top/bottom.
+    const topCenterY = cy - Math.floor(verticalCenterDistance / 2);
+    const bottomCenterY = cy + Math.floor(verticalCenterDistance / 2);
+
+    // convert visual centers to sprite origins (compensate for +20 body offset).
+    const topY = topCenterY - halfIkh - 20;
+    const bottomY = bottomCenterY - halfIkh - 20;
+
+    // HORIZONTAL: Left/Right are DiamondGap away from the center column body.
+    // That means each side center is offset by (ikw + desiredGap) from cx.
+    const sideCenterOffset = ikw + desiredGap;
+    const leftCenterX = cx - sideCenterOffset;
+    const rightCenterX = cx + sideCenterOffset;
+
+    // convert centers to sprite origins.
+    const leftX = leftCenterX - halfIkw;
+    const rightX = rightCenterX - halfIkw;
+
+    // Left/Right share the midline vertically.
+    const sideY = cy - halfIkh - 20;
+
+    // Top and Bottom share the same x (center column).
+    const topX = cx - halfIkw;
+    const bottomX = cx - halfIkw;
+
+    // draw four buttons according to mode.
+    switch (mode)
+    {
+      case Window_InputFrame.Modes.Skills:
+      {
+        // Top    → Skill 4
+        // Left   → Skill 3
+        // Right  → Skill 2
+        // Bottom → Skill 1
+        this.drawButton(topX, topY, JABS_Button.CombatSkill4, slotOpacity);
+        this.drawButton(leftX, sideY, JABS_Button.CombatSkill3, slotOpacity);
+        this.drawButton(rightX, sideY, JABS_Button.CombatSkill2, slotOpacity);
+        this.drawButton(bottomX, bottomY, JABS_Button.CombatSkill1, slotOpacity);
+        break;
+      }
+
+      case Window_InputFrame.Modes.Base:
+      default:
+      {
+        // decide the left node based on combat context.
+        const leftButton = this.partyInCombat()
+          ? JABS_Button.Dodge
+          : JABS_Button.Sprint;
+
+        // Top    → Tool
+        // Left   → Sprint (OoC) or Dodge (In‑combat)
+        // Right  → Offhand
+        // Bottom → Mainhand
+        this.drawButton(topX, topY, JABS_Button.Tool, slotOpacity);
+        this.drawButton(leftX, sideY, leftButton, slotOpacity);
+        this.drawButton(rightX, sideY, JABS_Button.Offhand, slotOpacity);
+        this.drawButton(bottomX, bottomY, JABS_Button.Mainhand, slotOpacity);
+        break;
+      }
+    }
   }
 
-  drawKeyboardPrimaryInputKeys(x, y)
+  /**
+   * Draw a single button at x,y.
+   * Sprint is a special case (not a skillslot), everything else uses drawInputKey().
+   * @param {number} x The x coordinate (CONTENTS space).
+   * @param {number} y The y coordinate (CONTENTS space).
+   * @param {string} button The logical button (from {@link JABS_Button}).
+   * @param {number} opacity The per-pass opacity (0..255) for slot sprites.
+   */
+  drawButton(x, y, button, opacity)
   {
-    // shorthand the variables for re-use.
-    const ikw = this.inputKeyWidth();
-    const baseX = x + 16;
-    const baseY = y + 8;
+    // sprint is not backed by a JABS_SkillSlot; render its node directly.
+    if (button === JABS_Button.Sprint)
+    {
+      this.drawSprintNode(x, y);
+      return;
+    }
 
-    // draw the four basic core functions of JABS.
-    this.drawInputKey(JABS_Button.Mainhand, baseX + ikw * 0, baseY);
-    this.drawInputKey(JABS_Button.Offhand, baseX + ikw * 1, baseY);
-    this.drawInputKey(JABS_Button.Dodge, baseX + ikw * 2, baseY);
-    this.drawInputKey(JABS_Button.Tool, baseX + ikw * 3, baseY);
+    // draw the input-key backed slot with the provided opacity.
+    this.drawInputKey(button, x, y, opacity);
   }
 
-  drawKeyboardSecondaryInputKeys(x, y)
+  /**
+   * Draws a Sprint node styled like a skill slot: a panel,
+   * a centered icon, and a small label reading "dash".
+   * @param {number} x The x coordinate for the node (contents space).
+   * @param {number} y The y coordinate for the node (contents space).
+   */
+  drawSprintNode(x, y)
   {
-    // shorthand the variables for re-use.
+    // node size, aligned with other keys.
     const ikw = this.inputKeyWidth();
-    const baseX = x + 16;
-    const baseY = y + 8;
+    const ikh = this.inputKeyHeight();
 
-    // draw the combat skills equipped for JABS.
-    this.drawInputKey(JABS_Button.CombatSkill1, baseX + ikw * 0, baseY);
-    this.drawInputKey(JABS_Button.CombatSkill2, baseX + ikw * 1, baseY);
-    this.drawInputKey(JABS_Button.CombatSkill3, baseX + ikw * 2, baseY);
-    this.drawInputKey(JABS_Button.CombatSkill4, baseX + ikw * 3, baseY);
+    // panel rectangle aligned to other slot panels.
+    const panelX = x - 10;
+    const panelY = y + 20;
+    const panelW = ikw - 10;
+    const panelH = ikh;
+
+    // render the fancy HUD panel background.
+    this.drawHudPanelFancy(panelX, panelY, panelW, panelH, {
+      tint: null,
+      tintAlpha: 0,
+    });
+
+    // icon (temporary index 140) centered, biased upward to leave label room.
+    const iconIndex = 140;
+    const iconW = ImageManager.iconWidth;
+    const iconH = ImageManager.iconHeight;
+    const labelReserve = 18;
+    const iconX = panelX + Math.floor((panelW - iconW) / 2);
+    const iconY = panelY + Math.max(0, Math.floor((panelH - labelReserve - iconH) / 2));
+    this.drawIcon(iconIndex, iconX, iconY);
+
+    // small label using Window_Base helpers (no direct font pokes).
+    const originalSize = this.contents.fontSize;
+    const originalOutlineW = this.contents.outlineWidth;
+    const originalOutlineC = this.contents.outlineColor;
+
+    // match other slot label sizing (slightly smaller than default).
+    this.setFontSize(originalSize - 10);
+    this.contents.outlineWidth = 4;
+    this.contents.outlineColor = 'rgba(0, 0, 0, 0.85)';
+
+    const text = 'Dash';
+    const tw = this.textSizeEx(text).width;
+    const labelX = panelX + Math.floor((panelW - tw) / 2) - 5;
+    const labelY = panelY + panelH - labelReserve - 16;
+    this.drawText(text, labelX, labelY, tw, 'left');
+
+    // restore font settings.
+    this.setFontSize(originalSize);
+    this.contents.outlineWidth = originalOutlineW;
+    this.contents.outlineColor = originalOutlineC;
   }
 
   /**
@@ -2555,8 +3156,9 @@ class Window_InputFrame
    * @param {string} inputType The type of input key this is.
    * @param {number} x The x coordinate.
    * @param {number} y The y coordinate.
+   * @param {number} opacity The per-pass opacity (0..255) for slot sprites.
    */
-  drawInputKey(inputType, x, y)
+  drawInputKey(inputType, x, y, opacity)
   {
     // shorthand the player's JABS battler data.
     const jabsPlayer = $jabsEngine.getPlayer1();
@@ -2570,33 +3172,47 @@ class Window_InputFrame
     // extract the input key's data.
     const skillSlot = actionKeyData.skillslot;
 
-    // draw the input key slot's sprite.
-    this.drawInputKeySlotSprite(skillSlot, inputType, x, y);
+    // draw the input key slot's sprite with the provided opacity.
+    this.drawInputKeySlotSprite(skillSlot, inputType, x, y, opacity);
   }
 
   /**
    * Draw the input key associated with a given skill slot.
    * @param {JABS_SkillSlot} skillSlot The skill slot to draw.
    * @param {string} inputType The type of input key this is.
-   * @param {number} x The x coordinate.
-   * @param {number} y The y coordinate.
+   * @param {number} x The x coordinate (CONTENTS space).
+   * @param {number} y The y coordinate (CONTENTS space).
+   * @param {number} opacity The per-pass opacity (0..255) for the slot sprite.
    */
-  drawInputKeySlotSprite(skillSlot, inputType, x, y)
+  drawInputKeySlotSprite(skillSlot, inputType, x, y, opacity)
   {
     const sprite = this.getOrCreateInputKeySlotSprite(skillSlot, inputType);
 
+    // draw the panel background when the slot isn’t empty.
     if (!skillSlot.isEmpty())
     {
       const width = this.inputKeyWidth() - 10;
       const height = this.inputKeyHeight();
-      const c1 = ColorManager.itemBackColor1();
-      const c2 = ColorManager.itemBackColor2();
-      this.contents.gradientFillRect(x - 10, y + 20, width, height, c1, c2, true);
+
+      // fancy multi-layer HUD panel.
+      this.drawHudPanelFancy(x - 10, y + 20, width, height, {
+        // no tint by default; wire one in later if you theme by state.
+        tint: null,
+        tintAlpha: 0,
+      });
     }
 
+    // TODO: adjust x/y back a bit.
+
+    // position the slot sprite.
+    const px = this.padding + x - 4;
+    const py = this.padding + y + 14;
     sprite.show();
-    sprite.move(x + 6, y + 20);
+    sprite.move(px, py);
+    sprite.opacity = Math.max(0, Math.min(255, opacity || 255));
   }
+
+  //endregion draw
 }
 
 //endregion Window_InputFrame

--- a/project/js/plugins/hud/ext/J-HUD-PartyFrame.js
+++ b/project/js/plugins/hud/ext/J-HUD-PartyFrame.js
@@ -2,14 +2,14 @@
 /*:
  * @target MZ
  * @plugindesc
- * [v1.0.0 HUD-PARTY] A HUD frame that displays your party's data.
+ * [v1.1.0 HUD-PARTY] A HUD frame that displays your party's data.
  * @author JE
  * @url https://github.com/je-can-code/rmmz-plugins
- * @base J-ABS
  * @base J-Base
+ * @base J-ABS
  * @base J-HUD
- * @orderAfter J-ABS
  * @orderAfter J-Base
+ * @orderAfter J-ABS
  * @orderAfter J-HUD
  * @help
  * ============================================================================
@@ -19,6 +19,11 @@
  * This is the Party Frame, which displays the leader and allied members that
  * the player currently has in their party.
  *
+ * This plugin requires JABS.
+ * This plugin requires the base HUD.
+ * This plugin has no additional configuration required.
+ * ----------------------------------------------------------------------------
+ * DETAILS:
  * This includes the following data points for all actors:
  * - face portrait
  * - hp gauge
@@ -29,6 +34,16 @@
  * - current level
  * - experience gauge
  * - positive/negative state tracking
+ * - in combat indicator
+ * ============================================================================
+ * CHANGELOG
+ * ----------------------------------------------------------------------------
+ * - 1.1.0
+ *    Added visual tracking indicator for "in combat" for the leader.
+ *    Retroactively added this changelog.
+ * - 1.0.0
+ *    Initial release.
+ * ============================================================================
  */
 
 /**
@@ -40,7 +55,7 @@ var J = J || {};
 (() =>
 {
   // Check to ensure we have the minimum required version of the J-Base plugin.
-  const requiredBaseVersion = '1.0.0';
+  const requiredBaseVersion = '2.3.1';
   const hasBaseRequirement = J.BASE.Helpers.satisfies(J.BASE.Metadata.Version, requiredBaseVersion);
   if (!hasBaseRequirement)
   {
@@ -60,7 +75,7 @@ J.HUD.EXT.PARTY = {};
  */
 J.HUD.EXT.PARTY = {};
 J.HUD.EXT.PARTY.Metadata = {};
-J.HUD.EXT.PARTY.Metadata.Version = '1.0.0';
+J.HUD.EXT.PARTY.Metadata.Version = '1.1.0';
 J.HUD.EXT.PARTY.Metadata.Name = `J-HUD-PartyFrame`;
 
 /**
@@ -308,29 +323,70 @@ Sprite_ActorValue.prototype.refresh = function()
  */
 Sprite_ActorValue.prototype.hasParameterChanged = function()
 {
+  // default to "changed" in case we do not match a parameter.
   let changed = true;
+
+  // decide which parameter we are tracking and compare against the cache.
   switch (this._j._parameter)
   {
-    case "hp":
+    case 'hp':
+    {
+      // check for hp change.
       changed = this._j._actor.hp !== this._j._last._hp;
+
+      // update the last-known hp if changed.
       if (changed) this._j._last._hp = this._j._actor.hp;
+
+      // end case.
       return changed;
-    case "mp":
+    }
+    case 'mp':
+    {
+      // check for mp change.
       changed = this._j._actor.mp !== this._j._last._mp;
+
+      // update the last-known mp if changed.
       if (changed) this._j._last._mp = this._j._actor.mp;
+
+      // end case.
       return changed;
-    case "tp":
+    }
+    case 'tp':
+    {
+      // check for tp change.
       changed = this._j._actor.tp !== this._j._last._tp;
-      if (changed) this._j._last.tp = this._j._actor.tp;
+
+      // update the last-known tp if changed.
+      if (changed) this._j._last._tp = this._j._actor.tp;
+
+      // end case.
       return changed;
-    case "time":
-      changed = this._j._actor.currentExp() !== this._j._last._xp;
-      if (changed) this._j._last._xp = this._j._actor.currentExp();
+    }
+    case 'time':
+    {
+      // compute the current exp for comparison.
+      const current = this._j._actor.currentExp();
+
+      // check for exp change.
+      changed = current !== this._j._last._xp;
+
+      // update the last-known exp if changed.
+      if (changed) this._j._last._xp = current;
+
+      // end case.
       return changed;
-    case "lvl":
+    }
+    case 'lvl':
+    {
+      // check for level change.
       changed = this._j._actor.level !== this._j._last._lvl;
+
+      // update the last-known level if changed.
       if (changed) this._j._last._lvl = this._j._actor.level;
+
+      // end case.
       return changed;
+    }
   }
 };
 
@@ -339,44 +395,109 @@ Sprite_ActorValue.prototype.hasParameterChanged = function()
  */
 Sprite_ActorValue.prototype.createBitmap = function()
 {
+  // default the value to 0.
   let value = 0;
+
+  // determine the bitmap dimensions.
   const width = this.bitmapWidth();
+
+  // determine the bitmap height relative to font size.
   const height = this.fontSize() + 4;
+
+  // create the bitmap for this value sprite.
   const bitmap = new Bitmap(width, height);
+
+  // assign the font face for this value.
   bitmap.fontFace = this.fontFace();
+
+  // assign the font size for this value.
   bitmap.fontSize = this.fontSize();
+
+  // decide how to render based on the parameter being displayed.
   switch (this._j._parameter)
   {
-    case "hp":
+    case 'hp':
+    {
+      // set the outline thickness for readability.
       bitmap.outlineWidth = 4;
-      bitmap.outlineColor = "rgba(128, 24, 24, 1.0)";
-      value = Math.floor(this._j._actor.hp);
+
+      // set the red-tinted outline color for HP.
+      bitmap.outlineColor = 'rgba(128, 24, 24, 1.0)';
+
+      // display rounded HP to avoid off-by-one visuals against fractional HP.
+      value = Math.round(this._j._actor.hp);
+
+      // end case.
       break;
-    case "mp":
+    }
+    case 'mp':
+    {
+      // set the outline thickness for readability.
       bitmap.outlineWidth = 4;
-      bitmap.outlineColor = "rgba(24, 24, 192, 1.0)";
-      value = Math.floor(this._j._actor.mp);
+
+      // set the blue-tinted outline color for MP.
+      bitmap.outlineColor = 'rgba(24, 24, 192, 1.0)';
+
+      // display rounded MP to align with fractional accumulation.
+      value = Math.round(this._j._actor.mp);
+
+      // end case.
       break;
-    case "tp":
+    }
+    case 'tp':
+    {
+      // set the outline thickness for readability.
       bitmap.outlineWidth = 2;
-      bitmap.outlineColor = "rgba(64, 128, 64, 1.0)";
-      value = Math.floor(this._j._actor.tp);
+
+      // set the green-tinted outline color for TP.
+      bitmap.outlineColor = 'rgba(64, 128, 64, 1.0)';
+
+      // TP can change in non-integers under JABS; display rounded for consistency.
+      value = Math.round(this._j._actor.tp);
+
+      // end case.
       break;
-    case "time":
+    }
+    case 'time':
+    {
+      // set the outline thickness for readability.
       bitmap.outlineWidth = 4;
-      bitmap.outlineColor = "rgba(72, 72, 72, 1.0)";
+
+      // set the neutral outline for XP remaining.
+      bitmap.outlineColor = 'rgba(72, 72, 72, 1.0)';
+
+      // compute exp remaining to next level.
       const curExp = (this._j._actor.nextLevelExp() - this._j._actor.currentLevelExp());
+
+      // compute progress into the current level.
       const nextLv = (this._j._actor.currentExp() - this._j._actor.currentLevelExp());
+
+      // calculate the remaining exp as a whole number.
       value = curExp - nextLv;
+
+      // end case.
       break;
-    case "lvl":
+    }
+    case 'lvl':
+    {
+      // set the outline thickness for readability.
       bitmap.outlineWidth = 4;
-      bitmap.outlineColor = "rgba(72, 72, 72, 1.0)";
+
+      // set the neutral outline for level text.
+      bitmap.outlineColor = 'rgba(72, 72, 72, 1.0)';
+
+      // display the level as a 3-digit number.
       value = this._j._actor.level.padZero(3);
+
+      // end case.
       break;
+    }
   }
 
-  bitmap.drawText(value, 0, 0, bitmap.width, bitmap.height, "left");
+  // draw the value left-aligned across the bitmap.
+  bitmap.drawText(value, 0, 0, bitmap.width, bitmap.height, 'left');
+
+  // return the created bitmap.
   return bitmap;
 };
 
@@ -505,29 +626,29 @@ class Window_PartyFrame
     /**
      * The type of gauge for hp.
      */
-    HP: "hp",
+    HP: 'hp',
 
     /**
      * The type of gauge for mp.
      */
-    MP: "mp",
+    MP: 'mp',
 
     /**
      * The type of gauge for tp.
      */
-    TP: "tp",
+    TP: 'tp',
 
     /**
      * The type of gauge for xp.
      * We borrow the "time" gauge for this, though.
      */
-    XP: "time",
+    XP: 'time',
 
     /**
      * Not actually a gauge, but does have an actorvalue representing
      * the actor's level.
      */
-    Level: "lvl"
+    Level: 'lvl'
   };
 
   /**
@@ -566,7 +687,7 @@ class Window_PartyFrame
   {
     /**
      * The cached collection of hud sprites.
-     * @type {Map<string, Sprite_Face|Sprite_MapGauge|Sprite_ActorValue|Sprite_Icon>}
+     * @type {Map<string, Sprite_Face|Sprite_MapGauge|Sprite_ActorValue|Sprite_Icon|Sprite_BaseText>}
      */
     this._hudSprites = new Map();
   }
@@ -773,7 +894,8 @@ class Window_PartyFrame
       Window_PartyFrame.gaugeTypes.HP,
       Window_PartyFrame.gaugeTypes.MP,
       Window_PartyFrame.gaugeTypes.TP,
-      Window_PartyFrame.gaugeTypes.XP ];
+      Window_PartyFrame.gaugeTypes.XP
+    ];
   }
 
   /**
@@ -1099,6 +1221,117 @@ class Window_PartyFrame
     return sprite;
   }
 
+  /**
+   * Creates or retrieves the combat icon sprite for the given actor.
+   * @param {Game_Actor} actor The actor this icon represents.
+   * @returns {Sprite_Icon} The combat icon sprite.
+   */
+  getOrCreateCombatIcon(actor)
+  {
+    // create a unique cache key for the icon.
+    const key = `combat-icon-${actor.name()}-${actor.actorId()}`;
+
+    // if cached already, return it.
+    if (this._hudSprites.has(key))
+    {
+      return this._hudSprites.get(key);
+    }
+
+    // in-combat icon index is two fists punching.
+    const iconIndex = 31;
+
+    // create the icon sprite.
+    const sprite = new Sprite_Icon(iconIndex);
+
+    // indicate we'll manage the opacity ourselves.
+    sprite.selfManageOpacity();
+
+    // cache and stage it.
+    this._hudSprites.set(key, sprite);
+    sprite.hide();
+    this.addChild(sprite);
+
+    // return the created sprite.
+    return sprite;
+  }
+
+  /**
+   * Creates or retrieves the combat timer sprite for the given actor.
+   * @param {Game_Actor} actor The actor this timer represents.
+   * @returns {Sprite_BaseText} The combat seconds text sprite.
+   */
+  getOrCreateCombatTimer(actor)
+  {
+    // create a unique cache key for the timer.
+    const key = `combat-timer-${actor.name()}-${actor.actorId()}`;
+
+    // if cached already, return it.
+    if (this._hudSprites.has(key))
+    {
+      return this._hudSprites.get(key);
+    }
+
+    // create a text sprite.
+    const sprite = new Sprite_BaseText('');
+
+    // configure the font for a small numeric readout (seconds, one decimal).
+    sprite.setFontFace($gameSystem.numberFontFace());
+    sprite.setFontSize($gameSystem.mainFontSize() - 10);
+    sprite.setAlignment(Sprite_BaseText.Alignments.Center);
+    sprite.setMinWidth(ImageManager.iconWidth);
+
+    // this sprite manages its own opacity (for fade out), so opt out of auto-managed opacity.
+    sprite.selfManageOpacity();
+
+    // start hidden until we actually show it in-combat.
+    sprite.hide();
+
+    // cache and stage it.
+    this._hudSprites.set(key, sprite);
+    this.addChild(sprite);
+
+    // return the created sprite.
+    return sprite;
+  }
+
+  /**
+   * Creates or retrieves the combat label sprite for the given actor.
+   * Shows a text blurb like "IN COMBAT" or "FREE" near the combat icon.
+   * @param {Game_Actor} actor The actor this label represents.
+   * @returns {Sprite_BaseText} The combat status label sprite.
+   */
+  getOrCreateCombatLabel(actor)
+  {
+    // create a unique cache key for the label.
+    const key = `combat-label-${actor.name()}-${actor.actorId()}`;
+
+    // if cached already, return it.
+    if (this._hudSprites.has(key))
+    {
+      return this._hudSprites.get(key);
+    }
+
+    // create a text sprite.
+    const sprite = new Sprite_BaseText('');
+
+    // configure the font for emphasis and readability.
+    sprite
+      .setFontFace($gameSystem.mainFontFace())
+      .setFontSize($gameSystem.mainFontSize() - 6)
+      .setAlignment(Sprite_BaseText.Alignments.Center)
+      .setBold(true)
+      .setItalics(true)
+      .setMinWidth(Math.round(ImageManager.iconWidth * 2.5))
+      .selfManageOpacity();
+
+    // cache and stage it.
+    this._hudSprites.set(key, sprite);
+    this.addChild(sprite);
+
+    // return the created sprite.
+    return sprite;
+  }
+
   //endregion caching
 
   /**
@@ -1204,13 +1437,20 @@ class Window_PartyFrame
   {
     this._hudSprites.forEach((sprite, _) =>
     {
+      // if the interference shouldn't be handled for this sprite, then don't.
+      if (this.canHandleSpriteInterference(sprite) === false) return;
+
       // if we are above 64, rapidly decrement by -15 until we get below 64.
       if (sprite.opacity > 64)
       {
         sprite.opacity -= 15;
-      }// if we are below 64, increment by +1 until we get to 64.
-      else if (sprite.opacity < 64) sprite.opacity += 1;
-    });
+      }
+      // if we are below 64, increment by +1 until we get to 64.
+      else if (sprite.opacity < 64)
+      {
+        sprite.opacity += 1;
+      }
+    }, this);
   }
 
   /**
@@ -1220,13 +1460,38 @@ class Window_PartyFrame
   {
     this._hudSprites.forEach((sprite, _) =>
     {
+      // if the interference shouldn't be handled for this sprite, then don't.
+      if (this.canHandleSpriteInterference(sprite) === false) return;
+
       // if we are below 255, rapidly increment by +15 until we get to 255.
       if (sprite.opacity < 255)
       {
         sprite.opacity += 15;
-      }// if we are above 255, set to 255.
-      else if (sprite.opacity > 255) sprite.opacity = 255;
-    });
+      }
+      // if we are above 255, set to 255.
+      else if (sprite.opacity > 255)
+      {
+        sprite.opacity = 255;
+      }
+    }, this);
+  }
+
+  /**
+   * Checks if the given sprite should be handled for interference.
+   * @param {Sprite_Face|Sprite_MapGauge|Sprite_ActorValue|Sprite_Icon|Sprite_BaseText} sprite
+   * @returns {boolean}
+   */
+  canHandleSpriteInterference(sprite)
+  {
+    // certain sprites can have self-managed opacity.
+    if (sprite instanceof Sprite_BaseText || sprite instanceof Sprite_Icon)
+    {
+      // if they have self-managed opacity, they shouldn't be handled.
+      if (sprite.hasSelfManagedOpacity() === true) return false;
+    }
+
+    // let the system handle the opacity management.
+    return true;
   }
 
   //endregion visibility
@@ -1260,6 +1525,9 @@ class Window_PartyFrame
     const statesX = gaugesX;
     const statesY = gaugesY - (ImageManager.iconHeight * 2) - 24;
     this.drawStates(statesX, statesY);
+
+    // draw the in‑combat indicator (icon + timer) just to the right of the gauges.
+    this.drawLeaderCombatIndicator(gaugesX, gaugesY);
   }
 
   /**
@@ -1388,6 +1656,108 @@ class Window_PartyFrame
   }
 
   /**
+   * Draws the leader's "in‑combat" indicator to the right of the gauges.
+   * @param {number} gaugesX The x coordinate where gauges start.
+   * @param {number} gaugesY The y coordinate where gauges start.
+   */
+  drawLeaderCombatIndicator(gaugesX, gaugesY)
+  {
+    // grab the leader and their tracked battler.
+    const leader = $gameParty.leader();
+    const leaderBattler = $gameParty.leaderJabsBattler();
+
+    // if we cannot resolve the tracked battler, don't draw.
+    if (!leader || !leaderBattler) return;
+
+    // decide visibility based on the combat rules.
+    const inCombat = ($jabsEngine.forcedCombat === true) || leaderBattler.isInCombat();
+
+    // grab the hp gauge sprite for width math (hp/mp/tp share the same width).
+
+    // fetch or create the three sprites we need.
+    const icon = this.getOrCreateCombatIcon(leader);
+    const timer = this.getOrCreateCombatTimer(leader);
+    const label = this.getOrCreateCombatLabel(leader);
+
+    // determine anchor coordinates to the immediate right of the gauges.
+    const hpGauge = this.getOrCreateFullSizeGaugeSprite(leader, Window_PartyFrame.gaugeTypes.HP);
+    const iconX = (gaugesX - 24) + hpGauge.bitmapWidth() + 8;
+    const iconY = gaugesY; // align with the HP row.
+    icon.move(iconX, iconY);
+
+    // move the timer to be centered below the icon.
+    const timerWidth = timer.bitmap
+      ? timer.bitmap.width
+      : ImageManager.iconWidth;
+    const timerX = iconX + Math.floor((ImageManager.iconWidth - timerWidth) / 2);
+    const timerY = iconY + ImageManager.iconHeight - 6;
+    timer.move(timerX, timerY);
+
+    // move the label to be centered above the icon.
+    const labelX = iconX - Math.floor((label.bitmap.width - ImageManager.iconWidth) / 2);
+    const labelY = iconY - label.bitmap.height;
+    label.move(labelX, labelY);
+
+    // configure a per‑frame fade step for ~0.5 seconds at 60fps.
+    const fadeStep = 9; // 255 / 30 ≈ 8.5 → 9
+
+    // we only branch once on inCombat for all three sprites.
+    if (inCombat)
+    {
+      // icon: snap visible and fully opaque while in combat.
+      icon.visible = true;
+      icon.opacity = 255;
+
+      // timer: update text, show, fully opaque.
+      const seconds = leaderBattler.getCombatSecondsRemaining();
+      const secondsText = Number(seconds)
+        .toFixed(1);
+      timer.setText(secondsText);
+      timer.show();
+      timer.opacity = 255;
+
+      // label: red "IN COMBAT" above the icon.
+      label.setColor('#ff3b3b');
+      label.setText('IN COMBAT');
+      label.show();
+      label.opacity = 255;
+    }
+    else
+    {
+      // not in combat: fade the icon and timer out over ~0.5s, then hide.
+
+      // icon fade.
+      if (icon.opacity > 0)
+      {
+        icon.opacity = Math.max(0, icon.opacity - fadeStep);
+        icon.visible = true;
+        if (icon.opacity === 0) icon.visible = false;
+      }
+      else
+      {
+        icon.visible = false;
+      }
+
+      // timer fade.
+      if (timer.opacity > 0)
+      {
+        timer.opacity = Math.max(0, timer.opacity - fadeStep);
+        if (timer.opacity === 0) timer.hide();
+      }
+      else
+      {
+        timer.hide();
+      }
+
+      // label: instant green "FREE" for strong visual contrast when idle.
+      label.setColor('#44ff66');
+      label.setText('FREE');
+      label.show();
+      label.opacity = 255;
+    }
+  }
+
+  /**
    * Hides all expired states on the leader.
    * @param {Game_Actor} leader The actor to hide states for.
    */
@@ -1451,7 +1821,7 @@ class Window_PartyFrame
 
     this.drawText(`x${trackedState.stackCount}`, ox, y - 30, 64, Window_Base.TextAlignments.Left);
 
-    this.resetFontSettings()
+    this.resetFontSettings();
   }
 
   /**

--- a/project/js/plugins/jafting/ext/J-JAFTING-Creation.js
+++ b/project/js/plugins/jafting/ext/J-JAFTING-Creation.js
@@ -1072,7 +1072,7 @@ RecipeTracking.prototype.craftingProficiency = function()
 /*:
  * @target MZ
  * @plugindesc
- * [v1.0.1 JAFT-Create] An extension for JAFTING to enable recipe creation.
+ * [v1.0.2 JAFT-Create] An extension for JAFTING to enable recipe creation.
  * @author JE
  * @url https://github.com/je-can-code/rmmz-plugins
  * @base J-Base
@@ -1204,6 +1204,8 @@ RecipeTracking.prototype.craftingProficiency = function()
  *
  * ============================================================================
  * CHANGELOG:
+ * - 1.0.2
+ *    Added flag for showing external file load info.
  * - 1.0.1
  *    Recipes & Categories can now be updated for existing save files.
  * - 1.0.0
@@ -1367,7 +1369,8 @@ class J_CraftingCreatePluginMetadata
         mappableRecipe.maskedUntilCrafted,
         parsedIngredients,
         parsedTools,
-        parsedOutputs);
+        parsedOutputs
+      );
 
       return newJaftingRecipe;
     };
@@ -1396,7 +1399,7 @@ class J_CraftingCreatePluginMetadata
         unlockedByDefault
       } = mappableCategory;
       const newCategory = new CraftingCategory(name, key, iconIndex, description, unlockedByDefault);
-      return newCategory
+      return newCategory;
     };
 
     // iterate over each category to classify the data.
@@ -1477,10 +1480,17 @@ class J_CraftingCreatePluginMetadata
      */
     this.categoriesMap = categoriesMap;
 
-    console.log(`loaded:
+    if (this.#hasMinimumBaseVersion() && J.BASE.Metadata.ShowExternalFileLoadInfo)
+    {
+      console.log(`loaded:
       - ${this.recipes.length} recipes
       - ${this.categories.length} categories
       from file ${J_CraftingCreatePluginMetadata.CONFIG_PATH}.`);
+    }
+    else
+    {
+      console.log(`loaded from file ${J_CraftingCreatePluginMetadata.CONFIG_PATH}.`);
+    }
   }
 
   /**
@@ -1571,6 +1581,39 @@ class J_CraftingCreatePluginMetadata
       .patch('0')
       .build();
   }
+
+  /**
+   * Checks if the BASE plugin meets the minimum version requirement for this plugin.
+   * @return {boolean}
+   */
+  #hasMinimumBaseVersion()
+  {
+    // identify the two versions for comparison.
+    const minimumVersion = this.#minimumBaseVersion();
+    const actualVersion = new PluginVersion(J.BASE.Metadata.Version);
+
+    // check if we meet the minimum version threshold.
+    const meetsThreshold = actualVersion.satisfiesPluginVersion(minimumVersion);
+
+    // if the version isn't high enough, then we cannot proceed.
+    if (!meetsThreshold) return false;
+
+    // we're good!
+    return true;
+  }
+
+  /**
+   * Gets the current minimum version of the J-BASE system this plugin requires.
+   * @returns {PluginVersion}
+   */
+  #minimumBaseVersion()
+  {
+    return PluginVersion.builder
+      .major('2')
+      .minor('3')
+      .patch('1')
+      .build();
+  }
 }
 
 //endregion plugin metadata
@@ -1594,7 +1637,7 @@ J.JAFTING.EXT.CREATE = {};
 /**
  * The metadata associated with this plugin.
  */
-J.JAFTING.EXT.CREATE.Metadata = new J_CraftingCreatePluginMetadata('J-JAFTING-Creation', '1.0.0');
+J.JAFTING.EXT.CREATE.Metadata = new J_CraftingCreatePluginMetadata('J-JAFTING-Creation', '1.0.2');
 
 /**
  * A collection of all aliased methods for this plugin.

--- a/project/js/plugins/jafting/ext/J-JAFTING-Creation.js
+++ b/project/js/plugins/jafting/ext/J-JAFTING-Creation.js
@@ -1480,7 +1480,7 @@ class J_CraftingCreatePluginMetadata
      */
     this.categoriesMap = categoriesMap;
 
-    if (this.#hasMinimumBaseVersion() && J.BASE.Metadata.ShowExternalFileLoadInfo)
+    if (J_CraftingCreatePluginMetadata.#hasMinimumBaseVersion() && J.BASE.Metadata.ShowExternalFileLoadInfo)
     {
       console.log(`loaded:
       - ${this.recipes.length} recipes
@@ -1586,7 +1586,7 @@ class J_CraftingCreatePluginMetadata
    * Checks if the BASE plugin meets the minimum version requirement for this plugin.
    * @return {boolean}
    */
-  #hasMinimumBaseVersion()
+  static #hasMinimumBaseVersion()
   {
     // identify the two versions for comparison.
     const minimumVersion = this.#minimumBaseVersion();
@@ -1606,7 +1606,7 @@ class J_CraftingCreatePluginMetadata
    * Gets the current minimum version of the J-BASE system this plugin requires.
    * @returns {PluginVersion}
    */
-  #minimumBaseVersion()
+  static #minimumBaseVersion()
   {
     return PluginVersion.builder
       .major('2')

--- a/project/js/plugins/omni/ext/J-Omni-Questopedia.js
+++ b/project/js/plugins/omni/ext/J-Omni-Questopedia.js
@@ -2286,14 +2286,15 @@ TrackedOmniQuest.prototype.handleQuestUpdateLog = function()
 /*:
  * @target MZ
  * @plugindesc
- * [v1.0.2 OMNI-QUEST] Extends the Omnipedia with a Questopedia entry.
+ * [v1.0.3 OMNI-QUEST] Extends the Omnipedia with a Questopedia entry.
  * @author JE
  * @url https://github.com/je-can-code/rmmz-plugins
  * @base J-Base
  * @base J-Omnipedia
  * @orderAfter J-Base
- * @orderAfter J-MessageTextCodes
  * @orderAfter J-Omnipedia
+ * @orderAfter J-HUD
+ * @orderAfter J-MessageTextCodes
  * @help
  * ============================================================================
  * OVERVIEW
@@ -2378,6 +2379,9 @@ TrackedOmniQuest.prototype.handleQuestUpdateLog = function()
  *
  * ============================================================================
  * CHANGELOG:
+ * - 1.0.3
+ *    Updated to accommodate for mapping shortcut to view quest log.
+ *    Added flag for showing external file load info.
  * - 1.0.2
  *    Adapted for updates to J-ABS-InputManager (input namespace).
  * - 1.0.1
@@ -2471,9 +2475,9 @@ class J_QUEST_PluginMetadata
     {
       // validate the name is not one of the organizational names for the editor-only.
       const questName = parsedQuest.name;
-      if (questName.startsWith("__")) return;
-      if (questName.startsWith("==")) return;
-      if (questName.startsWith("--")) return;
+      if (questName.startsWith('__')) return;
+      if (questName.startsWith('==')) return;
+      if (questName.startsWith('--')) return;
 
       const builtQuest = OmniQuest.Builder()
         .name(parsedQuest.name)
@@ -2486,7 +2490,7 @@ class J_QUEST_PluginMetadata
         .objectives(parsedQuest.objectives)
         .build();
 
-      parsedQuests.push(builtQuest)
+      parsedQuests.push(builtQuest);
     };
 
     parsedBlob.forEach(foreacher, this);
@@ -2569,11 +2573,18 @@ class J_QUEST_PluginMetadata
      */
     this.tagsMap = tagMap;
 
-    console.log(`loaded:
-      - ${this.quests.length} quests
-      - ${this.categories.length} categories
-      - ${this.tags.length} tags
-      from file ${J_QUEST_PluginMetadata.CONFIG_PATH}.`);
+    if (this.#hasMinimumBaseVersion() && J.BASE.Metadata.ShowExternalFileLoadInfo)
+    {
+      console.log(`loaded:
+        - ${this.quests.length} quests
+        - ${this.categories.length} categories
+        - ${this.tags.length} tags
+        from file ${J_QUEST_PluginMetadata.CONFIG_PATH}.`);
+    }
+    else
+    {
+      console.log(`loaded from file ${J_QUEST_PluginMetadata.CONFIG_PATH}.`);
+    }
   }
 
   /**
@@ -2600,18 +2611,51 @@ class J_QUEST_PluginMetadata
       /**
        * The name of the command when viewed from the Omnipedia.
        */
-      Name: "Questopedia",
+      Name: 'Questopedia',
 
       /**
        * The symbol of the command in the command list.
        */
-      Symbol: "quest-pedia",
+      Symbol: 'quest-pedia',
 
       /**
        * The icon for the command anywhere it is viewed.
        */
       IconIndex: 2564,
     };
+  }
+
+  /**
+   * Checks if the BASE plugin meets the minimum version requirement for this plugin.
+   * @return {boolean}
+   */
+  #hasMinimumBaseVersion()
+  {
+    // identify the two versions for comparison.
+    const minimumVersion = this.#minimumBaseVersion();
+    const actualVersion = new PluginVersion(J.BASE.Metadata.Version);
+
+    // check if we meet the minimum version threshold.
+    const meetsThreshold = actualVersion.satisfiesPluginVersion(minimumVersion);
+
+    // if the version isn't high enough, then we cannot proceed.
+    if (!meetsThreshold) return false;
+
+    // we're good!
+    return true;
+  }
+
+  /**
+   * Gets the current minimum version of the J-BASE system this plugin requires.
+   * @returns {PluginVersion}
+   */
+  #minimumBaseVersion()
+  {
+    return PluginVersion.builder
+      .major('2')
+      .minor('3')
+      .patch('1')
+      .build();
   }
 }
 
@@ -2637,7 +2681,7 @@ J.OMNI.EXT.QUEST = {};
 /**
  * The metadata associated with this plugin.
  */
-J.OMNI.EXT.QUEST.Metadata = new J_QUEST_PluginMetadata('J-Omni-Questopedia', '1.0.2');
+J.OMNI.EXT.QUEST.Metadata = new J_QUEST_PluginMetadata('J-Omni-Questopedia', '1.0.3');
 
 /**
  * A collection of all aliased methods for this plugin.

--- a/project/js/plugins/omni/ext/J-Omni-Questopedia.js
+++ b/project/js/plugins/omni/ext/J-Omni-Questopedia.js
@@ -2573,7 +2573,7 @@ class J_QUEST_PluginMetadata
      */
     this.tagsMap = tagMap;
 
-    if (this.#hasMinimumBaseVersion() && J.BASE.Metadata.ShowExternalFileLoadInfo)
+    if (J_QUEST_PluginMetadata.#hasMinimumBaseVersion() && J.BASE.Metadata.ShowExternalFileLoadInfo)
     {
       console.log(`loaded:
         - ${this.quests.length} quests
@@ -2629,7 +2629,7 @@ class J_QUEST_PluginMetadata
    * Checks if the BASE plugin meets the minimum version requirement for this plugin.
    * @return {boolean}
    */
-  #hasMinimumBaseVersion()
+  static #hasMinimumBaseVersion()
   {
     // identify the two versions for comparison.
     const minimumVersion = this.#minimumBaseVersion();
@@ -2649,7 +2649,7 @@ class J_QUEST_PluginMetadata
    * Gets the current minimum version of the J-BASE system this plugin requires.
    * @returns {PluginVersion}
    */
-  #minimumBaseVersion()
+  static #minimumBaseVersion()
   {
     return PluginVersion.builder
       .major('2')

--- a/src/build-tools/build-all.js
+++ b/src/build-tools/build-all.js
@@ -27,13 +27,13 @@ import { exec } from 'child_process';
 import * as fs from 'fs/promises';
 
 const pkg = JSON.parse(await fs.readFile('./package.json', 'utf-8'));
-import Logger from './logger.js';
+import Logger, { LogStyle } from './logger.js';
 
 // start for timings sake.
 const start = performance.now();
 
 // don't recursively build everything, or start generating a bunch of empty directories.
-const ignoredKeys = [ "plugin:", "copy:", "build:all", "hotfix" ];
+const ignoredKeys = [ 'plugin:', 'copy:', 'build:all', 'hotfix' ];
 
 // extract the scripts section of our package.json.
 const { scripts } = pkg;
@@ -46,7 +46,7 @@ for (const key in scripts)
 {
   if (ignoredKeys.some(ignoredKey => key.startsWith(ignoredKey)))
   {
-    Logger.log(`skipping: [${key}] because it starts with an ignored prefix.`)
+    Logger.log(`skipping: [${key}] because it starts with an ignored prefix.`);
     continue;
   }
 
@@ -56,6 +56,7 @@ for (const key in scripts)
   // capture the execution as a promise for parallelization.
   const execution = new Promise(resolve =>
   {
+    // eslint-disable-next-line no-unused-vars
     const handleOutcome = (error, stdout, stderr) =>
     {
       if (error)
@@ -65,16 +66,16 @@ for (const key in scripts)
       }
 
       resolve();
-    }
+    };
 
-    Logger.log(command);
+    Logger.log(command, LogStyle.yellow);
 
     // kick off the command.
     const process = exec(command, handleOutcome);
 
     // track the output and log it.
     process.stdout.on('data', data => Logger.log(data));
-  })
+  });
 
   // add the execution to the collection.
   executions.push(execution);
@@ -85,4 +86,7 @@ await Promise.all(executions);
 
 // capture the duration of this build-all execution in seconds.
 const durationSeconds = ((performance.now() - start) / 1000).toFixed(3);
-Logger.logAnyway(`Builder™ has completed building all plugins in ${durationSeconds}s. 🛠️  ✅`);
+Logger.logAnyway(
+  `Builder™ has completed building all ${executions.length} plugins in ${durationSeconds}s.`,
+  LogStyle.rainbow
+);

--- a/src/build-tools/combine.js
+++ b/src/build-tools/combine.js
@@ -36,7 +36,7 @@
 import { globSync } from 'glob';
 import { existsSync } from 'fs';
 import * as fs from 'fs/promises';
-import Logger from './logger.js';
+import Logger, { LogStyle } from './logger.js';
 
 // whether or not to include a timestamp of when this was bundled up.
 const USE_BUNDLE_TIMESTAMP = false;
@@ -82,13 +82,13 @@ async function main()
   }
 
   // concat the files into 1.
-  const bundledJs = files.join("\n\n");
+  const bundledJs = files.join('\n\n');
 
   // write the file to the designated location.
   await fs.writeFile(filepathAndName, bundledJs, 'utf-8');
 
-  Logger.log(`finished combining all files into 1.`);
-  Logger.logAnyway(`Combiner™ has completed execution for ${OUT_FILENAME}. 💯✅`);
+  Logger.log(`finished combining all files into 1.`, LogStyle.magenta);
+  Logger.logAnyway(`Combiner™ has completed execution for ${OUT_FILENAME}.`, LogStyle.rainbow);
 }
 
 /**
@@ -99,13 +99,13 @@ function getArgs()
 {
   const args = process.argv.slice(2);
 
-  const SRC_PATH = args[0] ?? "./src";
-  const OUT_PATH = args[1] ?? "../plugins/j";
-  const OUT_FILENAME = args[2] ?? "some_plugin.js";
+  const SRC_PATH = args[0] ?? './src';
+  const OUT_PATH = args[1] ?? '../plugins/j';
+  const OUT_FILENAME = args[2] ?? 'some_plugin.js';
 
-  Logger.log(`source path: ${SRC_PATH}`);
-  Logger.log(`output path: ${OUT_PATH}`);
-  Logger.log(`output filename: ${OUT_FILENAME}`);
+  Logger.log(`source path: ${SRC_PATH}`, LogStyle.yellow);
+  Logger.log(`output path: ${OUT_PATH}`, LogStyle.yellow);
+  Logger.log(`output filename: ${OUT_FILENAME}`, LogStyle.yellow);
 
   return [ SRC_PATH, OUT_PATH, OUT_FILENAME ];
 }
@@ -123,11 +123,11 @@ async function validateOutputDir(output_path)
     // make sure the directory is created.
     await fs.mkdir(output_path, { recursive: true });
 
-    Logger.log(`output directory created: ${output_path}`);
+    Logger.log(`output directory created: ${output_path}`, LogStyle.dim);
   }
   else
   {
-    Logger.log(`output directory already exists; ${output_path}`);
+    Logger.log(`output directory already exists; ${output_path}`, LogStyle.dim);
   }
 }
 
@@ -138,7 +138,7 @@ async function validateOutputDir(output_path)
 function getFilepaths(src, out)
 {
   const options = {
-    ignore: [ "node_modules/**/*", out ],
+    ignore: [ 'node_modules/**/*', out ],
     absolute: true
   };
 
@@ -146,7 +146,7 @@ function getFilepaths(src, out)
 
   return filepaths.sort((a, b) =>
   {
-    const left = a.toLowerCase()
+    const left = a.toLowerCase();
     const right = b.toLowerCase();
     if (left < right) //sort string ascending
     {
@@ -178,7 +178,7 @@ async function getFiles(filePaths)
     files.push(file);
   }
 
-  Logger.log(`found ${files.length} files to combine.`);
+  Logger.log(`found ${files.length} files to combine.`, LogStyle.dim);
 
   // returns all the found files.
   return files;

--- a/src/build-tools/copy.js
+++ b/src/build-tools/copy.js
@@ -1,5 +1,5 @@
-import Mirror from './mirror.js'
-import Logger from "./logger.js";
+import Mirror from './mirror.js';
+import Logger, { LogStyle } from './logger.js';
 
 // start for timings sake.
 const start = performance.now();
@@ -23,4 +23,4 @@ if (destinations.length)
 await mirror.mirrorToAllDestinations();
 
 const durationSeconds = ((performance.now() - start) / 1000).toFixed(3);
-Logger.logAnyway(`Mirror™ has completed copying in ${durationSeconds}s. 📋  ✅`);
+Logger.logAnyway(`Mirror™ has completed copying in ${durationSeconds}s.`, LogStyle.rainbow);

--- a/src/build-tools/init.js
+++ b/src/build-tools/init.js
@@ -26,7 +26,7 @@
  */
 
 import Mirror from './mirror.js';
-import Logger from "./logger.js";
+import Logger, { LogStyle } from './logger.js';
 
 /**
  * Initializes a new directory for the purpose of developing a new plugin.
@@ -51,7 +51,7 @@ class Initter
    */
   static async init()
   {
-    Logger.log(`working directory: ${process.cwd()}`);
+    Logger.log(`working directory: ${process.cwd()}`, LogStyle.dim);
 
     // derive a new mirror for mirroring our template.
     const mirror = new Mirror();
@@ -60,7 +60,7 @@ class Initter
     // clone the template into the destination.
     await mirror.mirrorToDestination(`${this.DEFAULT_BASE_PLUGIN_PATH}/${destinationPath}`);
 
-    Logger.logAnyway(`Initter™ has completed execution. 💯✅`);
+    Logger.logAnyway(`Initter™ has completed execution.`, LogStyle.rainbow);
   }
 }
 

--- a/src/build-tools/logger.js
+++ b/src/build-tools/logger.js
@@ -1,6 +1,52 @@
 /**
  * A simple logger utility for my cute lil RMMZ dev helper scripts.
  */
+
+/**
+ * A string-union type for valid Logger style keys.
+ * Use this type anywhere you want intellisense and checking for styles.
+ * @typedef {
+ *  'reset' | 'bold' | 'dim' |
+ *  'black' | 'red' | 'green' | 'yellow' | 'blue' | 'magenta' | 'cyan' | 'white' |
+ *  'brightBlack' | 'brightRed' | 'brightGreen' | 'brightYellow' | 'brightBlue' |
+ *  'brightMagenta' | 'brightCyan' | 'brightWhite' | 'rainbow'
+ * } LogStyleKey
+ */
+
+/**
+ * An enum-like object of style keys so callers can avoid magic strings.
+ * Example: Logger.log('Working...', LogStyle.cyan);
+ */
+export const LogStyle = Object.freeze({
+  // emphasis
+  reset: 'reset',
+  bold: 'bold',
+  dim: 'dim',
+
+  // foreground colors
+  black: 'black',
+  red: 'red',
+  green: 'green',
+  yellow: 'yellow',
+  blue: 'blue',
+  magenta: 'magenta',
+  cyan: 'cyan',
+  white: 'white',
+
+  // bright variants
+  brightBlack: 'brightBlack',
+  brightRed: 'brightRed',
+  brightGreen: 'brightGreen',
+  brightYellow: 'brightYellow',
+  brightBlue: 'brightBlue',
+  brightMagenta: 'brightMagenta',
+  brightCyan: 'brightCyan',
+  brightWhite: 'brightWhite',
+
+  // special effects
+  rainbow: 'rainbow',
+});
+
 class Logger
 {
   /**
@@ -8,6 +54,39 @@ class Logger
    * @type {boolean}
    */
   static #blocked = true;
+
+  /**
+   * ANSI style codes for simple coloring/styling.
+   * Keys align 1:1 with {@link LogStyle} values.
+   * @type {Record<LogStyleKey, string>}
+   */
+  static #styles = {
+    [LogStyle.reset]: '\x1b[0m',
+
+    // emphasis
+    [LogStyle.bold]: '\x1b[1m',
+    [LogStyle.dim]: '\x1b[2m',
+
+    // foreground colors
+    [LogStyle.black]: '\x1b[30m',
+    [LogStyle.red]: '\x1b[31m',
+    [LogStyle.green]: '\x1b[32m',
+    [LogStyle.yellow]: '\x1b[33m',
+    [LogStyle.blue]: '\x1b[34m',
+    [LogStyle.magenta]: '\x1b[35m',
+    [LogStyle.cyan]: '\x1b[36m',
+    [LogStyle.white]: '\x1b[37m',
+
+    // bright variants
+    [LogStyle.brightBlack]: '\x1b[90m',
+    [LogStyle.brightRed]: '\x1b[91m',
+    [LogStyle.brightGreen]: '\x1b[92m',
+    [LogStyle.brightYellow]: '\x1b[93m',
+    [LogStyle.brightBlue]: '\x1b[94m',
+    [LogStyle.brightMagenta]: '\x1b[95m',
+    [LogStyle.brightCyan]: '\x1b[96m',
+    [LogStyle.brightWhite]: '\x1b[97m',
+  };
 
   /**
    * Enables logging.
@@ -22,26 +101,180 @@ class Logger
   static disableLogging = () => this.#blocked = true;
 
   /**
-   * Logs some text to the window via string interpolation.
-   * Will not log if logging is not enabled.
-   * @param {string|string[]|number|number[]} text The text to log.
+   * Returns the given text wrapped in the requested ANSI style.
+   * If the style is unknown or falsy, the text is returned unmodified.
+   * @param {string} text The text to colorize.
+   * @param {LogStyleKey} [style] A style key from the built-in styles map.
+   * @returns {string}
    */
-  static log(text)
+  static color(text, style)
   {
-    // don't log if we're not using it.
-    if (this.#blocked) return;
+    // special-case: rainbow effect delegates to the rainbow renderer.
+    if (style === LogStyle.rainbow)
+    {
+      return this.rainbow(`${text}`);
+    }
 
-    // log!
-    console.log(`🔉 ${text}`);
+    // short-circuit when style is not provided or unknown.
+    if (!style || !this.#styles[style])
+    {
+      return `${text}`;
+    }
+
+    // apply the style and reset at the end.
+    const code = this.#styles[style];
+    const reset = this.#styles[LogStyle.reset];
+    return `${code}${text}${reset}`;
   }
 
   /**
-   * Logs some text to the window via string interpolation, period.
-   * @param {string|string[]|number|number[]} text The text to log.
+   * Returns a rainbow-ified version of the provided text by coloring each character
+   * with a cycling palette.
+   * @param {string} text The text to colorize.
+   * @param {object} [options]
+   * @param {import('./logger.js').LogStyleKey[]} [options.palette] The palette to use.
+   * @param {number} [options.offset] Starting index within the palette.
+   * @param {boolean} [options.keepSpaces] If true, spaces/newlines do not advance the palette.
+   * @returns {string}
    */
-  static logAnyway(text)
+  static rainbow(text, options = {})
   {
-    console.log(`✨ ${text}`);
+    // Pull options with sensible defaults.
+    const palette = options.palette || [
+      LogStyle.brightRed,
+      LogStyle.brightYellow,
+      LogStyle.brightGreen,
+      LogStyle.brightCyan,
+      LogStyle.brightBlue,
+      LogStyle.brightMagenta,
+    ];
+    const keepSpaces = options.keepSpaces === true;
+
+    // Guard: empty / trivial cases.
+    if (!text || !palette.length)
+    {
+      return `${text}`;
+    }
+
+    // Local references for speed.
+    const styles = this.#styles;
+    const reset = styles[LogStyle.reset];
+
+    // Determine starting offset; randomize when not explicitly provided.
+    const hasExplicitOffset = typeof options.offset === 'number' && Number.isFinite(options.offset);
+    const startOffset = hasExplicitOffset
+      ? options.offset
+      : Math.floor(Math.random() * palette.length);
+
+    // Build colored output char-by-char.
+    let out = '';
+    let i = startOffset % palette.length;
+
+    for (let idx = 0; idx < text.length; idx++)
+    {
+      // Grab the current character.
+      const ch = text[idx];
+
+      // Identify whitespace for optional palette advancement rules.
+      const isWhitespace = ch === ' ' || ch === '\t' || ch === '\n' || ch === '\r';
+
+      // Resolve this step's style and code.
+      const styleKey = palette[i % palette.length];
+      const code = styles[styleKey] || '';
+
+      // Append the styled character and a reset.
+      out += `${code}${ch}${reset}`;
+
+      // Optionally do not advance palette on whitespace/newlines.
+      if (keepSpaces && isWhitespace)
+      {
+        continue;
+      }
+
+      // Advance the palette index.
+      i += 1;
+    }
+
+    // Return the fully-styled result.
+    return out;
+  }
+
+  /**
+   * Logs some text to the console.
+   * Will not log if logging is not enabled.
+   * @param {string|string[]|number|number[]} text The text to log.
+   * @param {LogStyleKey} [style] Optional style key to colorize the message.
+   */
+  static log(text, style)
+  {
+    // don't log if we're not using it.
+    if (this.#blocked)
+    {
+      return;
+    }
+
+    // log with optional style.
+    const payload = this.color(text, style);
+    console.log(`🔉 ${payload}`);
+  }
+
+  /**
+   * Logs some text to the console regardless of the enabled flag.
+   * @param {string|string[]|number|number[]} text The text to log.
+   * @param {LogStyleKey} [style] Optional style key to colorize the message.
+   */
+  static logAnyway(text, style)
+  {
+    const payload = this.color(text, style);
+    console.log(`✨ ${payload}`);
+  }
+
+  /**
+   * Convenience: info-level (cyan).
+   * @param {string} text
+   */
+  static info(text)
+  {
+    this.log(`INFO: ${text}`, LogStyle.cyan);
+  }
+
+  /**
+   * Convenience: success-level (green).
+   * @param {string} text
+   */
+  static success(text)
+  {
+    this.log(`SUCCESS: ${text}`, LogStyle.green);
+  }
+
+  /**
+   * Convenience: warning-level (yellow).
+   * @param {string} text
+   */
+  static warn(text)
+  {
+    this.log(`WARN: ${text}`, LogStyle.yellow);
+  }
+
+  /**
+   * Convenience: error-level (brightRed).
+   * @param {string|Error} text
+   */
+  static error(text)
+  {
+    const msg = text && text.stack
+      ? text.stack
+      : `${text}`;
+    this.logAnyway(`ERROR: ${msg}`, LogStyle.brightRed);
+  }
+
+  /**
+   * Convenience: dim a message (useful for verbose or timing notes).
+   * @param {string} text
+   */
+  static dim(text)
+  {
+    this.log(text, LogStyle.dim);
   }
 }
 

--- a/src/build-tools/mirror.js
+++ b/src/build-tools/mirror.js
@@ -1,6 +1,6 @@
 import fs from 'fs';
 import path from 'path';
-import Logger from './logger.js';
+import Logger, { LogStyle } from './logger.js';
 
 /**
  * A utility class that is a wrapper over {@link fs.cp}.
@@ -12,13 +12,13 @@ class Mirror
    * The source from which to mirror the structure of.
    * @type {string}
    */
-  #source = "./out";
+  #source = './out';
 
   /**
    * The destinations currently designated to this mirroring utility.
    * @type {[]}
    */
-  #destinations = [ "./project/js/plugins" ];
+  #destinations = [ './project/js/plugins' ];
 
   /**
    * Gets the destinations that have been assigned to this mirror.
@@ -35,7 +35,7 @@ class Mirror
    */
   setDestinations(destinations)
   {
-    this.#destinations = destinations
+    this.#destinations = destinations;
   }
 
   /**
@@ -98,8 +98,9 @@ class Mirror
       resolvedSource,
       resolvedDestination,
       { recursive: true },
-      this.#handleFileError);
-    Logger.logAnyway(`copied [${resolvedSource}] to [${resolvedDestination}]`);
+      this.#handleFileError
+    );
+    Logger.logAnyway(`copied [${resolvedSource}] to [${resolvedDestination}]`, LogStyle.magenta);
   }
 
   /**
@@ -113,13 +114,15 @@ class Mirror
     if (!fs.existsSync(`${targetPath}`))
     {
       // make sure the directory is created.
-      await fs.mkdir(targetPath,
+      await fs.mkdir(
+        targetPath,
         {
           force: true,
           recursive: true
         },
-        this.#handleFileError);
-      Logger.logAnyway(`target directory created: ${targetPath}`);
+        this.#handleFileError
+      );
+      Logger.logAnyway(`target directory created: ${targetPath}`, LogStyle.dim);
     }
     else
     {

--- a/src/build-tools/obliterator.js
+++ b/src/build-tools/obliterator.js
@@ -1,0 +1,63 @@
+/**
+ * OBLITERATOR
+ *
+ * OVERVIEW
+ * This nodejs script is intended to be used to quickly remove all files from a
+ * given directory.
+ *
+ * NOTE:
+ * Obviously you should be careful with where you point this thing, its loaded and dangerous!
+ *
+ * USAGE:
+ * Supply a space-seperated list of directories to obliterate.
+ *
+ * SAMPLE INPUT:
+ * $ node obliterator.js ./out ./dist
+ *
+ * SAMPLE OUTPUT:
+ *
+ * obliterated: /path/to/out
+ * obliterated: /path/to/dist
+ * Obliterator™ finished in 0.123s.
+ */
+
+import * as fs from 'fs/promises';
+import path from 'path';
+import Logger, { LogStyle } from './logger.js';
+
+// start timer for funsies.
+const start = performance.now();
+
+// Directories to obliterate; defaults to ./out if none given.
+const targets = process.argv.slice(2);
+const directories = targets.length
+  ? targets
+  : [ './out' ];
+
+for (const dir of directories)
+{
+  // Resolve to absolute path for clear logs.
+  const resolved = path.resolve(dir);
+
+  // Remove the directory and everything inside it, no questions asked.
+  await fs.rm(
+    resolved,
+    {
+      recursive: true,
+      force: true
+    }
+  );
+
+  // Recreate the (now-empty) directory.
+  await fs.mkdir(resolved, { recursive: true });
+
+  // Loud and proud.
+  Logger.logAnyway(`erased [${resolved}]`, LogStyle.magenta);
+}
+
+// victory lap!
+const durationSeconds = ((performance.now() - start) / 1000).toFixed(3);
+Logger.logAnyway(
+  `Obliterator™ has finished erasing [ ${directories.join(', ')} ] in ${durationSeconds}s.`,
+  LogStyle.rainbow
+);

--- a/src/plugins/_base/_metadata/_annotations.js
+++ b/src/plugins/_base/_metadata/_annotations.js
@@ -2,7 +2,7 @@
 /*:
  * @target MZ
  * @plugindesc
- * [v2.3.0 BASE] The base class for all J plugins.
+ * [v2.3.1 BASE] The base class for all J plugins.
  * @author JE
  * @url https://github.com/je-can-code/rmmz-plugins
  * @help
@@ -92,6 +92,10 @@
  *
  * ============================================================================
  * CHANGELOG:
+ * - 2.3.1
+ *    Added flag for showing external file load info across plugins.
+ *    Removed extraneous note tag enum-like object.
+ *    Updated various custom sprites with additional helpful methods.
  * - 2.3.0
  *    Added base Max TP management with tags for battlers.
  *    Added helper functions for detecting plugin commands inside of events.

--- a/src/plugins/_base/_metadata/initialization.js
+++ b/src/plugins/_base/_metadata/initialization.js
@@ -13,7 +13,7 @@ J.BASE = {};
  */
 J.BASE.Metadata = {};
 J.BASE.Metadata.Name = `J-Base`;
-J.BASE.Metadata.Version = '2.3.0';
+J.BASE.Metadata.Version = '2.3.1';
 
 /**
  * The actual `plugin parameters` extracted from RMMZ.
@@ -22,34 +22,8 @@ J.BASE.PluginParameters = PluginManager.parameters(J.BASE.Metadata.Name);
 J.BASE.Metadata.BaseTpMaxActors = Number(J.BASE.PluginParameters['actorBaseTp']);
 J.BASE.Metadata.BaseTpMaxEnemies = Number(J.BASE.PluginParameters['enemyBaseTp']);
 
-/**
- * A collection of helpful mappings for `notes` that are placed in
- * various locations, like events on the map, or in a database enemy.
- */
-J.BASE.Notetags = {
-  // on actors in database.
-  KnockbackResist: "knockbackResist",
-  NoSwitch: "noSwitch",
-
-  MaxRefineCount: "maxRefine",
-  MaxRefineTraits: "maxRefinedTraits",
-  NotRefinementBase: "notRefinementBase",
-  NotRefinementMaterial: "notRefinementMaterial",
-  NoRefinement: "noRefine",
-
-  // on events on map.
-  Sight: "s",
-  Pursuit: "p",
-  MoveSpeed: "ms",
-  NoIdle: "noIdle",
-  NoHpBar: "noHpBar",
-  NoDangerIndicator: "noDangerIndicator",
-  NoBattlerName: "noName",
-  Inanimate: "inanimate",
-  AlertDuration: "ad",
-  AlertSightBoost: "as",
-  AlertPursuitBoost: "ap",
-};
+// TODO: plugin parameterize this and make it "show/minimal/hide".
+J.BASE.Metadata.ShowExternalFileLoadInfo = false;
 
 /**
  * The various traits captured here by id with a more meaningful descriptor.
@@ -136,6 +110,10 @@ J.BASE.Traits = {
  * All regular expressions used by this plugin.
  */
 J.BASE.RegExp = {};
+
+/**
+ * The basic structure for the maximum count of a number of items holdable is.
+ */
 J.BASE.RegExp.MaxItems = /<max:(d+)>/gi;
 
 /**
@@ -149,7 +127,6 @@ J.BASE.RegExp.MaxItems = /<max:(d+)>/gi;
  *    <someKeyWithStringValue:someValue>
  *    <someKeyWithRangeValue:startRange-endRange>
  *  </pre>
- * @type {RegExp}
  */
 J.BASE.RegExp.ParsableComment = /^<[[\]\w :"',.!+\-*/\\]+>$/i;
 

--- a/src/plugins/_base/sprites/Sprite_BaseText.js
+++ b/src/plugins/_base/sprites/Sprite_BaseText.js
@@ -10,9 +10,9 @@ class Sprite_BaseText
    * The available supported text alignments.
    */
   static Alignments = {
-    Left: "left",
-    Center: "center",
-    Right: "right",
+    Left: 'left',
+    Center: 'center',
+    Right: 'right',
   };
 
   /**
@@ -58,7 +58,7 @@ class Sprite_BaseText
      * This should be a hexcode.
      * @type {string}
      */
-    this._j._color = "#ffffff";
+    this._j._color = '#ffffff';
 
     /**
      * The alignment of text in this sprite.
@@ -89,6 +89,19 @@ class Sprite_BaseText
      * @type {number}
      */
     this._j._fontSize = $gameSystem.mainFontSize();
+
+    /**
+     * The minimum width of the text.
+     * @type {number}
+     */
+    this._j._minWidth = 0;
+
+    /**
+     * Some systems that leverage {@link Sprite_BaseText} may have automation to manage the opacity of their text.
+     * Setting this flag to true will disable that automation and allow you to manage the opacity yourself.
+     * @type {boolean}
+     */
+    this._j._disableManagedOpacity = false;
   }
 
   /**
@@ -122,6 +135,9 @@ class Sprite_BaseText
     this.bitmap.fontBold = this.isBold();
     this.bitmap.fontItalic = this.isItalics();
     this.bitmap.textColor = this.color();
+
+    this.bitmap.outlineColor = "#000000"; // or a theme color
+    this.bitmap.outlineWidth = Math.max(2, Math.floor(this.fontSize() / 6));
   }
 
   /**
@@ -160,8 +176,10 @@ class Sprite_BaseText
     this._j._testBitmap.fontItalic = this.isItalics();
     this._j._testBitmap.fontBold = this.isBold();
 
-    // and return the measured text width.
-    return this._j._testBitmap.measureTextWidth(this.text());
+    // measure the text and respect a configured minimum width, if any.
+    const measured = this._j._testBitmap.measureTextWidth(this.text());
+    const min = this._j._minWidth;
+    return Math.max(measured, min);
   }
 
   /**
@@ -243,7 +261,7 @@ class Sprite_BaseText
   isValidColor(color)
   {
     // use regex to validate the hex color.
-    const structure = /^#([A-Fa-f0-9]{6}|[A-Fa-f0-9]{3})$/
+    const structure = /^#([A-Fa-f0-9]{6}|[A-Fa-f0-9]{3})$/;
     const isHexColor = structure.test(color);
 
     // check if we failed the validation.
@@ -295,7 +313,8 @@ class Sprite_BaseText
   isValidAlignment(alignment)
   {
     const validAlignments = [
-      Sprite_BaseText.Alignments.Left, Sprite_BaseText.Alignments.Center, Sprite_BaseText.Alignments.Right ]
+      Sprite_BaseText.Alignments.Left, Sprite_BaseText.Alignments.Center, Sprite_BaseText.Alignments.Right
+    ];
 
     return validAlignments.includes(alignment);
   }
@@ -407,16 +426,71 @@ class Sprite_BaseText
   }
 
   /**
+   * Gets the minimum width for the text box.
+   * @returns {number}
+   */
+  minWidth()
+  {
+    return this._j._minWidth;
+  }
+
+  /**
+   * Sets a minimum width for the text box. Useful to make center/right alignment visible.
+   * @param {number} width The minimum pixel width of this sprite’s bitmap.
+   * @returns {this}
+   */
+  setMinWidth(width)
+  {
+    // guard to make sure the width isn't being set to something negative.
+    const w = Math.max(0, width);
+
+    if (this._j._minWidth !== w)
+    {
+      this._j._minWidth = w;
+      this.refresh();
+    }
+
+    // return this for chaining if desired.
+    return this;
+  }
+
+  /**
+   * Flags this sprite to disable the managed opacity automation.
+   */
+  selfManageOpacity()
+  {
+    this._j._disableManagedOpacity = true;
+  }
+
+  /**
+   * Unflags this sprite to enable the managed opacity automation.
+   */
+  autoManageOpacity()
+  {
+    this._j._disableManagedOpacity = false;
+  }
+
+  /**
+   * Checks whether or not this sprite is flagged for self-managed opacity.
+   * @returns {boolean}
+   */
+  hasSelfManagedOpacity()
+  {
+    return this._j._disableManagedOpacity;
+  }
+
+  /**
    * Renders the text of this sprite.
    */
   renderText()
   {
-    const width = this.alignment() === Sprite_BaseText.Alignments.Center
-      ? this.width
+    // always draw using the bitmap’s own width so alignment behaves predictably.
+    const drawWidth = this.bitmap
+      ? this.bitmap.width
       : this.bitmapWidth();
 
     // draw the text with the current settings onto the bitmap.
-    this.bitmap.drawText(this.text(), 0, 0, width, this.bitmapHeight(), this.alignment());
+    this.bitmap.drawText(this.text(), 0, 0, drawWidth, this.bitmapHeight(), this.alignment());
   }
 }
 

--- a/src/plugins/_base/sprites/Sprite_Icon.js
+++ b/src/plugins/_base/sprites/Sprite_Icon.js
@@ -68,6 +68,13 @@ class Sprite_Icon
      * @type {number}
      */
     this._j._iconColumns = ImageManager.iconColumns;
+
+    /**
+     * Some systems that leverage {@link Sprite_Icon} may have automation to manage the opacity of their icons.
+     * Setting this flag to true will disable that automation and allow you to manage the opacity yourself.
+     * @type {boolean}
+     */
+    this._j._disableManagedOpacity = false;
   }
 
   /**
@@ -90,7 +97,7 @@ class Sprite_Icon
     // upon promise delivery, execute the rendering.
     Promise.all([ bitmapPromise ])
       // execute on-ready logic, such as setting the icon index of this sprite to render.
-      .then(() => this.onReady(iconIndex))
+      .then(() => this.onReady(iconIndex));
   }
 
   /**
@@ -119,6 +126,7 @@ class Sprite_Icon
     this.bitmap = bitmap;
   }
 
+  //region properties
   /**
    * Gets the icon index from the iconset for this sprite.
    * @returns {number}
@@ -197,6 +205,33 @@ class Sprite_Icon
   {
     this._j._iconColumns = columns;
   }
+
+  /**
+   * Flags this sprite to disable the managed opacity automation.
+   */
+  selfManageOpacity()
+  {
+    this._j._disableManagedOpacity = true;
+  }
+
+  /**
+   * Unflags this sprite to enable the managed opacity automation.
+   */
+  autoManageOpacity()
+  {
+    this._j._disableManagedOpacity = false;
+  }
+
+  /**
+   * Checks whether or not this sprite is flagged for self-managed opacity.
+   * @returns {boolean}
+   */
+  hasSelfManagedOpacity()
+  {
+    return this._j._disableManagedOpacity;
+  }
+
+  //endregion properties
 
   /**
    * Upon becoming ready, execute this logic.

--- a/src/plugins/_base/windows/Window_Base.js
+++ b/src/plugins/_base/windows/Window_Base.js
@@ -7,21 +7,21 @@ Window_Base.TextAlignments = {
    * The "left" text alignment.
    * This is the default and not normally required to be set.
    */
-  Left: "left",
+  Left: 'left',
 
   /**
    * The "center" text alignment.
    * This requires the full width of the area attempting to be centered within
    * be provided (such as the whole window's width).
    */
-  Center: "center",
+  Center: 'center',
 
   /**
    * The "right" text alignment.
    * It is encouraged to use {@link Window_Base.prototype.textWidth} to define the
    * width parameter in order to properly right-align.
    */
-  Right: "right"
+  Right: 'right'
 };
 
 /**

--- a/src/plugins/abs/core/__models/JABS_Action.js
+++ b/src/plugins/abs/core/__models/JABS_Action.js
@@ -136,6 +136,12 @@ class JABS_Action
      * @type {JABS_ActionOptions|null}
      */
     this._actionOptions = null;
+
+    /**
+     * The animation id to play once on the caster when the skill executes (after any casting).
+     * @type {number}
+     */
+    this._onCastAnimationId = this.getBaseSkill().jabsOnCastAnimationId ?? 0;
   }
 
   /**
@@ -342,6 +348,46 @@ class JABS_Action
   }
 
   /**
+   * Gets whether or not this action has an on-cast animation id.
+   * @returns {boolean}
+   */
+  hasOnCastAnimationId()
+  {
+    // non-zero indicates a configured animation.
+    return this.getOnCastAnimationId() !== 0;
+  }
+
+  /**
+   * Gets the on-cast animation id to display on the caster when executing this action.
+   * @returns {number}
+   */
+  getOnCastAnimationId()
+  {
+    // return the cached on-cast animation id.
+    return this._onCastAnimationId;
+  }
+
+  /**
+   * Performs the on-cast animation on the caster.
+   * @param {JABS_Battler=} caster Optional caster override; defaults to this action’s caster.
+   */
+  performOnCastAnimation(caster)
+  {
+    // determine the caster if not provided.
+    const who = caster || this.getCaster();
+
+    // validate a caster exists.
+    if (!who) return;
+
+    // only perform if a valid animation id is defined.
+    if (this.hasOnCastAnimationId())
+    {
+      // request the one-off animation on the caster’s map character.
+      who.getCharacter().requestAnimation(this.getOnCastAnimationId());
+    }
+  }
+
+  /**
    * Gets the `uuid` of this action.
    *
    * If one is not returned, then it is probably a direct action with no event representing it.
@@ -492,7 +538,7 @@ class JABS_Action
    */
   getMaxDuration()
   {
-    return Math.max(this.getBaseSkill().jabsDuration, JABS_Action.getMinimumDuration())
+    return Math.max(this.getBaseSkill().jabsDuration, JABS_Action.getMinimumDuration());
   }
 
   /**

--- a/src/plugins/abs/core/__models/JABS_Aggro.js
+++ b/src/plugins/abs/core/__models/JABS_Aggro.js
@@ -97,4 +97,29 @@ JABS_Aggro.prototype.modAggro = function(modAggro, forced = false)
   this.aggro += modAggro;
   if (this.aggro < 0) this.aggro = 0;
 };
+
+/**
+ * Determines whether or not this aggro is for a living actor.
+ * @returns {boolean}
+ */
+JABS_Aggro.prototype.isForLivingActor = function()
+{
+  // grab the battler for reference.
+  const battler = JABS_AiManager.getBattlerByUuid(this.battlerUuid);
+
+  // if there was no battler by this id, then its not for an actor.
+  if (!battler) return false;
+
+  // if the battler is not an actor, then its not for an actor.
+  if (battler.isActor() !== false) return false;
+
+  // if the actor is dead, then it doesn't count.
+  if (battler.isDead() === true) return false;
+
+  // if the aggro is reset/empty, then it doesn't count.
+  if (this.aggro <= 0) return false;
+
+  // the aggro's target is a living actor.
+  return true;
+};
 //endregion JABS_Aggro

--- a/src/plugins/abs/core/__models/JABS_Battler/_initialization.js
+++ b/src/plugins/abs/core/__models/JABS_Battler/_initialization.js
@@ -427,6 +427,18 @@ JABS_Battler.prototype.initBattleInfo = function()
    * @type {JABS_Aggro[]}
    */
   this._aggros = [];
+
+  /**
+   * Frames remaining that this battler is considered “in combat”.
+   * @type {number}
+   */
+  this._inCombatCountdown = 0;
+
+  /**
+   * Default window for the in‑combat countdown (60fps × seconds).
+   * @type {number}
+   */
+  this._inCombatWindowMax = 600; // 10s default.
 };
 
 /**

--- a/src/plugins/abs/core/__models/JABS_Battler/_reference.js
+++ b/src/plugins/abs/core/__models/JABS_Battler/_reference.js
@@ -1,4 +1,5 @@
 //region reference helpers
+//region else
 /**
  * Reassigns the character to something else.
  * @param {Game_Event|Game_Player|Game_Follower} newCharacter The new character to assign.
@@ -313,7 +314,7 @@ JABS_Battler.prototype.addFollower = function(newFollowerUuid)
   const found = this.getFollowerByUuid(newFollowerUuid);
   if (found)
   {
-    console.error("this follower already existed within the follower list.");
+    console.error('this follower already existed within the follower list.');
   }
   else
   {
@@ -334,7 +335,7 @@ JABS_Battler.prototype.removeFollower = function(oldFollowerUuid)
   }
   else
   {
-    console.error("could not find follower to remove from the list.", oldFollowerUuid);
+    console.error('could not find follower to remove from the list.', oldFollowerUuid);
   }
 };
 
@@ -392,7 +393,7 @@ JABS_Battler.prototype.removeFollowerByUuid = function(uuid)
  */
 JABS_Battler.prototype.clearLeaderData = function()
 {
-  this.setLeader("");
+  this.setLeader('');
   this.clearLeaderDecidedActionsQueue();
 };
 
@@ -465,7 +466,7 @@ JABS_Battler.prototype.isPlayer = function()
  */
 JABS_Battler.prototype.isActor = function()
 {
-  return (this.isPlayer() || this.getBattler() instanceof Game_Actor)
+  return (this.isPlayer() || this.getBattler() instanceof Game_Actor);
 };
 
 /**
@@ -1584,4 +1585,127 @@ JABS_Battler.prototype.isShowingAnimation = function()
   return this.getCharacter()
     .isAnimationPlaying();
 };
+
+//endregion rest
+
+//region in-combat
+/**
+ * Flags this battler as in‑combat for the full window.
+ */
+JABS_Battler.prototype.enterCombat = function()
+{
+  // set the in‑combat countdown to the window max.
+  this.setInCombatCountdown(this.getCombatWindowMax());
+};
+
+/**
+ * Gets the remaining frames for the in‑combat countdown.
+ * @returns {number}
+ */
+JABS_Battler.prototype.getInCombatCountdown = function()
+{
+  // return the number of frames remaining while in combat.
+  return this._inCombatCountdown || 0;
+};
+
+/**
+ * Gets the remaining in‑combat time in seconds with one decimal.
+ * @returns {number}
+ */
+JABS_Battler.prototype.getCombatSecondsRemaining = function()
+{
+  // convert remaining frames to seconds (60fps) with one decimal place.
+  const seconds = (this.getInCombatCountdown() / 60).toFixed(1);
+
+  // return the remaining seconds as a number.
+  return parseFloat(seconds);
+};
+
+/**
+ * Gets whether or not this battler is currently considered in‑combat.
+ * @returns {boolean}
+ */
+JABS_Battler.prototype.isInCombat = function()
+{
+  // honor the forced combat flag.
+  if ($jabsEngine.forcedCombat === true) return true;
+
+  // a positive countdown means still in combat.
+  if (this._inCombatCountdown > 0) return true;
+
+  // nothing combat-related is happening.
+  return false;
+};
+
+/**
+ * Gets the default in‑combat window duration.
+ * @returns {number}
+ */
+JABS_Battler.prototype.getCombatWindowMax = function()
+{
+  // return the configured max (fallback guards against legacy saves).
+  return this._inCombatWindowMax || 600;
+};
+
+/**
+ * Sets the default in‑combat window duration.
+ * @param {number} frames The number of frames to use for the window.
+ */
+JABS_Battler.prototype.setCombatWindowMax = function(frames)
+{
+  // clamp to zero minimum.
+  this._inCombatWindowMax = Math.max(0, frames);
+};
+
+/**
+ * Sets the current in‑combat countdown window.
+ * @param {number} frames The number of frames remaining.
+ */
+JABS_Battler.prototype.setInCombatCountdown = function(frames)
+{
+  // clamp to zero minimum.
+  this._inCombatCountdown = Math.max(0, frames);
+};
+
+/**
+ * Counts down the in‑combat timer.
+ */
+JABS_Battler.prototype.countdownCombat = function()
+{
+  // stop counting if finished.
+  if (this._inCombatCountdown <= 0)
+  {
+    this._inCombatCountdown = 0;
+    return;
+  }
+
+  // opportunistically compress the countdown when combat is truly clear.
+  // This reduces long tails after one‑shot wipes or non-retaliated kills.
+  // Tail length is 120 frames (2.0s) by default.
+  this._maybeShortenCombatTail(120);
+
+  // tick the countdown.
+  this._inCombatCountdown--;
+};
+
+/**
+ * Optionally clamps the in‑combat countdown to a short tail when there are
+ * no living enemies with aggro on the party.
+ * @param {number} tailFrames The maximum tail to leave when calm (in frames).
+ */
+JABS_Battler.prototype._maybeShortenCombatTail = function(tailFrames)
+{
+  // do not lengthen; only clamp if the window is larger than our tail.
+  if (this._inCombatCountdown <= tailFrames)
+  {
+    return;
+  }
+
+  // if nobody is aggroed to the party, compress the combat tail.
+  if (JABS_AiManager.anyLivingEnemiesAggroedToParty() === false)
+  {
+    this._inCombatCountdown = tailFrames;
+  }
+};
+//endregion in-combat
 //endregion reference helpers

--- a/src/plugins/abs/core/__models/JABS_Battler/_updates.js
+++ b/src/plugins/abs/core/__models/JABS_Battler/_updates.js
@@ -10,7 +10,7 @@ JABS_Battler.prototype.update = function()
   this.updateCooldowns();
   this.updateTimers();
   this.updateEngagement();
-  this.updateRG();
+  this.updateRegen();
   this.updateDodging();
   this.updateDeathHandling();
 };
@@ -41,7 +41,9 @@ JABS_Battler.prototype.processQueuedActions = function()
     const options = primaryAction.getActionOptions();
 
     // try to read a frozen target location from the options.
-    const loc = options ? options.getTargetLocation() : null;
+    const loc = options
+      ? options.getTargetLocation()
+      : null;
 
     // if a frozen location exists, extract coordinates from it.
     if (loc)
@@ -252,6 +254,7 @@ JABS_Battler.prototype.updateTimers = function()
   this.processAlertTimer();
   this.processParryTimer();
   this.processLastHitTimer();
+  this.processCombatTimer();
   this.processCastingTimer();
   this.processEngagementTimer();
 };
@@ -299,6 +302,18 @@ JABS_Battler.prototype.processLastHitTimer = function()
   if (this.hasBattlerLastHit())
   {
     this.countdownLastHit();
+  }
+};
+
+/**
+ * Updates the timer for "in combat".
+ */
+JABS_Battler.prototype.processCombatTimer = function()
+{
+  // if in combat, update the combat timer.
+  if (this.isInCombat())
+  {
+    this.countdownCombat();
   }
 };
 

--- a/src/plugins/abs/core/__models/JABS_Battler/regeneration.js
+++ b/src/plugins/abs/core/__models/JABS_Battler/regeneration.js
@@ -2,10 +2,10 @@
 /**
  * Updates all regenerations and ticks four times per second.
  */
-JABS_Battler.prototype.updateRG = function()
+JABS_Battler.prototype.updateRegen = function()
 {
   // check if we are able to update the RG.
-  if (!this.canUpdateRG()) return;
+  if (!this.canUpdateRegen()) return;
 
   //
   this.performRegeneration();
@@ -16,7 +16,7 @@ JABS_Battler.prototype.updateRG = function()
  * Determines whether or not the regeneration can be updated.
  * @returns {boolean}
  */
-JABS_Battler.prototype.canUpdateRG = function()
+JABS_Battler.prototype.canUpdateRegen = function()
 {
   // check if the regen is even ready for this battler.
   if (!this.isRegenReady()) return false;
@@ -112,8 +112,6 @@ JABS_Battler.prototype.processNaturalRegens = function()
   // process the natural hp/mp regens, possibly reduced.
   this.processNaturalHpRegen(isReduced);
   this.processNaturalMpRegen(isReduced);
-
-  // natural TP regen is never reduced.
   this.processNaturalTpRegen(isReduced);
 };
 
@@ -126,12 +124,11 @@ JABS_Battler.prototype.isNaturalRegenReduced = function()
   // enemies are not impacted by reduced natural regen.
   if (this.isEnemy()) return false;
 
-  // in-combat players will have a "last battler hit" tracked. Once that fades, they aren't in combat.
-  // TODO: may need to add a "i was last hit in the last 10 seconds" tracker.
-  if (this.isPlayer() && this.getBattlerLastHit() !== null) return true;
+  // if combat is globally forced (boss phases, etc), always reduced for non‑enemies.
+  if ($jabsEngine.forcedCombat === true) return true;
 
   // in-combat allies will be actors that are presently engaged.
-  if (this.isActor() && this.isEngaged()) return true;
+  if (this.isActor() && this.isInCombat()) return true;
 
   // no reason to reduce natural regen.
   return false;
@@ -502,7 +499,7 @@ JABS_Battler.prototype.slipEval = function(formula, sourceBattler, afflictedBatt
     if (!Number.isFinite(result))
     {
       // throw, and then catch to properly log in the next block.
-      throw new Error("Invalid formula.")
+      throw new Error('Invalid formula.');
     }
   }
   catch (err)

--- a/src/plugins/abs/core/_metadata/_annotations.js
+++ b/src/plugins/abs/core/_metadata/_annotations.js
@@ -46,6 +46,11 @@
  * JABS lives at the top instead of the bottom like the rest of my plugins.
  *
  * CHANGELOG:
+ * - 4.3.0
+ *    Unified sprint and dash as one alter-action.
+ *    Added a notion of "being in combat" based on hitting or being hit.
+ *    Force dash function to change to mobility skill while "in combat".
+ *    Added "on cast animation" that plays once a skill is done casting.
  * - 4.2.0
  *    Split projectile count from projectile formation.
  * - 4.1.1

--- a/src/plugins/abs/core/_metadata/initialization.js
+++ b/src/plugins/abs/core/_metadata/initialization.js
@@ -9,7 +9,7 @@ var J = J || {};
 (() =>
 {
   // Check to ensure we have the minimum required version of the J-Base plugin.
-  const requiredBaseVersion = '2.1.3';
+  const requiredBaseVersion = '2.3.1';
   const hasBaseRequirement = J.BASE.Helpers.satisfies(J.BASE.Metadata.Version, requiredBaseVersion);
   if (!hasBaseRequirement)
   {
@@ -27,7 +27,7 @@ J.ABS = {};
 /**
  * The parent namespace for all JABS extensions.
  */
-J.ABS.EXT = {}
+J.ABS.EXT = {};
 
 //region helpers
 /**
@@ -49,17 +49,17 @@ J.ABS.Helpers.PluginManager.TranslateOptionToSlot = slot =>
 {
   switch (slot)
   {
-    case "Tool":
+    case 'Tool':
       return JABS_Button.Tool;
-    case "Dodge":
+    case 'Dodge':
       return JABS_Button.Dodge;
-    case "L1A":
+    case 'L1A':
       return JABS_Button.CombatSkill1;
-    case "L1B":
+    case 'L1B':
       return JABS_Button.CombatSkill2;
-    case "L1X":
+    case 'L1X':
       return JABS_Button.CombatSkill3;
-    case "L1Y":
+    case 'L1Y':
       return JABS_Button.CombatSkill4;
   }
 };
@@ -97,7 +97,7 @@ J.ABS.Helpers.PluginManager.TranslateElementalIcons = obj =>
  */
 J.ABS.Metadata = {};
 J.ABS.Metadata.Name = 'J-ABS';
-J.ABS.Metadata.Version = '4.2.0';
+J.ABS.Metadata.Version = '4.3.0';
 
 /**
  * The actual `plugin parameters` extracted from RMMZ.
@@ -125,14 +125,14 @@ J.ABS.Metadata.DefaultEnemyPursuitRange = Number(J.ABS.PluginParameters['default
 J.ABS.Metadata.DefaultEnemyAlertedSightBoost = Number(J.ABS.PluginParameters['defaultEnemyAlertedSightBoost']);
 J.ABS.Metadata.DefaultEnemyAlertedPursuitBoost = Number(J.ABS.PluginParameters['defaultEnemyAlertedPursuitBoost']);
 J.ABS.Metadata.DefaultEnemyAlertDuration = Number(J.ABS.PluginParameters['defaultEnemyAlertDuration']);
-J.ABS.Metadata.DefaultEnemyCanIdle = Boolean(J.ABS.PluginParameters['defaultEnemyCanIdle'] === "true");
-J.ABS.Metadata.DefaultEnemyShowHpBar = Boolean(J.ABS.PluginParameters['defaultEnemyShowHpBar'] === "true");
-J.ABS.Metadata.DefaultEnemyShowBattlerName = Boolean(J.ABS.PluginParameters['defaultEnemyShowBattlerName'] === "true");
-J.ABS.Metadata.DefaultEnemyIsInvincible = Boolean(J.ABS.PluginParameters['defaultEnemyIsInvincible'] === "true");
-J.ABS.Metadata.DefaultEnemyIsInanimate = Boolean(J.ABS.PluginParameters['defaultEnemyIsInanimate'] === "true");
+J.ABS.Metadata.DefaultEnemyCanIdle = Boolean(J.ABS.PluginParameters['defaultEnemyCanIdle'] === 'true');
+J.ABS.Metadata.DefaultEnemyShowHpBar = Boolean(J.ABS.PluginParameters['defaultEnemyShowHpBar'] === 'true');
+J.ABS.Metadata.DefaultEnemyShowBattlerName = Boolean(J.ABS.PluginParameters['defaultEnemyShowBattlerName'] === 'true');
+J.ABS.Metadata.DefaultEnemyIsInvincible = Boolean(J.ABS.PluginParameters['defaultEnemyIsInvincible'] === 'true');
+J.ABS.Metadata.DefaultEnemyIsInanimate = Boolean(J.ABS.PluginParameters['defaultEnemyIsInanimate'] === 'true');
 
 // custom data configurations.
-J.ABS.Metadata.UseElementalIcons = J.ABS.PluginParameters['useElementalIcons'] === "true";
+J.ABS.Metadata.UseElementalIcons = J.ABS.PluginParameters['useElementalIcons'] === 'true';
 J.ABS.Metadata.ElementalIcons = J.ABS.Helpers.PluginManager.TranslateElementalIcons(J.ABS.PluginParameters['elementalIconData']);
 
 // action decided configurations.
@@ -164,10 +164,10 @@ J.ABS.Metadata.DefaultStateLoseAllStacksAtOnce = (J.ABS.PluginParameters['defaul
 
 // miscellaneous configurations.
 J.ABS.Metadata.LootPickupRange = Number(J.ABS.PluginParameters['lootPickupDistance']);
-J.ABS.Metadata.DisableTextPops = Boolean(J.ABS.PluginParameters['disableTextPops'] === "true");
+J.ABS.Metadata.DisableTextPops = Boolean(J.ABS.PluginParameters['disableTextPops'] === 'true');
 J.ABS.Metadata.AllyRubberbandAdjustment = Number(J.ABS.PluginParameters['allyRubberbandAdjustment']);
 J.ABS.Metadata.DashSpeedBoost = Number(J.ABS.PluginParameters['dashSpeedBoost']);
-J.ABS.Metadata.HitboxOverlaysInitiallyVisible = (J.ABS.PluginParameters['hitboxOverlaysInitiallyVisible'] === "true");
+J.ABS.Metadata.HitboxOverlaysInitiallyVisible = (J.ABS.PluginParameters['hitboxOverlaysInitiallyVisible'] === 'true');
 
 // quick menu commands configurations.
 J.ABS.Metadata.EquipCombatSkillsText = J.ABS.PluginParameters['equipCombatSkillsText'];
@@ -220,8 +220,12 @@ J.ABS.Metadata.HitboxStyles = {
   // Battler overrides by kind (player/follower/battler)
   byKind:
     {
-      player:  { fillColor: 0x4DA3FF, lineColor: 0x2368CC, fillAlpha: 0.25 },
-      follower:{ fillColor: 0x9B59B6 },
+      player: {
+        fillColor: 0x4DA3FF,
+        lineColor: 0x2368CC,
+        fillAlpha: 0.25
+      },
+      follower: { fillColor: 0x9B59B6 },
       battler: { fillColor: 0x2ECC71 },
     },
 
@@ -331,9 +335,9 @@ J.ABS.Globals = {};
  *
  * * TODO: implement the global cooldown blocking other cooldowns.
  * * TODO: alternatively, consider applying cooldowns against global to all slots on a battler.
- * @type {"global"}
+ * @type {'global'}
  */
-J.ABS.Globals.GlobalCooldownKey = "global";
+J.ABS.Globals.GlobalCooldownKey = 'global';
 
 /**
  * A collection of helpful mappings for emoji balloons
@@ -458,42 +462,42 @@ J.ABS.Shapes = {
   /**
    * A circle shaped hitbox.
    */
-  Circle: "circle",
+  Circle: 'circle',
 
   /**
    * A rhombus (aka diamond) shaped hitbox.
    */
-  Rhombus: "rhombus",
+  Rhombus: 'rhombus',
 
   /**
    * A square around the target hitbox.
    */
-  Square: "square",
+  Square: 'square',
 
   /**
    *  A square in front of the target hitbox.
    */
-  FrontSquare: "frontsquare",
+  FrontSquare: 'frontsquare',
 
   /**
    * A line from the target hitbox.
    */
-  Line: "line",
+  Line: 'line',
 
   /**
    * An arc shape hitbox in front of the action.
    */
-  Arc: "arc",
+  Arc: 'arc',
 
   /**
    * A wall in front of the target hitbox.
    */
-  Wall: "wall",
+  Wall: 'wall',
 
   /**
    * A cross from the target hitbox.
    */
-  Cross: "cross"
+  Cross: 'cross'
 };
 
 /**
@@ -501,19 +505,19 @@ J.ABS.Shapes = {
  */
 J.ABS.ProjectileFormations = {
   /** A single spoke in the forward direction. */
-  Line: "line",
+  Line: 'line',
 
   /** Three spokes: forward, forward-left, forward-right. */
-  Spray: "spray",
+  Spray: 'spray',
 
   /** Four cardinals: up, right, down, left. */
-  Cross: "cross",
+  Cross: 'cross',
 
   /** Four diagonals: up-right, down-right, down-left, up-left. */
-  Xburst: "xburst",
+  Xburst: 'xburst',
 
   /** All eight directions: cardinals + diagonals. */
-  Nova: "nova",
+  Nova: 'nova',
 };
 
 /**
@@ -522,9 +526,9 @@ J.ABS.ProjectileFormations = {
  */
 J.ABS.Notetags = {
   MoveType: {
-    Forward: "forward",
-    Backward: "backward",
-    Directional: "directional",
+    Forward: 'forward',
+    Backward: 'backward',
+    Directional: 'directional',
   }
 };
 
@@ -563,6 +567,7 @@ J.ABS.RegExp = {
 
   // animation-related.
   SelfAnimationId: /<selfAnimationId:[ ]?(\d+)>/gi,
+  OnCastAnimationId: /<onCastAnimationId:[ ]?(\d+)>/gi,
 
   // combo-related.
   ComboAction: /<combo:[ ]?(\[\d+,[ ]?\d+])>/gi,
@@ -724,10 +729,10 @@ J.ABS.RegExp.VisDebug = /<visDebug>/gi; // show visual center/debug gizmo
  * Cardinal: U/D/L/R
  * Optional diagonals: UR/UL/DR/DL
  */
-J.ABS.RegExp.VisOffsetU  = /<visOffsetU:[ ]?(\[-?\d+,[ ]?-?\d+])>/gi;  // [x, y]
-J.ABS.RegExp.VisOffsetD  = /<visOffsetD:[ ]?(\[-?\d+,[ ]?-?\d+])>/gi;  // [x, y]
-J.ABS.RegExp.VisOffsetL  = /<visOffsetL:[ ]?(\[-?\d+,[ ]?-?\d+])>/gi;  // [x, y]
-J.ABS.RegExp.VisOffsetR  = /<visOffsetR:[ ]?(\[-?\d+,[ ]?-?\d+])>/gi;  // [x, y]
+J.ABS.RegExp.VisOffsetU = /<visOffsetU:[ ]?(\[-?\d+,[ ]?-?\d+])>/gi;  // [x, y]
+J.ABS.RegExp.VisOffsetD = /<visOffsetD:[ ]?(\[-?\d+,[ ]?-?\d+])>/gi;  // [x, y]
+J.ABS.RegExp.VisOffsetL = /<visOffsetL:[ ]?(\[-?\d+,[ ]?-?\d+])>/gi;  // [x, y]
+J.ABS.RegExp.VisOffsetR = /<visOffsetR:[ ]?(\[-?\d+,[ ]?-?\d+])>/gi;  // [x, y]
 
 // Optional diagonals for future use.
 J.ABS.RegExp.VisOffsetUR = /<visOffsetUR:[ ]?(\[-?\d+,[ ]?-?\d+])>/gi; // [x, y]

--- a/src/plugins/abs/core/database/RPG_Skill.js
+++ b/src/plugins/abs/core/database/RPG_Skill.js
@@ -1116,6 +1116,40 @@ RPG_Skill.prototype.extractJabsSelfAnimationId = function()
 };
 //endregion range
 
+//region onCastAnimation
+/**
+ * The animation id to play on the caster once when the skill actually executes.
+ * @type {number}
+ */
+Object.defineProperty(RPG_Skill.prototype, 'jabsOnCastAnimationId', {
+  get: function()
+  {
+    // retrieve the parsed on-cast animation id from notes.
+    return this.getJabsOnCastAnimationId();
+  },
+});
+
+/**
+ * Gets the on-cast animation id for this skill.
+ * @returns {number}
+ */
+RPG_Skill.prototype.getJabsOnCastAnimationId = function()
+{
+  // parse and return the value from notes.
+  return this.extractJabsOnCastAnimationId();
+};
+
+/**
+ * Extracts the on-cast animation id for this skill from its notes.
+ * @returns {number}
+ */
+RPG_Skill.prototype.extractJabsOnCastAnimationId = function()
+{
+  // use the shared regex dictionary to pull the integer.
+  return this.getNumberFromNotesByRegex(J.ABS.RegExp.OnCastAnimationId, true);
+};
+//endregion onCastAnimation
+
 //region delay
 /**
  * The JABS delay data for this skill.

--- a/src/plugins/abs/core/managers/JABS_AiManager.js
+++ b/src/plugins/abs/core/managers/JABS_AiManager.js
@@ -36,7 +36,7 @@ class JABS_AiManager
    */
   constructor()
   {
-    throw new Error("This is a static class.");
+    throw new Error('This is a static class.');
   }
 
   //region get battlers
@@ -353,6 +353,38 @@ class JABS_AiManager
     return battlers.sort(comparing);
   }
 
+  /**
+   * Determines whether any living enemy currently has aggro on any party member.
+   * @returns {boolean}
+   */
+  static anyLivingEnemiesAggroedToParty()
+  {
+    // get all tracked enemy battlers from your registry.
+    const enemies = JABS_AiManager.getEnemyBattlers();
+
+    // if there are no enemies, then there is no aggro.
+    if (!enemies.length) return false;
+
+    // iterate for any enemy who is alive and has aggro on a party target.
+    const hasAggroOnParty = enemies.some(enemy =>
+    {
+      // grab all the aggros for this enemy for reference.
+      const aggros = enemy.getAllAggros();
+
+      // if there are no aggros, then this enemy has no aggro for the party.
+      if (aggros.length === 0) return false;
+
+      // return whether or not there are active aggros for a living actor.
+      return aggros.some(aggro => aggro.isForLivingActor());
+    });
+
+    // one or more of the enemies has active aggro on the party.
+    if (hasAggroOnParty) return true;
+
+    // nobody has aggro on the party.
+    return false;
+  }
+
   //endregion get battlers
 
   //region manage battlers
@@ -476,7 +508,7 @@ class JABS_AiManager
     this.postConvertMutate(battler, jabsBattler);
 
     // if there is something affecting max hp- such as natural growths- they should be fully healed on-creation.
-    battler.recoverAll()
+    battler.recoverAll();
 
     // return the newly created battler.
     return jabsBattler;
@@ -558,7 +590,7 @@ class JABS_AiManager
     if (J.ABS.EXT.DANGER)
     {
       // never show the danger indicator for allies.
-      builder.setShowDangerIndicator(false)
+      builder.setShowDangerIndicator(false);
     }
 
     // build the core data.
@@ -725,7 +757,8 @@ class JABS_AiManager
     // grab all available battlers within a fixed range.
     const battlers = this.getAllBattlersWithinRangeSortedByDistance(
       $jabsEngine.getPlayer1(),
-      J.ABS.Metadata.MaxAiUpdateRange);
+      J.ABS.Metadata.MaxAiUpdateRange
+    );
 
     // if we have no battlers, then do not process AI.
     if (!battlers.length) return;
@@ -1435,13 +1468,13 @@ class JABS_AiManager
     if (action.isSupportAction())
     {
       // show the "support decision" animation on the battler.
-      battler.showAnimation(J.ABS.Metadata.SupportDecidedAnimationId)
+      battler.showAnimation(J.ABS.Metadata.SupportDecidedAnimationId);
     }
     // the action is not a support action.
     else
     {
       // show the "attack decision" animation on the battler.
-      battler.showAnimation(J.ABS.Metadata.AttackDecidedAnimationId)
+      battler.showAnimation(J.ABS.Metadata.AttackDecidedAnimationId);
     }
   }
 

--- a/src/plugins/abs/core/managers/JABS_Engine.js
+++ b/src/plugins/abs/core/managers/JABS_Engine.js
@@ -100,6 +100,12 @@ class JABS_Engine
    */
   hitboxOverlaysVisible = false;
 
+  /**
+   * When `true`, all non‑enemies are considered in combat (UI and mechanics that consult the engine).
+   * Useful for boss phases or scripted moments.
+   * @type {boolean}
+   */
+  forcedCombat = false;
   //endregion properties
 
   /**
@@ -1315,6 +1321,9 @@ class JABS_Engine
     // handle the cast animation for this action.
     this.handleActionCastAnimation(caster, action);
 
+    // handle the one-off on-cast animation on the caster at execution time.
+    this.handleActionOnCastAnimation(caster, action);
+
     // handle the generation of the action on the map.
     this.handleActionGeneration(caster, action, targetX, targetY);
   }
@@ -1348,6 +1357,21 @@ class JABS_Engine
       // execute the cast animation.
       caster.getCharacter()
         .requestAnimation(casterAnimation);
+    }
+  }
+
+  /**
+   * Handles the single-fire, on-cast animation on the caster at execution time.
+   * @param {JABS_Battler} caster The `JABS_Battler` executing the JABS action.
+   * @param {JABS_Action} action The JABS action to execute.
+   */
+  handleActionOnCastAnimation(caster, action)
+  {
+    // only perform if an on-cast animation id is configured.
+    if (action.hasOnCastAnimationId())
+    {
+      // play it once on the caster’s character.
+      action.performOnCastAnimation(caster);
     }
   }
 
@@ -2394,9 +2418,19 @@ class JABS_Engine
     this.triggerAlert(caster, target);
 
     // if the attacker and the target are the same team, then don't set that as "last hit".
-    if (!(caster.isSameTeam(target.getTeam())))
+    if ((caster.isSameTeam(target.getTeam())) === false)
     {
       caster.setBattlerLastHit(target);
+
+      // refresh in‑combat timers on real engagements only.
+      const isHealing = action.isHealing();
+      const hitOrParry = (result.isHit() || result.parried);
+      if (hitOrParry && isHealing === false && target.isInanimate() === false)
+      {
+        // both sides are considered engaged.
+        caster.enterCombat();
+        target.enterCombat();
+      }
     }
   }
 

--- a/src/plugins/abs/core/objects/Game_Party.js
+++ b/src/plugins/abs/core/objects/Game_Party.js
@@ -78,4 +78,29 @@ Game_Party.prototype.leaderJabsBattler = function()
   // return the leader's battler.
   return JABS_AiManager.getBattlerByUuid(leaderUuid);
 };
+
+/**
+ * Gets whether any current party battle member is in combat.
+ * @returns {boolean}
+ */
+Game_Party.prototype.anyMemberInCombat = function()
+{
+  // if globally forced, then the party is in combat.
+  if ($jabsEngine.forcedCombat === true) return true;
+
+  // check each battle member for a tracked JABS battler that is in combat.
+  const members = this.battleMembers();
+  for (let i = 0; i < members.length; i++)
+  {
+    const actor = members[i];
+    const jabsBattler = JABS_AiManager.getBattlerByUuid(actor.getUuid());
+    if (jabsBattler && jabsBattler.isInCombat())
+    {
+      return true;
+    }
+  }
+
+  // nobody is in combat.
+  return false;
+};
 //endregion Game_Party

--- a/src/plugins/abs/core/objects/Game_Player.js
+++ b/src/plugins/abs/core/objects/Game_Player.js
@@ -60,6 +60,25 @@ Game_Player.prototype.canMove = function()
 };
 
 /**
+ * Extends/Overrides {@link #isDashing}.<br/>
+ * Disables engine dash while the player is in JABS combat.
+ */
+J.ABS.Aliased.Game_Player.set("isDashing", Game_Player.prototype.isDashing);
+Game_Player.prototype.isDashing = function()
+{
+  // if JABS says the party is in combat, engine-style dashing is disabled.
+  const inCombat = $gameParty.anyMemberInCombat();
+  if (inCombat)
+  {
+    // force no dash during combat so sprint cannot re-assert itself.
+    return false;
+  }
+
+  // otherwise, perform original engine logic.
+  return J.ABS.Aliased.Game_Player.get("isDashing").call(this);
+};
+
+/**
  * Initializes the player's `JABS_Battler` if it was not already initialized.
  */
 J.ABS.Aliased.Game_Player.set('refresh', Game_Player.prototype.refresh);
@@ -90,6 +109,7 @@ Game_Player.prototype.updateMove = function()
   this.checkForLoot();
 };
 
+//region loot
 /**
  * Checks to see if the player coordinates are intercepting with any loot
  * currently on the ground.
@@ -254,4 +274,5 @@ Game_Player.prototype.removeLoot = function(lootEvent)
   lootEvent.setLootNeedsRemoving(true);
   $jabsEngine.requestClearLoot = true;
 };
+//endregion loot
 //endregion Game_Player

--- a/src/plugins/abs/ext/input/_metadata/_annotations.js
+++ b/src/plugins/abs/ext/input/_metadata/_annotations.js
@@ -2,7 +2,7 @@
 /*:
  * @target MZ
  * @plugindesc
- * [v2.1.1 INPUT] A manager for overseeing the input of JABS.
+ * [v2.2.0 INPUT] A manager for overseeing the input of JABS.
  * @author JE
  * @url https://github.com/je-can-code/rmmz-plugins
  * @base J-ABS
@@ -38,6 +38,10 @@
  * ============================================================================
  * CHANGELOG
  * ----------------------------------------------------------------------------
+ * - 2.2.0
+ *    Removed independent remappability of sprint and mobility.
+ *    Added support for tracking "in combat" to handle dash/mobility switching.
+ *    Updated sprint input to switch to mobility skill while "in combat".
  * - 2.1.1
  *    Fixed typo in custom input mapping.
  * - 2.1.0

--- a/src/plugins/abs/ext/input/_metadata/initialization.js
+++ b/src/plugins/abs/ext/input/_metadata/initialization.js
@@ -7,7 +7,7 @@ var J = J || {};
 (() =>
 {
   // Check to ensure we have the minimum required version of the J-Base plugin.
-  const requiredBaseVersion = '2.1.0';
+  const requiredBaseVersion = '2.3.1';
   const hasBaseRequirement = J.BASE.Helpers.satisfies(J.BASE.Metadata.Version, requiredBaseVersion);
   if (!hasBaseRequirement)
   {
@@ -27,7 +27,7 @@ J.ABS.EXT.INPUT = {};
  */
 J.ABS.EXT.INPUT = {};
 J.ABS.EXT.INPUT.Metadata = {};
-J.ABS.EXT.INPUT.Metadata.Version = '2.1.1';
+J.ABS.EXT.INPUT.Metadata.Version = '2.2.0';
 J.ABS.EXT.INPUT.Metadata.Name = `J-ABS-InputManager`;
 
 /**

--- a/src/plugins/abs/ext/input/_models/JABS_Button.js
+++ b/src/plugins/abs/ext/input/_models/JABS_Button.js
@@ -127,7 +127,7 @@ class JABS_Button
     // the valid set of assignable inputs.
     const okInputs = [
       // primary
-      this.Mainhand, this.Offhand, this.Tool, this.Dodge,
+      this.Mainhand, this.Offhand, this.Tool,
 
       // modifiers & mobility
       this.SkillTrigger, this.Sprint, this.Strafe, this.Rotate,

--- a/src/plugins/abs/ext/input/_models/JABS_StandardController.js
+++ b/src/plugins/abs/ext/input/_models/JABS_StandardController.js
@@ -45,6 +45,14 @@ class JABS_StandardController
      * @type {Map<string, string[]>}
      */
     this.inputMapping = new Map();
+
+    /**
+     * Tracks whether the last-processed frame was considered in combat.
+     * Used for treating a hold across the boundary (exploration → combat)
+     * as a single edge-press for Mobility.
+     * @type {boolean}
+     */
+    this._lastInCombat = false;
   }
 
   /**
@@ -61,7 +69,8 @@ class JABS_StandardController
     this.inputMapping.set(JABS_Button.Mainhand, [ J.ABS.EXT.INPUT.Symbols.Mainhand ]);
     this.inputMapping.set(JABS_Button.Offhand, [ J.ABS.EXT.INPUT.Symbols.Offhand ]);
     this.inputMapping.set(JABS_Button.Tool, [ J.ABS.EXT.INPUT.Symbols.Tool ]);
-    this.inputMapping.set(JABS_Button.Dodge, [ J.ABS.EXT.INPUT.Symbols.MobilitySkill ]);
+
+    // NOTE: Dodge is intentionally not seeded; Sprint handles mobility contextually.
 
     // seed mobility & modifiers.
     this.inputMapping.set(JABS_Button.Sprint, [ J.ABS.EXT.INPUT.Symbols.Dash ]);
@@ -70,7 +79,7 @@ class JABS_StandardController
     this.inputMapping.set(JABS_Button.Guard, [ J.ABS.EXT.INPUT.Symbols.GuardTrigger ]);
     this.inputMapping.set(JABS_Button.SkillTrigger, [ J.ABS.EXT.INPUT.Symbols.SkillTrigger ]);
 
-    // seed L1 + buttons (combat skills).
+    // seed L1+ face shortcuts (keyboard direct shortcuts available separately).
     this.inputMapping.set(JABS_Button.CombatSkill1, [ J.ABS.EXT.INPUT.Symbols.CombatSkill1 ]);
     this.inputMapping.set(JABS_Button.CombatSkill2, [ J.ABS.EXT.INPUT.Symbols.CombatSkill2 ]);
     this.inputMapping.set(JABS_Button.CombatSkill3, [ J.ABS.EXT.INPUT.Symbols.CombatSkill3 ]);
@@ -298,7 +307,7 @@ class JABS_StandardController
     this.updateMainhandAction();
     this.updateOffhandAction();
     this.updateToolAction();
-    this.updateDodgeAction();
+    this.updateSprintCommand();
 
     // update input for multi-button actions.
     this.updateCombatAction1();
@@ -307,7 +316,6 @@ class JABS_StandardController
     this.updateCombatAction4();
 
     // update input for the pressed(held down)-button actions.
-    this.updateSprintCommand();
     this.updateGuardCommand();
     this.updateStrafeCommand();
     this.updateRotateCommand();
@@ -527,27 +535,61 @@ class JABS_StandardController
 
   /**
    * Checks the inputs of the sprint action currently assigned (Shift default).
+   * Context-aware:
+   * - Out of combat: treat Sprint as a held input (classic run).
+   * - In combat: treat Sprint strictly as an edge-trigger (for Mobility/Dodge).
    * @returns {boolean}
    */
   isSprintActionTriggered()
   {
-    // this action requires Sprint to be pressed.
-    if (this.isActionPressed(JABS_Button.Sprint))
+    // grab the battler for reference.
+    const battler = this.getBattler();
+
+    // determine if the battler is in combat.
+    const inCombat = battler.isInCombat();
+
+    // if in combat, only a new press (edge) should trigger mobility.
+    if (inCombat)
     {
-      return true;
+      // update last-known combat state for subsequent frames.
+      this._lastInCombat = true;
+
+      // return whether Sprint was newly triggered this frame.
+      return this.isActionTriggered(JABS_Button.Sprint);
     }
 
-    // Sprint is not being pressed.
-    return false;
+    // not in combat → classic sprint is a held input.
+    // update last-known combat state before returning.
+    this._lastInCombat = false;
+
+    // return whether Sprint is currently held.
+    return this.isActionPressed(JABS_Button.Sprint);
   }
 
   /**
-   * Enables sprinting for this controller's battler.
+   * Enables sprinting for this controller's battler when out of combat.
+   * In combat, Sprint becomes the Mobility/Dodge action instead.
    */
   performSprintAction()
   {
-    // perform sprint enable for this controller's battler.
-    JABS_InputAdapter.performSprint(true, this.battler);
+    // grab the battler for reference.
+    const battler = this.getBattler();
+
+    // check if the battler is in combat.
+    if (battler.isInCombat())
+    {
+      // proactively disable exploration sprint when entering combat.
+      JABS_InputAdapter.performSprint(false, battler);
+
+      // perform the dodge action for this controller's battler.
+      JABS_InputAdapter.performDodgeAction(battler);
+
+      // end early; no sprint toggling while in combat.
+      return;
+    }
+
+    // not in combat → enable classic sprint while the input is held.
+    JABS_InputAdapter.performSprint(true, battler);
   }
 
   /**
@@ -555,9 +597,19 @@ class JABS_StandardController
    */
   performSprintAlterAction()
   {
-    // perform sprint disable for this controller's battler.
-    JABS_InputAdapter.performSprint(false, this.battler);
+    // grab the battler for reference.
+    const battler = this.getBattler();
+
+    // check if the battler is in combat.
+    if (battler.isInCombat())
+    {
+      return;
+    }
+
+    // not in combat → disable sprint when the input is released.
+    JABS_InputAdapter.performSprint(false, battler);
   }
+
   //endregion sprint
 
   //region tool
@@ -607,48 +659,6 @@ class JABS_StandardController
   }
 
   //endregion tool
-
-  //region dodge
-  /**
-   * Monitors and takes action based on player input regarding the dodge action.
-   * This is `R2` on the gamepad by default.
-   */
-  updateDodgeAction()
-  {
-    // check if the action's input requirements have been met.
-    if (this.isDodgeActionTriggered())
-    {
-      // execute the action.
-      this.performDodgeAction();
-    }
-  }
-
-  /**
-   * Checks the inputs of the dodge action currently assigned (R2 default).
-   * @returns {boolean}
-   */
-  isDodgeActionTriggered()
-  {
-    // this action requires the logical Dodge to be triggered.
-    if (this.isActionTriggered(JABS_Button.Dodge))
-    {
-      return true;
-    }
-
-    // Dodge is not being triggered.
-    return false;
-  }
-
-  /**
-   * Executes the currently assigned dodge action (R2 default).
-   */
-  performDodgeAction()
-  {
-    // perform the dodge action for this controller's battler.
-    JABS_InputAdapter.performDodgeAction(this.getBattler());
-  }
-
-  //endregion dodge
 
   //region combat actions
   /**
@@ -791,7 +801,7 @@ class JABS_StandardController
     if (this.isCombatSkillUsageEnabled())
     {
       // ...and Dodge is triggered this frame, then combat action 3 should fire.
-      if (this.isActionTriggered(JABS_Button.Dodge))
+      if (this.isActionTriggered(JABS_Button.Sprint))
       {
         return true;
       }

--- a/src/plugins/abs/ext/input/managers/Input.js
+++ b/src/plugins/abs/ext/input/managers/Input.js
@@ -352,31 +352,42 @@ Input.getRemapCaptureSymbols = function()
  */
 Input.ensureRemapBootstrapped = function()
 {
+  // if already bootstrapped for this session, do nothing.
   if (Input._jRegistries.bootstrapped === true)
   {
-    return; // already bootstrapped for this session
+    return;
   }
 
   // Seed JABS defaults (logical actions -> physical symbols).
   const d = {};
+
+  // functionality
   d[JABS_Button.Menu] = [ J.ABS.EXT.INPUT.Symbols.Quickmenu ];
   d[JABS_Button.Select] = [ J.ABS.EXT.INPUT.Symbols.PartyCycle ];
+
+  // primary actions
   d[JABS_Button.Mainhand] = [ J.ABS.EXT.INPUT.Symbols.Mainhand ];
   d[JABS_Button.Offhand] = [ J.ABS.EXT.INPUT.Symbols.Offhand ];
   d[JABS_Button.Tool] = [ J.ABS.EXT.INPUT.Symbols.Tool ];
-  d[JABS_Button.Dodge] = [ J.ABS.EXT.INPUT.Symbols.MobilitySkill ];
+
+  // mobility & modifiers
+  // IMPORTANT: No default binding for Dodge; Sprint handles mobility contextually.
+  // d[JABS_Button.Dodge] is intentionally omitted.
   d[JABS_Button.Sprint] = [ J.ABS.EXT.INPUT.Symbols.Dash ];
   d[JABS_Button.Strafe] = [ J.ABS.EXT.INPUT.Symbols.StrafeTrigger ];
   d[JABS_Button.Rotate] = [ J.ABS.EXT.INPUT.Symbols.GuardTrigger ];
   d[JABS_Button.Guard] = [ J.ABS.EXT.INPUT.Symbols.GuardTrigger ];
   d[JABS_Button.SkillTrigger] = [ J.ABS.EXT.INPUT.Symbols.SkillTrigger ];
+
+  // L1 + buttons (keyboard shortcuts available separately)
   d[JABS_Button.CombatSkill1] = [ J.ABS.EXT.INPUT.Symbols.CombatSkill1 ];
   d[JABS_Button.CombatSkill2] = [ J.ABS.EXT.INPUT.Symbols.CombatSkill2 ];
   d[JABS_Button.CombatSkill3] = [ J.ABS.EXT.INPUT.Symbols.CombatSkill3 ];
   d[JABS_Button.CombatSkill4] = [ J.ABS.EXT.INPUT.Symbols.CombatSkill4 ];
 
+  // register the defaults and ensure live bindings are initialized.
   Input.seedDefaultBindings('JABS', d);
-  Input.getAllBindings('JABS'); // lazy-init live bindings
+  Input.getAllBindings('JABS');
 
   // friendly labels for some common symbols.
   Input.registerSymbolLabel(J.ABS.EXT.INPUT.Symbols.L3, 'L3');
@@ -387,7 +398,7 @@ Input.ensureRemapBootstrapped = function()
   Input.registerSymbolLabel(J.ABS.EXT.INPUT.Symbols.DPadLeft, 'D-Pad Left');
   Input.registerSymbolLabel(J.ABS.EXT.INPUT.Symbols.DPadRight, 'D-Pad Right');
 
-  // Allow these symbols to be captured in the prompt if desired.
+  // allow these symbols to be captured in the prompt if desired.
   Input.registerRemapCaptureSymbol(J.ABS.EXT.INPUT.Symbols.L3);
   Input.registerRemapCaptureSymbol(J.ABS.EXT.INPUT.Symbols.R3);
   Input.registerRemapCaptureSymbol(J.ABS.EXT.INPUT.Symbols.DPadUp);
@@ -395,11 +406,41 @@ Input.ensureRemapBootstrapped = function()
   Input.registerRemapCaptureSymbol(J.ABS.EXT.INPUT.Symbols.DPadLeft);
   Input.registerRemapCaptureSymbol(J.ABS.EXT.INPUT.Symbols.DPadRight);
 
-  // NEW: expose all non-engine keyboard keys for capture/binding.
+  // expose all non-engine keyboard keys for capture/binding.
   Input.bootstrapAllKeyboardKeysForCapture();
 
-  // Mark as bootstrapped for this runtime session.
+  // SAFETY: strip deprecated Dodge bindings from existing saves/config.
+  Input.removeDeprecatedDodgeBindings();
+
+  // mark as bootstrapped for this runtime session.
   Input._jRegistries.bootstrapped = true;
+};
+
+/**
+ * Removes any live/default bindings for the deprecated standalone Dodge action.
+ * This is a migration helper and may be removed in a future version.
+ */
+Input.removeDeprecatedDodgeBindings = function()
+{
+
+  // TODO: remove this function in some later patch after 2.0.2.
+
+
+  // read live bindings for JABS and clear Dodge if present.
+  const live = Input.getAllBindings('JABS');
+  if (live && Object.hasOwn(live, JABS_Button.Dodge))
+  {
+    // clear the list of physical symbols bound to Dodge.
+    live[JABS_Button.Dodge] = [];
+  }
+
+  // also clear from defaults if present (legacy boot sequences).
+  const defs = Input._jRegistries.defaults['JABS'];
+  if (defs && Object.hasOwn(defs, JABS_Button.Dodge))
+  {
+    // clear any default mapping that may have been serialized previously.
+    defs[JABS_Button.Dodge] = [];
+  }
 };
 
 /**
@@ -411,9 +452,7 @@ Input.bootstrapAllKeyboardKeysForCapture = function()
   // collect a snapshot of engine/core-reserved symbols to avoid overriding them.
   const reserved = new Set([
     // core engine actions and directions.
-    'ok', 'cancel', 'menu', 'escape',
-    'tab', 'pageup', 'pagedown', 'shift', 'control',
-    'up', 'down', 'left', 'right',
+    'ok', 'cancel', 'menu', 'escape', 'tab', 'pageup', 'pagedown', 'shift', 'control', 'up', 'down', 'left', 'right',
   ]);
 
   // also consider whatever the current keyMapper already resolves to.

--- a/src/plugins/abs/ext/input/scenes/Scene_JabsRemap.js
+++ b/src/plugins/abs/ext/input/scenes/Scene_JabsRemap.js
@@ -193,7 +193,7 @@ class Scene_JabsRemap
   topHelpWindowRectangle()
   {
     // determine the height for the top help window (single row).
-    const wh = this.calcWindowHeight(1.8, true);
+    const wh = this.calcWindowHeight(1.6, true);
 
     // compute the total width for the centered middle group.
     const ww = Math.floor(Graphics.boxWidth * 0.60);

--- a/src/plugins/diff/_metadata/_annotations.js
+++ b/src/plugins/diff/_metadata/_annotations.js
@@ -3,7 +3,7 @@
 /*:
  * @target MZ
  * @plugindesc
- * [v2.0.0 DIFFICULTY] A layered difficulty system.
+ * [v2.0.1 DIFFICULTY] A layered difficulty system.
  * @author JE
  * @url https://github.com/je-can-code/rmmz-plugins
  * @base J-Base
@@ -18,15 +18,19 @@
  * actors and enemies alike.
  * ----------------------------------------------------------------------------
  * NOTE:
- * There are no tags for this plugin, but all difficulty layers are defined in
- * the plugin parameters.
+ * There are no tags for this plugin.
+ * All difficulties are defined in an external JSON file.
  * ============================================================================
  * CHANGELOG:
+ * - 2.0.1
+ *    Added flag for showing external file load info.
+ *    Removed dead plugin parameter inputs.
  * - 2.0.0
  *    Updated window layout of scene.
  *    Added multiple layer application support.
  *    Updated difficulty layers to also be applicable to actors if desired.
  *    Refactored a lot of underlying code.
+ *    Externalized difficulty layer data.
  * - 1.0.0
  *    Initial release.
  * ============================================================================
@@ -47,14 +51,6 @@
  * @text Default Difficulty
  * @desc The key of the starting or default difficulty before it is decided.
  * @default 000_default
- *
- * @param difficulties
- * @parent difficultyConfigs
- * @type struct<DifficultyStruct>[]
- * @text Difficulties
- * @desc All difficulties, locked or otherwise.
- * @default ["{\"key\":\"020_Normal\",\"name\":\"Normal\",\"iconIndex\":\"883\",\"enabled\":\"false\",\"unlocked\":\"true\",\"hidden\":\"false\",\"description\":\"Your expected gameplay difficulty. Nothing is modified.\",\"bparams\":\"[]\",\"xparams\":\"[]\",\"sparams\":\"[]\",\"bonuses\":\"[]\"}","{\"key\":\"010_Easy\",\"name\":\"Easy\",\"iconIndex\":\"881\",\"enabled\":\"false\",\"unlocked\":\"true\",\"hidden\":\"false\",\"description\":\"A mild experience for players that want to try less and fun more.\",\"bparams\":\"[\\\"{\\\\\\\"parameterId\\\\\\\":\\\\\\\"0\\\\\\\",\\\\\\\"parameterRate\\\\\\\":\\\\\\\"80\\\\\\\"}\\\",\\\"{\\\\\\\"parameterId\\\\\\\":\\\\\\\"1\\\\\\\",\\\\\\\"parameterRate\\\\\\\":\\\\\\\"80\\\\\\\"}\\\",\\\"{\\\\\\\"parameterId\\\\\\\":\\\\\\\"2\\\\\\\",\\\\\\\"parameterRate\\\\\\\":\\\\\\\"80\\\\\\\"}\\\",\\\"{\\\\\\\"parameterId\\\\\\\":\\\\\\\"4\\\\\\\",\\\\\\\"parameterRate\\\\\\\":\\\\\\\"80\\\\\\\"}\\\",\\\"{\\\\\\\"parameterId\\\\\\\":\\\\\\\"7\\\\\\\",\\\\\\\"parameterRate\\\\\\\":\\\\\\\"110\\\\\\\"}\\\"]\",\"xparams\":\"[\\\"{\\\\\\\"parameterId\\\\\\\":\\\\\\\"1\\\\\\\",\\\\\\\"parameterRate\\\\\\\":\\\\\\\"50\\\\\\\"}\\\",\\\"{\\\\\\\"parameterId\\\\\\\":\\\\\\\"3\\\\\\\",\\\\\\\"parameterRate\\\\\\\":\\\\\\\"0\\\\\\\"}\\\",\\\"{\\\\\\\"parameterId\\\\\\\":\\\\\\\"4\\\\\\\",\\\\\\\"parameterRate\\\\\\\":\\\\\\\"0\\\\\\\"}\\\"]\",\"sparams\":\"[\\\"{\\\\\\\"parameterId\\\\\\\":\\\\\\\"6\\\\\\\",\\\\\\\"parameterRate\\\\\\\":\\\\\\\"120\\\\\\\"}\\\",\\\"{\\\\\\\"parameterId\\\\\\\":\\\\\\\"7\\\\\\\",\\\\\\\"parameterRate\\\\\\\":\\\\\\\"120\\\\\\\"}\\\"]\",\"bonuses\":\"[\\\"{\\\\\\\"bonusId\\\\\\\":\\\\\\\"0\\\\\\\",\\\\\\\"bonusRate\\\\\\\":\\\\\\\"120\\\\\\\"}\\\",\\\"{\\\\\\\"bonusId\\\\\\\":\\\\\\\"1\\\\\\\",\\\\\\\"bonusRate\\\\\\\":\\\\\\\"120\\\\\\\"}\\\",\\\"{\\\\\\\"bonusId\\\\\\\":\\\\\\\"2\\\\\\\",\\\\\\\"bonusRate\\\\\\\":\\\\\\\"120\\\\\\\"}\\\",\\\"{\\\\\\\"bonusId\\\\\\\":\\\\\\\"3\\\\\\\",\\\\\\\"bonusRate\\\\\\\":\\\\\\\"120\\\\\\\"}\\\"]\"}","{\"key\":\"030_Hard\",\"name\":\"Hard\",\"iconIndex\":\"885\",\"enabled\":\"false\",\"unlocked\":\"true\",\"hidden\":\"false\",\"description\":\"A more challenging experience where you might have to try more than button mashing to win.\",\"bparams\":\"[\\\"{\\\\\\\"parameterId\\\\\\\":\\\\\\\"0\\\\\\\",\\\\\\\"parameterRate\\\\\\\":\\\\\\\"120\\\\\\\"}\\\",\\\"{\\\\\\\"parameterId\\\\\\\":\\\\\\\"1\\\\\\\",\\\\\\\"parameterRate\\\\\\\":\\\\\\\"120\\\\\\\"}\\\",\\\"{\\\\\\\"parameterId\\\\\\\":\\\\\\\"2\\\\\\\",\\\\\\\"parameterRate\\\\\\\":\\\\\\\"120\\\\\\\"}\\\",\\\"{\\\\\\\"parameterId\\\\\\\":\\\\\\\"4\\\\\\\",\\\\\\\"parameterRate\\\\\\\":\\\\\\\"120\\\\\\\"}\\\",\\\"{\\\\\\\"parameterId\\\\\\\":\\\\\\\"7\\\\\\\",\\\\\\\"parameterRate\\\\\\\":\\\\\\\"120\\\\\\\"}\\\"]\",\"xparams\":\"[\\\"{\\\\\\\"parameterId\\\\\\\":\\\\\\\"1\\\\\\\",\\\\\\\"parameterRate\\\\\\\":\\\\\\\"150\\\\\\\"}\\\",\\\"{\\\\\\\"parameterId\\\\\\\":\\\\\\\"3\\\\\\\",\\\\\\\"parameterRate\\\\\\\":\\\\\\\"150\\\\\\\"}\\\",\\\"{\\\\\\\"parameterId\\\\\\\":\\\\\\\"4\\\\\\\",\\\\\\\"parameterRate\\\\\\\":\\\\\\\"150\\\\\\\"}\\\"]\",\"sparams\":\"[\\\"{\\\\\\\"parameterId\\\\\\\":\\\\\\\"6\\\\\\\",\\\\\\\"parameterRate\\\\\\\":\\\\\\\"80\\\\\\\"}\\\",\\\"{\\\\\\\"parameterId\\\\\\\":\\\\\\\"7\\\\\\\",\\\\\\\"parameterRate\\\\\\\":\\\\\\\"80\\\\\\\"}\\\"]\",\"bonuses\":\"[\\\"{\\\\\\\"bonusId\\\\\\\":\\\\\\\"0\\\\\\\",\\\\\\\"bonusRate\\\\\\\":\\\\\\\"150\\\\\\\"}\\\",\\\"{\\\\\\\"bonusId\\\\\\\":\\\\\\\"1\\\\\\\",\\\\\\\"bonusRate\\\\\\\":\\\\\\\"150\\\\\\\"}\\\",\\\"{\\\\\\\"bonusId\\\\\\\":\\\\\\\"2\\\\\\\",\\\\\\\"bonusRate\\\\\\\":\\\\\\\"150\\\\\\\"}\\\",\\\"{\\\\\\\"bonusId\\\\\\\":\\\\\\\"3\\\\\\\",\\\\\\\"bonusRate\\\\\\\":\\\\\\\"150\\\\\\\"}\\\"]\"}"]
- *
  *
  * @command callDifficultyMenu
  * @text Call Difficulty Menu
@@ -110,241 +106,5 @@
  * @desc The amount to modify the max layer points by. This can be negative.
  * @min -999999
  * @max 999999
- */
-/*~struct~DifficultyStruct:
- * @param key
- * @parent overview
- * @type string
- * @text Unique Key
- * @desc A unique identifier for this difficulty.
- * Only letters, numbers, and underscores are recognized.
- * @default 010_Easy
- *
- * @param name
- * @parent overview
- * @type string
- * @text Name
- * @desc The name of the difficulty.
- * Displayed in the list of difficulties on the left.
- * @default Normal
- *
- * @param iconIndex
- * @parent overview
- * @type number
- * @text Icon Index
- * @desc The index of the icon to represent this difficulty.
- * @default 1
- *
- * @param description
- * @parent overview
- * @type string
- * @text Help Window Text
- * @desc Some text maybe describing the panel.
- * Shows up in the bottom help window.
- * @default Some really cool panel that has lots of hardcore powers.
- *
- * @param cost
- * @parent overview
- * @type number
- * @text Cost
- * @desc The cost required to enable this difficulty.
- * @default 0
- *
- * @param enabled
- * @parent overview
- * @text Is Enabled
- * @type boolean
- * @desc If this is ON/true, then this difficulty will be enabled when a new game starts.
- * @default false
- *
- * @param unlocked
- * @parent overview
- * @text Is Unlocked
- * @type boolean
- * @desc If this is ON/true, then this difficulty will be unlocked when a new game is started.
- * @default false
- *
- * @param hidden
- * @parent overview
- * @text Is Hidden
- * @type boolean
- * @desc If this is ON/true, then this difficulty will be hidden when a new game is started.
- * @default false
- *
- * @param enemyEffects
- * @parent data
- * @type struct<BattlerEffectsStruct>
- * @text Enemy Effects
- * @desc The effects that are applied to enemy battlers.
- * @default {"bparams":"[]","xparams":"[]","sparams":"[]"}
- *
- * @param actorEffects
- * @parent data
- * @type struct<BattlerEffectsStruct>
- * @text Actor Effects
- * @desc The effects that are applied to actor battlers.
- * @default {"bparams":"[]","xparams":"[]","sparams":"[]"}
- *
- * @param bonuses
- * @parent data
- * @type struct<BonusStruct>[]
- * @text Bonus Modifiers
- * @desc Bonuses listed here will be modified by the their respective provided rates.
- * @default []
- */
-/*~struct~BParamStruct:
- * @param parameterId
- * @text Parameter Id
- * @desc 0-7 are core parameters.
- * @type number
- * @type select
- * @option All params
- * @value -1
- * @option Max HP
- * @value 0
- * @option Max MP
- * @value 1
- * @option Power
- * @value 2
- * @option Endurance
- * @value 3
- * @option Force
- * @value 4
- * @option Resist
- * @value 5
- * @option Speed
- * @value 6
- * @option Luck
- * @value 7
- * @default 0
- *
- * @param parameterRate
- * @text Parameter Rate
- * @type number
- * @desc The percent multiplier that the given parameter will be modified by.
- * @default 100
- */
-/*~struct~XParamStruct:
- * @param parameterId
- * @text X-Parameter Id
- * @desc This x-parameter to be modified.
- * @type select
- * @option All params
- * @value -1
- * @option Hit Rate
- * @value 0
- * @option Evasion Rate
- * @value 1
- * @option Crit Chance
- * @value 2
- * @option Crit Evasion
- * @value 3
- * @option Magic Evasion
- * @value 4
- * @option Magic Reflect Rate
- * @value 5
- * @option Counter Rate
- * @value 6
- * @option HP Regen
- * @value 7
- * @option MP Regen
- * @value 8
- * @option TP Regen
- * @value 9
- * @default 0
- *
- * @param parameterRate
- * @text Parameter Rate
- * @type number
- * @desc The percent multiplier that the given parameter will be modified by.
- * @default 100
- */
-/*~struct~SParamStruct:
- * @param parameterId
- * @text S-Parameter Id
- * @desc This s-parameter to be modified.
- * @type select
- * @option All params
- * @value -1
- * @option Targeting Rate
- * @value 0
- * @option Guard Rate
- * @value 1
- * @option Recovery Rate
- * @value 2
- * @option Pharmacy Rate
- * @value 3
- * @option MP Cost Reduction
- * @value 4
- * @option TP Cost Reduction
- * @value 5
- * @option Phys DMG Reduction
- * @value 6
- * @option Magi DMG Reduction
- * @value 7
- * @option Floor DMG Reduction
- * @value 8
- * @option Experience Rate
- * @value 9
- * @default 0
- *
- * @param parameterRate
- * @text Parameter Rate
- * @type number
- * @desc The percent multiplier that the given parameter will be modified by.
- * @default 100
- */
-/*~struct~BonusStruct:
- * @param bonusId
- * @text Bonus Modifier
- * @desc This bonus rate to be modified.
- * @type select
- * @option Experience Earned
- * @value 0
- * @option Gold Found
- * @value 1
- * @option Loot Dropped
- * @value 2
- * @option SDP Acquired
- * @value 3
- * @default 0
- *
- * @param bonusRate
- * @text Bonus Rate
- * @type number
- * @desc The percent multiplier that the given bonus will be modified by.
- * @default 100
- */
-/*~struct~BattlerEffectsStruct:
- * @param bparams
- * @parent data
- * @type struct<BParamStruct>[]
- * @text B-Parameter Modifiers
- * @desc Parameters listed here will be modified by the their respective provided rates.
- * @default []
- *
- * @param xparams
- * @parent data
- * @type struct<XParamStruct>[]
- * @text X-Parameter Modifiers
- * @desc Parameters listed here will be modified by the their respective provided rates.
- * @default []
- *
- * @param sparams
- * @parent data
- * @type struct<SParamStruct>[]
- * @text S-Parameter Modifiers
- * @desc Parameters listed here will be modified by the their respective provided rates.
- * @default []
- *
- */
-/*
- * ==============================================================================
- * CHANGELOG:
- * - 2.0.0
- *    Updated to enable toggling one to many difficulties on at once.
- * - 1.0.0
- *    Initial release.
- * ==============================================================================
  */
 /* eslint-enable */

--- a/src/plugins/diff/_metadata/_pluginMetadata.js
+++ b/src/plugins/diff/_metadata/_pluginMetadata.js
@@ -187,9 +187,16 @@ class J_DiffPluginMetadata
      */
     this.allMetadatas = classifiedMetadatas;
 
-    console.log(`loaded:
+    if (J.BASE.Metadata.ShowExternalFileLoadInfo)
+    {
+      console.log(`loaded:
       - ${this.allMetadatas.size} difficulty layers
       from file ${J_DiffPluginMetadata.CONFIG_PATH}.`);
+    }
+    else
+    {
+      console.log(`loaded from file ${J_DiffPluginMetadata.CONFIG_PATH}.`);
+    }
   }
 
   initializeMetadata()

--- a/src/plugins/diff/_metadata/initialization.js
+++ b/src/plugins/diff/_metadata/initialization.js
@@ -8,7 +8,7 @@ var J = J || {};
 (() =>
 {
   // Check to ensure we have the minimum required version of the J-Base plugin.
-  const requiredBaseVersion = '2.1.3';
+  const requiredBaseVersion = '2.3.1';
   const hasBaseRequirement = J.BASE.Helpers.satisfies(J.BASE.Metadata.Version, requiredBaseVersion);
   if (!hasBaseRequirement)
   {
@@ -25,7 +25,7 @@ J.DIFFICULTY = {};
 /**
  * The `metadata` associated with this plugin, such as version.
  */
-J.DIFFICULTY.Metadata = new J_DiffPluginMetadata('J-Difficulty', '3.0.0');
+J.DIFFICULTY.Metadata = new J_DiffPluginMetadata('J-Difficulty', '2.0.1');
 
 /**
  * The actual `plugin parameters` extracted from RMMZ.

--- a/src/plugins/hud/ext/input/_metadata/_annotations.js
+++ b/src/plugins/hud/ext/input/_metadata/_annotations.js
@@ -2,14 +2,14 @@
 /*:
  * @target MZ
  * @plugindesc
- * [v1.0.0 HUD-INPUT] A HUD frame that displays your leader's buttons data.
+ * [v1.1.0 HUD-INPUT] A HUD frame that displays your leader's buttons data.
  * @author JE
  * @url https://github.com/je-can-code/rmmz-plugins
- * @base J-ABS
  * @base J-Base
+ * @base J-ABS
  * @base J-HUD
- * @orderAfter J-ABS
  * @orderAfter J-Base
+ * @orderAfter J-ABS
  * @orderAfter J-HUD
  * @help
  * ============================================================================
@@ -19,10 +19,22 @@
  * This is the Input Frame, which displays the various action keys and their
  * corresponding cooldown and cost data points for the leader of the party.
  *
+ * This plugin requires JABS.
+ * This plugin requires the base HUD.
+ * This plugin has no additional configuration required.
+ * ----------------------------------------------------------------------------
+ * DETAILS:
  * This includes the following data points for the currently selected leader:
- * - main and offhand action keys
- * - tool and dodge action keys
- * - ability keys (L1 + A/B/X/Y) action keys
- * - ability costs for all action keys, or item count remaining for tool.
+ * - mainhand, offhand, tool, and dodge/sprint action keys.
+ * - while holding the skill trigger, skill keys show instead.
+ * - ability costs for all keys, or item count remaining for tool.
+ * ============================================================================
+ * CHANGELOG
+ * ----------------------------------------------------------------------------
+ * - 1.1.0
+ *    Changed input to reflect a switch-view diamond in the center.
+ *    Retroactively added this changelog.
+ * - 1.0.0
+ *    Initial release.
  * ============================================================================
  */

--- a/src/plugins/hud/ext/input/_metadata/initialization.js
+++ b/src/plugins/hud/ext/input/_metadata/initialization.js
@@ -7,7 +7,7 @@ var J = J || {};
 (() =>
 {
   // Check to ensure we have the minimum required version of the J-Base plugin.
-  const requiredBaseVersion = '2.1.2';
+  const requiredBaseVersion = '2.3.1';
   const hasBaseRequirement = J.BASE.Helpers.satisfies(J.BASE.Metadata.Version, requiredBaseVersion);
   if (!hasBaseRequirement)
   {
@@ -27,17 +27,8 @@ J.HUD.EXT.INPUT = {};
  */
 J.HUD.EXT.INPUT = {};
 J.HUD.EXT.INPUT.Metadata = {};
-J.HUD.EXT.INPUT.Metadata.Version = '1.0.0';
+J.HUD.EXT.INPUT.Metadata.Version = '1.1.0';
 J.HUD.EXT.INPUT.Metadata.Name = `J-HUD-InputFrame`;
-
-/**
- * The actual `plugin parameters` extracted from RMMZ.
- */
-J.HUD.EXT.INPUT.PluginParameters = PluginManager.parameters(J.HUD.EXT.INPUT.Metadata.Name);
-
-J.HUD.EXT.INPUT.Metadata.InputFrameX = Number(J.HUD.EXT.INPUT.PluginParameters['inputFrameX']);
-J.HUD.EXT.INPUT.Metadata.InputFrameY = Number(J.HUD.EXT.INPUT.PluginParameters['inputFrameY']);
-J.HUD.EXT.INPUT.Metadata.UseGamepadLayout = false;
 
 /**
  * A collection of all aliased methods for this plugin.

--- a/src/plugins/hud/ext/input/scenes/Scene_Map.js
+++ b/src/plugins/hud/ext/input/scenes/Scene_Map.js
@@ -60,7 +60,7 @@ Scene_Map.prototype.buildInputFrameWindow = function()
 
   // return the built and configured window.
   return window;
-}
+};
 
 /**
  * Creates the rectangle representing the window for the input frame.
@@ -68,29 +68,33 @@ Scene_Map.prototype.buildInputFrameWindow = function()
  */
 Scene_Map.prototype.inputFrameWindowRect = function()
 {
-  // if using the keyboard layout, apply a modifier against the width.
-  const usingKeyboardWidthModifier = J.HUD.EXT.INPUT.Metadata.UseGamepadLayout
-    ? 0     // no bonus for gamepads.
-    : 220;  // bonus width for all-in-one row.
+  // Match Window_InputFrame’s key geometry.
+  const ikw = 72;
+  const ikh = 72;
 
-  // define the width of the window.
-  const width = 500 + usingKeyboardWidthModifier;
+  // Use the same diamond gap as the window, for perfect alignment.
+  const bodyGap = Window_InputFrame.DiamondGap;
 
-  // if using the keyboard layout, apply a modifier against the height.
-  const usingKeyboardHeightModifier = J.HUD.EXT.INPUT.Metadata.UseGamepadLayout
-    ? 0
-    : -60;
+  // Visual span.
+  const diamondBodyWidth = (3 * ikw) + (2 * bodyGap);
+  const diamondBodyHeight = (2 * ikh) + bodyGap;
 
-  // define the height of the window.
-  const height = 160 + usingKeyboardHeightModifier;
+  // Reserve horizontal space for the labels (“Actions” left, “Skills” right).
+  const labelReserveEachSide = 48;
 
-  // define the origin x of the window.
-  const x = Graphics.boxWidth - width;
+  // Add small margins to avoid clipping gradients/labels.
+  const marginX = 24;
+  const marginY = 24;
 
-  // define the origin y of the window.
+  // Final window size: body span + label reserves + visual margins.
+  const width = Math.ceil(diamondBodyWidth + (labelReserveEachSide * 2) + marginX);
+  const height = Math.ceil(diamondBodyHeight + marginY);
+
+  // Center horizontally; anchor bottom.
+  const x = Math.floor((Graphics.boxWidth - width) / 2);
   const y = Graphics.boxHeight - height;
 
-  // return the built rectangle.
+  // Build and return the rectangle.
   return new Rectangle(x, y, width, height);
 };
 
@@ -101,7 +105,7 @@ Scene_Map.prototype.inputFrameWindowRect = function()
 Scene_Map.prototype.getInputFrameWindow = function()
 {
   return this._j._hud._inputFrame;
-}
+};
 
 /**
  * Set the currently tracked input frame window to the given window.
@@ -110,7 +114,7 @@ Scene_Map.prototype.getInputFrameWindow = function()
 Scene_Map.prototype.setInputFrameWindow = function(window)
 {
   this._j._hud._inputFrame = window;
-}
+};
 //endregion input frame
 
 /**

--- a/src/plugins/hud/ext/input/sprites/Sprite_CooldownTimer.js
+++ b/src/plugins/hud/ext/input/sprites/Sprite_CooldownTimer.js
@@ -59,17 +59,8 @@ Sprite_CooldownTimer.prototype.updateCooldownText = function()
   const cooldownBaseText = baseCooldown > 0
     ? baseCooldown
     : String.empty;
-  const cooldownComboText = (cooldownBaseText > 0 && this._j._cooldownData.comboNextActionId !== 0)
-    ? "COMBO!"
-    : "❌";
 
   this.bitmap.drawText(cooldownBaseText, 0, 0, this.bitmapWidth(), this.bitmapHeight(), "center");
-  this.bitmap.fontSize = this.fontSize() - 8;
-  this.bitmap.fontItalic = true;
-  this.bitmap.drawText(cooldownComboText, 0, this.fontSize(), this.bitmapWidth(), this.bitmapHeight(), "center");
-  this.bitmap.fontSize = this.fontSize();
-  this.bitmap.fontItalic = false;
-
 }
 
 /**

--- a/src/plugins/hud/ext/input/sprites/Sprite_InputKeySlot.js
+++ b/src/plugins/hud/ext/input/sprites/Sprite_InputKeySlot.js
@@ -197,6 +197,8 @@ class Sprite_InputKeySlot
 
     // grab the leader and their battler for doing things.
     const leader = $gameParty.leader();
+
+    // TODO: implement.
   }
 
   /**
@@ -351,7 +353,7 @@ class Sprite_InputKeySlot
    * @param {boolean} isItem Whether or not this cooldown timer is for the item slot.
    * @returns {string}
    */
-  makeInputKeyCooldowntTimerSpriteKey(cooldownData, inputType, isItem)
+  makeInputKeyCooldownTimerSpriteKey(cooldownData, inputType, isItem)
   {
     return `cooldown-${this.battler()
       .name()}-${this.battler()
@@ -370,7 +372,7 @@ class Sprite_InputKeySlot
     const isItem = inputType === JABS_Button.Tool;
 
     // determine the key for this sprite.
-    const key = this.makeInputKeyCooldowntTimerSpriteKey(cooldownData, inputType, isItem);
+    const key = this.makeInputKeyCooldownTimerSpriteKey(cooldownData, inputType, isItem);
 
     // check if the key already maps to a cached sprite.
     if (this._j._spriteCache.has(key))
@@ -698,7 +700,7 @@ class Sprite_InputKeySlot
     // relocate the sprite.
     const sprite = this.getOrCreateInputKeySkillCostSprite(skillSlot, Sprite_SkillCost.Types.Item, inputType);
     sprite.show();
-    sprite.move(x + 36, y + 10);
+    sprite.move(x + 42, y + 24);
   }
 
   /**

--- a/src/plugins/hud/ext/input/windows/Window_InputFrame.js
+++ b/src/plugins/hud/ext/input/windows/Window_InputFrame.js
@@ -6,6 +6,27 @@ class Window_InputFrame
   extends Window_Frame
 {
   /**
+   * Modes for how the input diamond should render.
+   * @type {{ Base: string, Skills: string }}
+   */
+  static Modes = {
+    Base: 'base',
+    Skills: 'skills',
+  };
+
+  /**
+   * The visual gap (in pixels) between the top and bottom bodies of the diamond.
+   * Also used by the scene’s window sizing to keep things in sync.
+   * Tweak this to 4/6/etc to fiddle the spacing.
+   * @returns {number}
+   */
+  static get DiamondGap()
+  {
+    // default was 2; try 4 or 6 to taste.
+    return 6;
+  }
+
+  /**
    * Constructor.
    * @param {Rectangle} rect The shape of this window.
    */
@@ -14,6 +35,25 @@ class Window_InputFrame
     super(rect);
   }
 
+  /**
+   * The rough estimate of width for a single input key and all its subsprites.
+   * @returns {number}
+   */
+  inputKeyWidth()
+  {
+    return 72;
+  }
+
+  /**
+   * The rough estimate of height for a single input key and all its subsprites.
+   * @returns {number}
+   */
+  inputKeyHeight()
+  {
+    return 72;
+  }
+
+  //region state
   /**
    * Initializes all members of this class.
    */
@@ -35,7 +75,160 @@ class Window_InputFrame
      * @type {boolean}
      */
     this._j._needsRefresh = true;
+
+    /**
+     * A grouping for tracking last-known values used to determine
+     * if this HUD requires a refresh.
+     */
+    this._j._last ||= {};
+
+    /**
+     * Tracks whether SkillTrigger was held on the last processed frame.
+     * Used to request refreshes only when the held state changes so we
+     * preserve the "draw only when needed" behavior.
+     * @type {boolean}
+     */
+    this._j._last._skillTriggerHeld = false;
+
+    /**
+     * Tracks whether the party was considered in combat on the last processed frame.
+     * Used to request refresh on combat context changes so the left node can
+     * swap between Sprint (out of combat) and Mobility/Dodge (in combat).
+     * @type {boolean}
+     */
+    this._j._last._partyInCombat = false;
+
+    /**
+     * A grouping for tracking the flip progress and direction.
+     */
+    this._j._flip ||= {};
+
+    /**
+     * The current progress for the flip animation.
+     * @type {number}
+     */
+    this._j._flip._progress = 0;
+
+    /**
+     * The maximum duration for the flip animation.
+     * @type {number}
+     */
+    this._j._flip._max = 10;
+
+    /**
+     * The current direction of the flip animation.
+     * @type {number}
+     */
+    this._j._flip._direction = 0;
   }
+
+  /**
+   * Gets whether or not the skill trigger is held.
+   * @returns {boolean}
+   */
+  skillTriggerHeld()
+  {
+    return this._j._last._skillTriggerHeld;
+  }
+
+  /**
+   * Sets whether or not the skill trigger is held.
+   * @param {boolean} value True if the skill trigger is held, false otherwise.
+   */
+  setSkillTriggerHeld(value)
+  {
+    this._j._last._skillTriggerHeld = value;
+  }
+
+  /**
+   * Gets whether or not the party is in combat.
+   * @returns {boolean}
+   */
+  partyInCombat()
+  {
+    return this._j._last._partyInCombat;
+  }
+
+  /**
+   * Sets whether or not the party is in combat.
+   * @param {boolean} value True if the party is in combat, false otherwise.
+   */
+  setPartyInCombat(value)
+  {
+    this._j._last._partyInCombat = value;
+  }
+
+  /**
+   * Gets the current flip progress (0..max).
+   * @returns {number}
+   */
+  getFlipProgress()
+  {
+    // store under a dedicated bag to avoid accidental overlap.
+    return this._j._flip._progress;
+  }
+
+  /**
+   * Sets the current flip progress (0..max).
+   * @param {number} value The new progress.
+   */
+  setFlipProgress(value)
+  {
+    this._j._flip._progress = Math.max(0, value);
+  }
+
+  /**
+   * Gets the maximum flip duration in frames.
+   * @returns {number}
+   */
+  getFlipMax()
+  {
+    return this._j._flip._max;
+  }
+
+  /**
+   * Sets the maximum flip duration in frames.
+   * @param {number} value The new max duration.
+   */
+  setFlipMax(value)
+  {
+    this._j._flip._max = Math.max(0, value);
+  }
+
+  /**
+   * Gets the current flip direction (-1, 0, +1).
+   * @returns {number}
+   */
+  getFlipDirection()
+  {
+    return this._j._flip._direction;
+  }
+
+  /**
+   * Sets the current flip direction (-1, 0, +1).
+   * @param {number} value The new direction.
+   */
+  setFlipDirection(value)
+  {
+    // cache the numeric direction requested.
+    const dir = value;
+
+    // normalize to -1, 0, or +1 only.
+    if (dir < 0)
+    {
+      this._j._flip._direction = -1;
+    }
+    else if (dir > 0)
+    {
+      this._j._flip._direction = 1;
+    }
+    else
+    {
+      this._j._flip._direction = 0;
+    }
+  }
+
+  //endregion state
 
   /**
    * Executes any one-time configuration required for this window.
@@ -46,32 +239,7 @@ class Window_InputFrame
     super.configure();
 
     // remove opacity for completely transparent window.
-    this.opacity = 0;
-  }
-
-  /**
-   * Requests this window to clear and redraw its contents.
-   */
-  requestInternalRefresh()
-  {
-    this._j._needsRefresh = true;
-  }
-
-  /**
-   * Gets whether or not this window needs refresh.
-   * @returns {boolean}
-   */
-  needsInternalRefresh()
-  {
-    return this._j._needsRefresh;
-  }
-
-  /**
-   * Flags internally this window for successfully refreshing text.
-   */
-  acknowledgeInternalRefresh()
-  {
-    this._j._needsRefresh = false;
+    this.opacity = 32;
   }
 
   //region caching
@@ -132,6 +300,32 @@ class Window_InputFrame
 
   //endregion caching
 
+  //region refresh
+  /**
+   * Requests this window to clear and redraw its contents.
+   */
+  requestInternalRefresh()
+  {
+    this._j._needsRefresh = true;
+  }
+
+  /**
+   * Gets whether or not this window needs refresh.
+   * @returns {boolean}
+   */
+  needsInternalRefresh()
+  {
+    return this._j._needsRefresh;
+  }
+
+  /**
+   * Flags internally this window for successfully refreshing text.
+   */
+  acknowledgeInternalRefresh()
+  {
+    this._j._needsRefresh = false;
+  }
+
   /**
    * Refreshes the contents of this window.
    */
@@ -143,6 +337,8 @@ class Window_InputFrame
     // rebuilds the contents of the window.
     this.requestInternalRefresh();
   }
+
+  //endregion refresh
 
   /**
    * Hide all sprites for the hud.
@@ -166,8 +362,60 @@ class Window_InputFrame
     // handle the visibility of the hud for dynamic interferences.
     this.manageVisibility();
 
+    // check if the player is holding the skill trigger.
+    this.checkSkillTrigger();
+
+    // check if the party combat context changed and request redraw if so.
+    this.checkCombatContext();
+
+    // advance the crossfade animator when active (using accessors only).
+    this.advanceFlipAnimator();
+
     // draw the contents.
     this.drawInputFrame();
+  }
+
+  /**
+   * Checks if the player is holding the SkillTrigger and updates the internal state accordingly.
+   */
+  checkSkillTrigger()
+  {
+    // determine whether the SkillTrigger is currently held.
+    const currentlyHeld = this.isSkillTriggerHeld();
+
+    // if the held state changed since last frame, request a redraw.
+    if (this.skillTriggerHeld() !== currentlyHeld)
+    {
+      // update last-known held state.
+      this.setSkillTriggerHeld(currentlyHeld);
+
+      // kick the flip animator in the correct direction via setter only.
+      this.setFlipDirection(currentlyHeld
+        ? +1
+        : -1);
+
+      // redraw is required to flip between views.
+      this.requestInternalRefresh();
+    }
+  }
+
+  /**
+   * Checks if the party combat context changed and updates internal state.
+   */
+  checkCombatContext()
+  {
+    // determine whether the party is currently considered in combat.
+    const currentlyInCombat = $gameParty.anyMemberInCombat();
+
+    // if the combat context changed since last frame, request a redraw.
+    if (this.partyInCombat() !== currentlyInCombat)
+    {
+      // update last-known in-combat state.
+      this.setPartyInCombat(currentlyInCombat);
+
+      // redraw is required to swap the left node (Sprint ↔ Mobility).
+      this.requestInternalRefresh();
+    }
   }
 
   //region visibility
@@ -265,19 +513,78 @@ class Window_InputFrame
   //endregion visibility
 
   /**
-   * The rough estimate of width for a single input key and all its subsprites.
-   * @returns {number}
+   * Advances the flip animator when active; requests refresh while animating.
+   * Uses only accessors for state changes.
    */
-  inputKeyWidth()
+  advanceFlipAnimator()
   {
-    return 72;
+    // if idle, nothing to do.
+    if (this.getFlipDirection() === 0)
+    {
+      return;
+    }
+
+    // compute new progress.
+    const next = this.getFlipProgress() + this.getFlipDirection();
+    const max = this.getFlipMax();
+
+    // clamp into [0, max].
+    if (next <= 0)
+    {
+      this.setFlipProgress(0);
+      this.setFlipDirection(0);
+    }
+    else if (next >= max)
+    {
+      this.setFlipProgress(max);
+      this.setFlipDirection(0);
+    }
+    else
+    {
+      this.setFlipProgress(next);
+    }
+
+    // while animating, ensure redraw continues.
+    this.requestInternalRefresh();
   }
 
-  inputKeyHeight()
+  /**
+   * Computes current alphas for base and skills diamonds from the flip animator.
+   * @returns {{alphaBase:number, alphaSkills:number}}
+   */
+  computeFlipAlphas()
   {
-    return 96;
+    // if animator is idle, snap to whichever mode is active.
+    if (this.getFlipDirection() === 0)
+    {
+      const skillsActive = this.isSkillTriggerHeld();
+      return {
+        alphaBase: skillsActive
+          ? 0
+          : 255,
+        alphaSkills: skillsActive
+          ? 255
+          : 0,
+      };
+    }
+
+    // blend based on normalized progress.
+    const max = this.getFlipMax();
+    const prog = this.getFlipProgress();
+    const t = max > 0
+      ? (prog / max)
+      : 1;
+
+    // direction +1 means transitioning to Skills; -1 to Actions.
+    const alphaSkills = Math.round(255 * t);
+    const alphaBase = 255 - alphaSkills;
+    return {
+      alphaBase,
+      alphaSkills
+    };
   }
 
+  //region draw
   /**
    * Draws the input frame window in its entirety.
    */
@@ -288,24 +595,47 @@ class Window_InputFrame
 
     // wipe the drawn contents.
     this.contents.clear();
+    this.contentsBack.clear();
 
-    // hide all the sprites.
+    // hide all the sprites and let each update its own bitmap.
     this._j._spriteCache.forEach((sprite =>
     {
       sprite.hide();
       sprite.drawInputKey();
     }));
 
-    if (J.HUD.EXT.INPUT.Metadata.UseGamepadLayout)
+    // compute blend alphas between modes (0..255 each) using accessors.
+    const alphas = this.computeFlipAlphas();
+    const {
+      alphaBase,
+      alphaSkills
+    } = alphas;
+
+    // draw Actions (base) with its alpha when non-zero.
+    if (alphaBase > 0)
     {
-      // draw the inputs.
-      this.drawGamepadStyleInputKeys();
+      // apply paint opacity for gradients/text.
+      this.contents.paintOpacity = alphaBase;
+
+      // pass the same alpha down so child slot sprites also fade.
+      this.drawDiamond(Window_InputFrame.Modes.Base, alphaBase);
     }
-    else
+
+    // draw Skills with its alpha when non-zero.
+    if (alphaSkills > 0)
     {
-      // draw the inputs.
-      this.drawKeyboardStyleInputKeys();
+      // apply paint opacity for gradients/text.
+      this.contents.paintOpacity = alphaSkills;
+
+      // pass the same alpha down so child slot sprites also fade.
+      this.drawDiamond(Window_InputFrame.Modes.Skills, alphaSkills);
     }
+
+    // reset paint opacity for any future draws this frame.
+    this.contents.paintOpacity = 255;
+
+    // draw the mode labels with their own fading alphas.
+    this.drawModeLabels(alphaBase, alphaSkills);
 
     // flags that this has been refreshed.
     this.acknowledgeInternalRefresh();
@@ -331,105 +661,376 @@ class Window_InputFrame
   }
 
   /**
-   * Draws the inputs to be more console-style with a gamepad layout.
+   * Checks the current bindings for SkillTrigger and returns true if any bound
+   * physical symbol is currently pressed. This is remap‑aware.
+   * @returns {boolean}
    */
-  drawGamepadStyleInputKeys()
+  isSkillTriggerHeld()
   {
-    // our origin x:y coordinates.
-    const x = 0;
-    const y = 0;
+    // get JABS bindings and the physical symbols for the logical SkillTrigger.
+    const allBindings = Input.getAllBindings('JABS');
+    const bound = allBindings && allBindings[JABS_Button.SkillTrigger]
+      ? allBindings[JABS_Button.SkillTrigger]
+      : [];
 
-    // draw the primary section of our input.
-    this.drawGamepadPrimaryInputKeys(x, y);
+    // if any symbol bound to SkillTrigger is held, return true.
+    for (let i = 0; i < bound.length; i++)
+    {
+      const symbol = bound[i];
+      if (Input.isPressed(symbol))
+      {
+        return true;
+      }
+    }
 
-    // draw the secondary section of our input.
-    this.drawGamepadSecondaryInputKeys(x + 250, y);
+    // none of the bound symbols are pressed.
+    return false;
   }
 
   /**
-   * Draws the inputs to be more PC-style with a keyboard layout.
+   * Draws the “Actions” and “Skills” labels with matching crossfade alphas.
+   * @param {number} alphaBase The opacity (0..255) for the Actions label.
+   * @param {number} alphaSkills The opacity (0..255) for the Skills label.
    */
-  drawKeyboardStyleInputKeys()
+  drawModeLabels(alphaBase, alphaSkills)
   {
-    // our origin x:y coordinates.
-    const ikw = this.inputKeyWidth();
-    const x = 0;
-    const y = 0;
+    // cache base font settings to restore afterward.
+    const prevSize = this.contents.fontSize;
+    const prevOutlineW = this.contents.outlineWidth;
+    const prevOutlineC = this.contents.outlineColor;
+    const prevPaint = this.contents.paintOpacity;
 
-    // draw the primary section of our input.
-    this.drawKeyboardPrimaryInputKeys(x, y);
+    // choose a slightly larger, bold-ish readable style.
+    this.contents.fontSize = prevSize + 2;
+    this.contents.outlineWidth = 4;
+    this.contents.outlineColor = 'rgba(0, 0, 0, 0.85)';
 
-    // draw the secondary section of our input.
-    const keyboardSecondaryX = x + (ikw * 4) + 24;
-    this.drawKeyboardSecondaryInputKeys(keyboardSecondaryX, y);
+    // compute margins for label placement inside contents space.
+    const leftMargin = 8;
+    const rightMargin = 8;
+    const topMargin = 2;
+
+    // draw "Actions" in the upper-left, using the base alpha.
+    if (alphaBase > 0)
+    {
+      // apply the alpha for this pass.
+      this.contents.paintOpacity = alphaBase;
+
+      // define text and measure for any future adjustments if needed.
+      const text = 'Actions';
+
+      // draw the text left-aligned at the top-left margin.
+      this.drawText(text, leftMargin, topMargin, 160, 'left');
+    }
+
+    // draw "Skills" in the upper-right, using the skills alpha.
+    if (alphaSkills > 0)
+    {
+      // apply the alpha for this pass.
+      this.contents.paintOpacity = alphaSkills;
+
+      // define text and measure its width.
+      const text = 'Skills';
+      const tw = this.textSizeEx(text).width; // consistent with Window_Base API.
+
+      // compute x so the right edge sits at contentsWidth - rightMargin.
+      const x = Math.max(0, this.contentsWidth() - rightMargin - tw);
+
+      // draw the text right-aligned at the top-right margin.
+      this.drawText(text, x, topMargin, tw, 'right');
+    }
+
+    // restore font and opacity.
+    this.contents.fontSize = prevSize;
+    this.contents.outlineWidth = prevOutlineW;
+    this.contents.outlineColor = prevOutlineC;
+    this.contents.paintOpacity = prevPaint;
   }
 
   /**
-   * Draws the primary set of input keys.
-   * This includes: mainhand, offhand, dodge, and tool input keys.
-   * @param {number} x The x coordinate.
-   * @param {number} y The y coordinate.
+   * Draws a multi-layer HUD panel background that looks richer than a flat gradient.
+   * Renders shadow to contentsBack, then gradient/border/gloss/tint to contents.
+   * @param {number} x The left of the panel (contents space).
+   * @param {number} y The top of the panel (contents space).
+   * @param {number} w The width of the panel.
+   * @param {number} h The height of the panel.
+   * @param {{
+   *   tint?: string,
+   *   tintAlpha?: number,
+   *   cornerPad?: number,
+   * }} [options] Optional styling overrides.
    */
-  drawGamepadPrimaryInputKeys(x, y)
+  drawHudPanelFancy(x, y, w, h, options)
   {
-    // shorthand the variables for re-use.
-    const ikw = this.inputKeyWidth();
-    const baseX = x + 16;
-    const baseY = y + 8;
+    // configure options w/ reasonable defaults.
+    const opts = options || {};
+    const tint = opts.tint || null;             // e.g., 'rgba(255,64,64,1.0)'
+    const tintAlpha = Number(opts.tintAlpha || 0); // 0..1
+    const radius = Math.max(0, Number(opts.cornerPad || 0));
 
-    // draw the four basic core functions of JABS.
-    this.drawInputKey(JABS_Button.Mainhand, baseX + ikw * 0, baseY + 32);
-    this.drawInputKey(JABS_Button.Offhand, baseX + (ikw * 1), baseY + 32);
-    this.drawInputKey(JABS_Button.Dodge, baseX + (ikw * 2), baseY + 64);
-    this.drawInputKey(JABS_Button.Tool, baseX + (ikw * 2), baseY);
+    // colors from theme (same family your old panels used).
+    const back1 = ColorManager.itemBackColor1(); // darker
+    const back2 = ColorManager.itemBackColor2(); // lighter
+
+    // quick guards.
+    if (w <= 0 || h <= 0) return;
+
+    // helpers to draw a rounded-rect path into a 2D context.
+    const roundRectPath = (ctx, rx, ry, rw, rh, r) =>
+    {
+      const rr = Math.min(r, Math.floor(Math.min(rw, rh) / 2));
+      if (rr <= 0)
+      {
+        ctx.rect(rx, ry, rw, rh);
+        return;
+      }
+      const r2 = rr * 2;
+      ctx.moveTo(rx + rr, ry);
+      ctx.lineTo(rx + rw - rr, ry);
+      ctx.arc(rx + rw - rr, ry + rr, rr, Math.PI * 1.5, 0);
+      ctx.lineTo(rx + rw, ry + rh - rr);
+      ctx.arc(rx + rw - rr, ry + rh - rr, rr, 0, Math.PI * 0.5);
+      ctx.lineTo(rx + rr, ry + rh);
+      ctx.arc(rx + rr, ry + rh - rr, rr, Math.PI * 0.5, Math.PI);
+      ctx.lineTo(rx, ry + rr);
+      ctx.arc(rx + rr, ry + rr, rr, Math.PI, Math.PI * 1.5);
+    };
+
+    // 1) soft shadow to contentsBack (subtle, non-accumulating because we clear each refresh).
+    {
+      const sb = this.contentsBack;
+      const ctx = sb.context;
+      ctx.save();
+      ctx.fillStyle = 'rgba(0, 0, 0, 0.28)';
+      for (let i = 1; i <= 3; i++)
+      {
+        ctx.beginPath();
+        roundRectPath(ctx, x + i, y + i + 1, w, h, radius);
+        ctx.fill();
+      }
+      ctx.restore();
+      sb._baseTexture.update();
+    }
+
+    // 2) main body gradient fill to contents (3-stop vertical feel).
+    const c = this.contents;
+    const ctx = c.context;
+    ctx.save();
+    const grad = ctx.createLinearGradient(0, y + h, 0, y);
+    grad.addColorStop(0.00, back1);
+    grad.addColorStop(0.50, back2);
+    grad.addColorStop(1.00, back1);
+    ctx.fillStyle = grad;
+    ctx.beginPath();
+    roundRectPath(ctx, x, y, w, h, radius);
+    ctx.fill();
+
+    // mid highlight band (very soft)
+    const midH = Math.max(6, Math.floor(h * 0.25));
+    const midY = y + Math.floor((h - midH) / 2);
+    const midGrad = ctx.createLinearGradient(0, midY + midH, 0, midY);
+    midGrad.addColorStop(0.00, 'rgba(255,255,255,0.00)');
+    midGrad.addColorStop(1.00, 'rgba(255,255,255,0.06)');
+    ctx.fillStyle = midGrad;
+    ctx.beginPath();
+    roundRectPath(ctx, x + 1, midY, w - 2, midH, Math.max(0, radius - 1));
+    ctx.fill();
+
+    // 3) inner border (crisper than before).
+    ctx.lineWidth = 1.0;
+    ctx.strokeStyle = 'rgba(255, 255, 255, 0.12)';
+    ctx.beginPath();
+    roundRectPath(ctx, x + 0.5, y + 0.5, w - 1, h - 1, Math.max(0, radius - 0.5));
+    ctx.stroke();
+
+    // 4) top gloss band for a gentle sheen.
+    const glossH = Math.max(4, Math.floor(h * 0.20));
+    const glossGrad = ctx.createLinearGradient(0, y + glossH, 0, y);
+    glossGrad.addColorStop(0.00, 'rgba(255,255,255,0.18)');
+    glossGrad.addColorStop(1.00, 'rgba(255,255,255,0.00)');
+    ctx.fillStyle = glossGrad;
+    ctx.beginPath();
+    roundRectPath(ctx, x + 1, y + 1, w - 2, glossH, Math.max(0, radius - 1));
+    ctx.fill();
+
+    // 5) optional tint overlay (context-aware color).
+    if (tint && tintAlpha > 0)
+    {
+      ctx.globalAlpha = Math.max(0, Math.min(1, tintAlpha));
+      ctx.fillStyle = tint;
+      ctx.beginPath();
+      roundRectPath(ctx, x, y, w, h, radius);
+      ctx.fill();
+    }
+
+    ctx.restore();
+    c._baseTexture.update();
+
   }
 
   /**
-   * Draws the primary set of input keys.
-   * This includes: all L1 and R1 combo inputs.
-   * @param {number} x The x coordinate.
-   * @param {number} y The y coordinate.
+   * Renders a diamond from the window's upper-left using shared coordinates.
+   * The parent computes x/y once per node and draws exactly four buttons.
+   * @param {string} mode One of {@link Window_InputFrame.Modes}.
+   * @param {number} slotOpacity The opacity to apply to slot sprites (0..255).
    */
-  drawGamepadSecondaryInputKeys(x, y)
+  drawDiamond(mode, slotOpacity)
   {
-    // shorthand the variables for re-use.
+    // shared key sizes.
     const ikw = this.inputKeyWidth();
-    const baseX = x + 16;
-    const baseY = y + 8;
+    const ikh = this.inputKeyHeight();
 
-    // draw the combat skills equipped for JABS.
-    this.drawInputKey(JABS_Button.CombatSkill3, baseX + ikw * 0, baseY + 32);
-    this.drawInputKey(JABS_Button.CombatSkill4, baseX + (ikw * 1), baseY);
-    this.drawInputKey(JABS_Button.CombatSkill1, baseX + (ikw * 1), baseY + 64);
-    this.drawInputKey(JABS_Button.CombatSkill2, baseX + (ikw * 2), baseY + 32);
+    // diamond geometry (centered in the window box; matches Scene sizing math).
+    const cx = Math.floor(this.width / 2) + 4;
+    const cy = Math.floor(this.height / 2) - 10;
+
+    // use a single desired body-to-body gap in BOTH axes.
+    const desiredGap = Window_InputFrame.DiamondGap; // applies horizontally AND vertically
+
+    // half-sizes for converting between centers and sprite origins.
+    const halfIkw = Math.floor(ikw / 2);
+    const halfIkh = Math.floor(ikh / 2);
+
+    // VERTICAL: distance between centers of top and bottom bodies so that
+    // the visible body gap equals desiredGap.
+    const verticalCenterDistance = ikh + desiredGap;
+
+    // compute the visual centers for top/bottom.
+    const topCenterY = cy - Math.floor(verticalCenterDistance / 2);
+    const bottomCenterY = cy + Math.floor(verticalCenterDistance / 2);
+
+    // convert visual centers to sprite origins (compensate for +20 body offset).
+    const topY = topCenterY - halfIkh - 20;
+    const bottomY = bottomCenterY - halfIkh - 20;
+
+    // HORIZONTAL: Left/Right are DiamondGap away from the center column body.
+    // That means each side center is offset by (ikw + desiredGap) from cx.
+    const sideCenterOffset = ikw + desiredGap;
+    const leftCenterX = cx - sideCenterOffset;
+    const rightCenterX = cx + sideCenterOffset;
+
+    // convert centers to sprite origins.
+    const leftX = leftCenterX - halfIkw;
+    const rightX = rightCenterX - halfIkw;
+
+    // Left/Right share the midline vertically.
+    const sideY = cy - halfIkh - 20;
+
+    // Top and Bottom share the same x (center column).
+    const topX = cx - halfIkw;
+    const bottomX = cx - halfIkw;
+
+    // draw four buttons according to mode.
+    switch (mode)
+    {
+      case Window_InputFrame.Modes.Skills:
+      {
+        // Top    → Skill 4
+        // Left   → Skill 3
+        // Right  → Skill 2
+        // Bottom → Skill 1
+        this.drawButton(topX, topY, JABS_Button.CombatSkill4, slotOpacity);
+        this.drawButton(leftX, sideY, JABS_Button.CombatSkill3, slotOpacity);
+        this.drawButton(rightX, sideY, JABS_Button.CombatSkill2, slotOpacity);
+        this.drawButton(bottomX, bottomY, JABS_Button.CombatSkill1, slotOpacity);
+        break;
+      }
+
+      case Window_InputFrame.Modes.Base:
+      default:
+      {
+        // decide the left node based on combat context.
+        const leftButton = this.partyInCombat()
+          ? JABS_Button.Dodge
+          : JABS_Button.Sprint;
+
+        // Top    → Tool
+        // Left   → Sprint (OoC) or Dodge (In‑combat)
+        // Right  → Offhand
+        // Bottom → Mainhand
+        this.drawButton(topX, topY, JABS_Button.Tool, slotOpacity);
+        this.drawButton(leftX, sideY, leftButton, slotOpacity);
+        this.drawButton(rightX, sideY, JABS_Button.Offhand, slotOpacity);
+        this.drawButton(bottomX, bottomY, JABS_Button.Mainhand, slotOpacity);
+        break;
+      }
+    }
   }
 
-  drawKeyboardPrimaryInputKeys(x, y)
+  /**
+   * Draw a single button at x,y.
+   * Sprint is a special case (not a skillslot), everything else uses drawInputKey().
+   * @param {number} x The x coordinate (CONTENTS space).
+   * @param {number} y The y coordinate (CONTENTS space).
+   * @param {string} button The logical button (from {@link JABS_Button}).
+   * @param {number} opacity The per-pass opacity (0..255) for slot sprites.
+   */
+  drawButton(x, y, button, opacity)
   {
-    // shorthand the variables for re-use.
-    const ikw = this.inputKeyWidth();
-    const baseX = x + 16;
-    const baseY = y + 8;
+    // sprint is not backed by a JABS_SkillSlot; render its node directly.
+    if (button === JABS_Button.Sprint)
+    {
+      this.drawSprintNode(x, y);
+      return;
+    }
 
-    // draw the four basic core functions of JABS.
-    this.drawInputKey(JABS_Button.Mainhand, baseX + ikw * 0, baseY);
-    this.drawInputKey(JABS_Button.Offhand, baseX + ikw * 1, baseY);
-    this.drawInputKey(JABS_Button.Dodge, baseX + ikw * 2, baseY);
-    this.drawInputKey(JABS_Button.Tool, baseX + ikw * 3, baseY);
+    // draw the input-key backed slot with the provided opacity.
+    this.drawInputKey(button, x, y, opacity);
   }
 
-  drawKeyboardSecondaryInputKeys(x, y)
+  /**
+   * Draws a Sprint node styled like a skill slot: a panel,
+   * a centered icon, and a small label reading "dash".
+   * @param {number} x The x coordinate for the node (contents space).
+   * @param {number} y The y coordinate for the node (contents space).
+   */
+  drawSprintNode(x, y)
   {
-    // shorthand the variables for re-use.
+    // node size, aligned with other keys.
     const ikw = this.inputKeyWidth();
-    const baseX = x + 16;
-    const baseY = y + 8;
+    const ikh = this.inputKeyHeight();
 
-    // draw the combat skills equipped for JABS.
-    this.drawInputKey(JABS_Button.CombatSkill1, baseX + ikw * 0, baseY);
-    this.drawInputKey(JABS_Button.CombatSkill2, baseX + ikw * 1, baseY);
-    this.drawInputKey(JABS_Button.CombatSkill3, baseX + ikw * 2, baseY);
-    this.drawInputKey(JABS_Button.CombatSkill4, baseX + ikw * 3, baseY);
+    // panel rectangle aligned to other slot panels.
+    const panelX = x - 10;
+    const panelY = y + 20;
+    const panelW = ikw - 10;
+    const panelH = ikh;
+
+    // render the fancy HUD panel background.
+    this.drawHudPanelFancy(panelX, panelY, panelW, panelH, {
+      tint: null,
+      tintAlpha: 0,
+    });
+
+    // icon (temporary index 140) centered, biased upward to leave label room.
+    const iconIndex = 140;
+    const iconW = ImageManager.iconWidth;
+    const iconH = ImageManager.iconHeight;
+    const labelReserve = 18;
+    const iconX = panelX + Math.floor((panelW - iconW) / 2);
+    const iconY = panelY + Math.max(0, Math.floor((panelH - labelReserve - iconH) / 2));
+    this.drawIcon(iconIndex, iconX, iconY);
+
+    // small label using Window_Base helpers (no direct font pokes).
+    const originalSize = this.contents.fontSize;
+    const originalOutlineW = this.contents.outlineWidth;
+    const originalOutlineC = this.contents.outlineColor;
+
+    // match other slot label sizing (slightly smaller than default).
+    this.setFontSize(originalSize - 10);
+    this.contents.outlineWidth = 4;
+    this.contents.outlineColor = 'rgba(0, 0, 0, 0.85)';
+
+    const text = 'Dash';
+    const tw = this.textSizeEx(text).width;
+    const labelX = panelX + Math.floor((panelW - tw) / 2) - 5;
+    const labelY = panelY + panelH - labelReserve - 16;
+    this.drawText(text, labelX, labelY, tw, 'left');
+
+    // restore font settings.
+    this.setFontSize(originalSize);
+    this.contents.outlineWidth = originalOutlineW;
+    this.contents.outlineColor = originalOutlineC;
   }
 
   /**
@@ -437,8 +1038,9 @@ class Window_InputFrame
    * @param {string} inputType The type of input key this is.
    * @param {number} x The x coordinate.
    * @param {number} y The y coordinate.
+   * @param {number} opacity The per-pass opacity (0..255) for slot sprites.
    */
-  drawInputKey(inputType, x, y)
+  drawInputKey(inputType, x, y, opacity)
   {
     // shorthand the player's JABS battler data.
     const jabsPlayer = $jabsEngine.getPlayer1();
@@ -452,33 +1054,47 @@ class Window_InputFrame
     // extract the input key's data.
     const skillSlot = actionKeyData.skillslot;
 
-    // draw the input key slot's sprite.
-    this.drawInputKeySlotSprite(skillSlot, inputType, x, y);
+    // draw the input key slot's sprite with the provided opacity.
+    this.drawInputKeySlotSprite(skillSlot, inputType, x, y, opacity);
   }
 
   /**
    * Draw the input key associated with a given skill slot.
    * @param {JABS_SkillSlot} skillSlot The skill slot to draw.
    * @param {string} inputType The type of input key this is.
-   * @param {number} x The x coordinate.
-   * @param {number} y The y coordinate.
+   * @param {number} x The x coordinate (CONTENTS space).
+   * @param {number} y The y coordinate (CONTENTS space).
+   * @param {number} opacity The per-pass opacity (0..255) for the slot sprite.
    */
-  drawInputKeySlotSprite(skillSlot, inputType, x, y)
+  drawInputKeySlotSprite(skillSlot, inputType, x, y, opacity)
   {
     const sprite = this.getOrCreateInputKeySlotSprite(skillSlot, inputType);
 
+    // draw the panel background when the slot isn’t empty.
     if (!skillSlot.isEmpty())
     {
       const width = this.inputKeyWidth() - 10;
       const height = this.inputKeyHeight();
-      const c1 = ColorManager.itemBackColor1();
-      const c2 = ColorManager.itemBackColor2();
-      this.contents.gradientFillRect(x - 10, y + 20, width, height, c1, c2, true);
+
+      // fancy multi-layer HUD panel.
+      this.drawHudPanelFancy(x - 10, y + 20, width, height, {
+        // no tint by default; wire one in later if you theme by state.
+        tint: null,
+        tintAlpha: 0,
+      });
     }
 
+    // TODO: adjust x/y back a bit.
+
+    // position the slot sprite.
+    const px = this.padding + x - 4;
+    const py = this.padding + y + 14;
     sprite.show();
-    sprite.move(x + 6, y + 20);
+    sprite.move(px, py);
+    sprite.opacity = Math.max(0, Math.min(255, opacity || 255));
   }
+
+  //endregion draw
 }
 
 //endregion Window_InputFrame

--- a/src/plugins/hud/ext/party/_metadata/_annotations.js
+++ b/src/plugins/hud/ext/party/_metadata/_annotations.js
@@ -2,14 +2,14 @@
 /*:
  * @target MZ
  * @plugindesc
- * [v1.0.0 HUD-PARTY] A HUD frame that displays your party's data.
+ * [v1.1.0 HUD-PARTY] A HUD frame that displays your party's data.
  * @author JE
  * @url https://github.com/je-can-code/rmmz-plugins
- * @base J-ABS
  * @base J-Base
+ * @base J-ABS
  * @base J-HUD
- * @orderAfter J-ABS
  * @orderAfter J-Base
+ * @orderAfter J-ABS
  * @orderAfter J-HUD
  * @help
  * ============================================================================
@@ -19,6 +19,11 @@
  * This is the Party Frame, which displays the leader and allied members that
  * the player currently has in their party.
  *
+ * This plugin requires JABS.
+ * This plugin requires the base HUD.
+ * This plugin has no additional configuration required.
+ * ----------------------------------------------------------------------------
+ * DETAILS:
  * This includes the following data points for all actors:
  * - face portrait
  * - hp gauge
@@ -29,4 +34,14 @@
  * - current level
  * - experience gauge
  * - positive/negative state tracking
+ * - in combat indicator
+ * ============================================================================
+ * CHANGELOG
+ * ----------------------------------------------------------------------------
+ * - 1.1.0
+ *    Added visual tracking indicator for "in combat" for the leader.
+ *    Retroactively added this changelog.
+ * - 1.0.0
+ *    Initial release.
+ * ============================================================================
  */

--- a/src/plugins/hud/ext/party/_metadata/initialization.js
+++ b/src/plugins/hud/ext/party/_metadata/initialization.js
@@ -7,7 +7,7 @@ var J = J || {};
 (() =>
 {
   // Check to ensure we have the minimum required version of the J-Base plugin.
-  const requiredBaseVersion = '1.0.0';
+  const requiredBaseVersion = '2.3.1';
   const hasBaseRequirement = J.BASE.Helpers.satisfies(J.BASE.Metadata.Version, requiredBaseVersion);
   if (!hasBaseRequirement)
   {
@@ -27,7 +27,7 @@ J.HUD.EXT.PARTY = {};
  */
 J.HUD.EXT.PARTY = {};
 J.HUD.EXT.PARTY.Metadata = {};
-J.HUD.EXT.PARTY.Metadata.Version = '1.0.0';
+J.HUD.EXT.PARTY.Metadata.Version = '1.1.0';
 J.HUD.EXT.PARTY.Metadata.Name = `J-HUD-PartyFrame`;
 
 /**

--- a/src/plugins/hud/ext/party/sprites/Sprite_ActorValue.js
+++ b/src/plugins/hud/ext/party/sprites/Sprite_ActorValue.js
@@ -79,29 +79,70 @@ Sprite_ActorValue.prototype.refresh = function()
  */
 Sprite_ActorValue.prototype.hasParameterChanged = function()
 {
+  // default to "changed" in case we do not match a parameter.
   let changed = true;
+
+  // decide which parameter we are tracking and compare against the cache.
   switch (this._j._parameter)
   {
-    case "hp":
+    case 'hp':
+    {
+      // check for hp change.
       changed = this._j._actor.hp !== this._j._last._hp;
+
+      // update the last-known hp if changed.
       if (changed) this._j._last._hp = this._j._actor.hp;
+
+      // end case.
       return changed;
-    case "mp":
+    }
+    case 'mp':
+    {
+      // check for mp change.
       changed = this._j._actor.mp !== this._j._last._mp;
+
+      // update the last-known mp if changed.
       if (changed) this._j._last._mp = this._j._actor.mp;
+
+      // end case.
       return changed;
-    case "tp":
+    }
+    case 'tp':
+    {
+      // check for tp change.
       changed = this._j._actor.tp !== this._j._last._tp;
-      if (changed) this._j._last.tp = this._j._actor.tp;
+
+      // update the last-known tp if changed.
+      if (changed) this._j._last._tp = this._j._actor.tp;
+
+      // end case.
       return changed;
-    case "time":
-      changed = this._j._actor.currentExp() !== this._j._last._xp;
-      if (changed) this._j._last._xp = this._j._actor.currentExp();
+    }
+    case 'time':
+    {
+      // compute the current exp for comparison.
+      const current = this._j._actor.currentExp();
+
+      // check for exp change.
+      changed = current !== this._j._last._xp;
+
+      // update the last-known exp if changed.
+      if (changed) this._j._last._xp = current;
+
+      // end case.
       return changed;
-    case "lvl":
+    }
+    case 'lvl':
+    {
+      // check for level change.
       changed = this._j._actor.level !== this._j._last._lvl;
+
+      // update the last-known level if changed.
       if (changed) this._j._last._lvl = this._j._actor.level;
+
+      // end case.
       return changed;
+    }
   }
 };
 
@@ -110,44 +151,109 @@ Sprite_ActorValue.prototype.hasParameterChanged = function()
  */
 Sprite_ActorValue.prototype.createBitmap = function()
 {
+  // default the value to 0.
   let value = 0;
+
+  // determine the bitmap dimensions.
   const width = this.bitmapWidth();
+
+  // determine the bitmap height relative to font size.
   const height = this.fontSize() + 4;
+
+  // create the bitmap for this value sprite.
   const bitmap = new Bitmap(width, height);
+
+  // assign the font face for this value.
   bitmap.fontFace = this.fontFace();
+
+  // assign the font size for this value.
   bitmap.fontSize = this.fontSize();
+
+  // decide how to render based on the parameter being displayed.
   switch (this._j._parameter)
   {
-    case "hp":
+    case 'hp':
+    {
+      // set the outline thickness for readability.
       bitmap.outlineWidth = 4;
-      bitmap.outlineColor = "rgba(128, 24, 24, 1.0)";
-      value = Math.floor(this._j._actor.hp);
+
+      // set the red-tinted outline color for HP.
+      bitmap.outlineColor = 'rgba(128, 24, 24, 1.0)';
+
+      // display rounded HP to avoid off-by-one visuals against fractional HP.
+      value = Math.round(this._j._actor.hp);
+
+      // end case.
       break;
-    case "mp":
+    }
+    case 'mp':
+    {
+      // set the outline thickness for readability.
       bitmap.outlineWidth = 4;
-      bitmap.outlineColor = "rgba(24, 24, 192, 1.0)";
-      value = Math.floor(this._j._actor.mp);
+
+      // set the blue-tinted outline color for MP.
+      bitmap.outlineColor = 'rgba(24, 24, 192, 1.0)';
+
+      // display rounded MP to align with fractional accumulation.
+      value = Math.round(this._j._actor.mp);
+
+      // end case.
       break;
-    case "tp":
+    }
+    case 'tp':
+    {
+      // set the outline thickness for readability.
       bitmap.outlineWidth = 2;
-      bitmap.outlineColor = "rgba(64, 128, 64, 1.0)";
-      value = Math.floor(this._j._actor.tp);
+
+      // set the green-tinted outline color for TP.
+      bitmap.outlineColor = 'rgba(64, 128, 64, 1.0)';
+
+      // TP can change in non-integers under JABS; display rounded for consistency.
+      value = Math.round(this._j._actor.tp);
+
+      // end case.
       break;
-    case "time":
+    }
+    case 'time':
+    {
+      // set the outline thickness for readability.
       bitmap.outlineWidth = 4;
-      bitmap.outlineColor = "rgba(72, 72, 72, 1.0)";
+
+      // set the neutral outline for XP remaining.
+      bitmap.outlineColor = 'rgba(72, 72, 72, 1.0)';
+
+      // compute exp remaining to next level.
       const curExp = (this._j._actor.nextLevelExp() - this._j._actor.currentLevelExp());
+
+      // compute progress into the current level.
       const nextLv = (this._j._actor.currentExp() - this._j._actor.currentLevelExp());
+
+      // calculate the remaining exp as a whole number.
       value = curExp - nextLv;
+
+      // end case.
       break;
-    case "lvl":
+    }
+    case 'lvl':
+    {
+      // set the outline thickness for readability.
       bitmap.outlineWidth = 4;
-      bitmap.outlineColor = "rgba(72, 72, 72, 1.0)";
+
+      // set the neutral outline for level text.
+      bitmap.outlineColor = 'rgba(72, 72, 72, 1.0)';
+
+      // display the level as a 3-digit number.
       value = this._j._actor.level.padZero(3);
+
+      // end case.
       break;
+    }
   }
 
-  bitmap.drawText(value, 0, 0, bitmap.width, bitmap.height, "left");
+  // draw the value left-aligned across the bitmap.
+  bitmap.drawText(value, 0, 0, bitmap.width, bitmap.height, 'left');
+
+  // return the created bitmap.
   return bitmap;
 };
 

--- a/src/plugins/hud/ext/party/windows/Window_PartyFrame.js
+++ b/src/plugins/hud/ext/party/windows/Window_PartyFrame.js
@@ -12,29 +12,29 @@ class Window_PartyFrame
     /**
      * The type of gauge for hp.
      */
-    HP: "hp",
+    HP: 'hp',
 
     /**
      * The type of gauge for mp.
      */
-    MP: "mp",
+    MP: 'mp',
 
     /**
      * The type of gauge for tp.
      */
-    TP: "tp",
+    TP: 'tp',
 
     /**
      * The type of gauge for xp.
      * We borrow the "time" gauge for this, though.
      */
-    XP: "time",
+    XP: 'time',
 
     /**
      * Not actually a gauge, but does have an actorvalue representing
      * the actor's level.
      */
-    Level: "lvl"
+    Level: 'lvl'
   };
 
   /**
@@ -73,7 +73,7 @@ class Window_PartyFrame
   {
     /**
      * The cached collection of hud sprites.
-     * @type {Map<string, Sprite_Face|Sprite_MapGauge|Sprite_ActorValue|Sprite_Icon>}
+     * @type {Map<string, Sprite_Face|Sprite_MapGauge|Sprite_ActorValue|Sprite_Icon|Sprite_BaseText>}
      */
     this._hudSprites = new Map();
   }
@@ -280,7 +280,8 @@ class Window_PartyFrame
       Window_PartyFrame.gaugeTypes.HP,
       Window_PartyFrame.gaugeTypes.MP,
       Window_PartyFrame.gaugeTypes.TP,
-      Window_PartyFrame.gaugeTypes.XP ];
+      Window_PartyFrame.gaugeTypes.XP
+    ];
   }
 
   /**
@@ -606,6 +607,117 @@ class Window_PartyFrame
     return sprite;
   }
 
+  /**
+   * Creates or retrieves the combat icon sprite for the given actor.
+   * @param {Game_Actor} actor The actor this icon represents.
+   * @returns {Sprite_Icon} The combat icon sprite.
+   */
+  getOrCreateCombatIcon(actor)
+  {
+    // create a unique cache key for the icon.
+    const key = `combat-icon-${actor.name()}-${actor.actorId()}`;
+
+    // if cached already, return it.
+    if (this._hudSprites.has(key))
+    {
+      return this._hudSprites.get(key);
+    }
+
+    // in-combat icon index is two fists punching.
+    const iconIndex = 31;
+
+    // create the icon sprite.
+    const sprite = new Sprite_Icon(iconIndex);
+
+    // indicate we'll manage the opacity ourselves.
+    sprite.selfManageOpacity();
+
+    // cache and stage it.
+    this._hudSprites.set(key, sprite);
+    sprite.hide();
+    this.addChild(sprite);
+
+    // return the created sprite.
+    return sprite;
+  }
+
+  /**
+   * Creates or retrieves the combat timer sprite for the given actor.
+   * @param {Game_Actor} actor The actor this timer represents.
+   * @returns {Sprite_BaseText} The combat seconds text sprite.
+   */
+  getOrCreateCombatTimer(actor)
+  {
+    // create a unique cache key for the timer.
+    const key = `combat-timer-${actor.name()}-${actor.actorId()}`;
+
+    // if cached already, return it.
+    if (this._hudSprites.has(key))
+    {
+      return this._hudSprites.get(key);
+    }
+
+    // create a text sprite.
+    const sprite = new Sprite_BaseText('');
+
+    // configure the font for a small numeric readout (seconds, one decimal).
+    sprite.setFontFace($gameSystem.numberFontFace());
+    sprite.setFontSize($gameSystem.mainFontSize() - 10);
+    sprite.setAlignment(Sprite_BaseText.Alignments.Center);
+    sprite.setMinWidth(ImageManager.iconWidth);
+
+    // this sprite manages its own opacity (for fade out), so opt out of auto-managed opacity.
+    sprite.selfManageOpacity();
+
+    // start hidden until we actually show it in-combat.
+    sprite.hide();
+
+    // cache and stage it.
+    this._hudSprites.set(key, sprite);
+    this.addChild(sprite);
+
+    // return the created sprite.
+    return sprite;
+  }
+
+  /**
+   * Creates or retrieves the combat label sprite for the given actor.
+   * Shows a text blurb like "IN COMBAT" or "FREE" near the combat icon.
+   * @param {Game_Actor} actor The actor this label represents.
+   * @returns {Sprite_BaseText} The combat status label sprite.
+   */
+  getOrCreateCombatLabel(actor)
+  {
+    // create a unique cache key for the label.
+    const key = `combat-label-${actor.name()}-${actor.actorId()}`;
+
+    // if cached already, return it.
+    if (this._hudSprites.has(key))
+    {
+      return this._hudSprites.get(key);
+    }
+
+    // create a text sprite.
+    const sprite = new Sprite_BaseText('');
+
+    // configure the font for emphasis and readability.
+    sprite
+      .setFontFace($gameSystem.mainFontFace())
+      .setFontSize($gameSystem.mainFontSize() - 6)
+      .setAlignment(Sprite_BaseText.Alignments.Center)
+      .setBold(true)
+      .setItalics(true)
+      .setMinWidth(Math.round(ImageManager.iconWidth * 2.5))
+      .selfManageOpacity();
+
+    // cache and stage it.
+    this._hudSprites.set(key, sprite);
+    this.addChild(sprite);
+
+    // return the created sprite.
+    return sprite;
+  }
+
   //endregion caching
 
   /**
@@ -711,13 +823,20 @@ class Window_PartyFrame
   {
     this._hudSprites.forEach((sprite, _) =>
     {
+      // if the interference shouldn't be handled for this sprite, then don't.
+      if (this.canHandleSpriteInterference(sprite) === false) return;
+
       // if we are above 64, rapidly decrement by -15 until we get below 64.
       if (sprite.opacity > 64)
       {
         sprite.opacity -= 15;
-      }// if we are below 64, increment by +1 until we get to 64.
-      else if (sprite.opacity < 64) sprite.opacity += 1;
-    });
+      }
+      // if we are below 64, increment by +1 until we get to 64.
+      else if (sprite.opacity < 64)
+      {
+        sprite.opacity += 1;
+      }
+    }, this);
   }
 
   /**
@@ -727,13 +846,38 @@ class Window_PartyFrame
   {
     this._hudSprites.forEach((sprite, _) =>
     {
+      // if the interference shouldn't be handled for this sprite, then don't.
+      if (this.canHandleSpriteInterference(sprite) === false) return;
+
       // if we are below 255, rapidly increment by +15 until we get to 255.
       if (sprite.opacity < 255)
       {
         sprite.opacity += 15;
-      }// if we are above 255, set to 255.
-      else if (sprite.opacity > 255) sprite.opacity = 255;
-    });
+      }
+      // if we are above 255, set to 255.
+      else if (sprite.opacity > 255)
+      {
+        sprite.opacity = 255;
+      }
+    }, this);
+  }
+
+  /**
+   * Checks if the given sprite should be handled for interference.
+   * @param {Sprite_Face|Sprite_MapGauge|Sprite_ActorValue|Sprite_Icon|Sprite_BaseText} sprite
+   * @returns {boolean}
+   */
+  canHandleSpriteInterference(sprite)
+  {
+    // certain sprites can have self-managed opacity.
+    if (sprite instanceof Sprite_BaseText || sprite instanceof Sprite_Icon)
+    {
+      // if they have self-managed opacity, they shouldn't be handled.
+      if (sprite.hasSelfManagedOpacity() === true) return false;
+    }
+
+    // let the system handle the opacity management.
+    return true;
   }
 
   //endregion visibility
@@ -767,6 +911,9 @@ class Window_PartyFrame
     const statesX = gaugesX;
     const statesY = gaugesY - (ImageManager.iconHeight * 2) - 24;
     this.drawStates(statesX, statesY);
+
+    // draw the in‑combat indicator (icon + timer) just to the right of the gauges.
+    this.drawLeaderCombatIndicator(gaugesX, gaugesY);
   }
 
   /**
@@ -895,6 +1042,108 @@ class Window_PartyFrame
   }
 
   /**
+   * Draws the leader's "in‑combat" indicator to the right of the gauges.
+   * @param {number} gaugesX The x coordinate where gauges start.
+   * @param {number} gaugesY The y coordinate where gauges start.
+   */
+  drawLeaderCombatIndicator(gaugesX, gaugesY)
+  {
+    // grab the leader and their tracked battler.
+    const leader = $gameParty.leader();
+    const leaderBattler = $gameParty.leaderJabsBattler();
+
+    // if we cannot resolve the tracked battler, don't draw.
+    if (!leader || !leaderBattler) return;
+
+    // decide visibility based on the combat rules.
+    const inCombat = ($jabsEngine.forcedCombat === true) || leaderBattler.isInCombat();
+
+    // grab the hp gauge sprite for width math (hp/mp/tp share the same width).
+
+    // fetch or create the three sprites we need.
+    const icon = this.getOrCreateCombatIcon(leader);
+    const timer = this.getOrCreateCombatTimer(leader);
+    const label = this.getOrCreateCombatLabel(leader);
+
+    // determine anchor coordinates to the immediate right of the gauges.
+    const hpGauge = this.getOrCreateFullSizeGaugeSprite(leader, Window_PartyFrame.gaugeTypes.HP);
+    const iconX = (gaugesX - 24) + hpGauge.bitmapWidth() + 8;
+    const iconY = gaugesY; // align with the HP row.
+    icon.move(iconX, iconY);
+
+    // move the timer to be centered below the icon.
+    const timerWidth = timer.bitmap
+      ? timer.bitmap.width
+      : ImageManager.iconWidth;
+    const timerX = iconX + Math.floor((ImageManager.iconWidth - timerWidth) / 2);
+    const timerY = iconY + ImageManager.iconHeight - 6;
+    timer.move(timerX, timerY);
+
+    // move the label to be centered above the icon.
+    const labelX = iconX - Math.floor((label.bitmap.width - ImageManager.iconWidth) / 2);
+    const labelY = iconY - label.bitmap.height;
+    label.move(labelX, labelY);
+
+    // configure a per‑frame fade step for ~0.5 seconds at 60fps.
+    const fadeStep = 9; // 255 / 30 ≈ 8.5 → 9
+
+    // we only branch once on inCombat for all three sprites.
+    if (inCombat)
+    {
+      // icon: snap visible and fully opaque while in combat.
+      icon.visible = true;
+      icon.opacity = 255;
+
+      // timer: update text, show, fully opaque.
+      const seconds = leaderBattler.getCombatSecondsRemaining();
+      const secondsText = Number(seconds)
+        .toFixed(1);
+      timer.setText(secondsText);
+      timer.show();
+      timer.opacity = 255;
+
+      // label: red "IN COMBAT" above the icon.
+      label.setColor('#ff3b3b');
+      label.setText('IN COMBAT');
+      label.show();
+      label.opacity = 255;
+    }
+    else
+    {
+      // not in combat: fade the icon and timer out over ~0.5s, then hide.
+
+      // icon fade.
+      if (icon.opacity > 0)
+      {
+        icon.opacity = Math.max(0, icon.opacity - fadeStep);
+        icon.visible = true;
+        if (icon.opacity === 0) icon.visible = false;
+      }
+      else
+      {
+        icon.visible = false;
+      }
+
+      // timer fade.
+      if (timer.opacity > 0)
+      {
+        timer.opacity = Math.max(0, timer.opacity - fadeStep);
+        if (timer.opacity === 0) timer.hide();
+      }
+      else
+      {
+        timer.hide();
+      }
+
+      // label: instant green "FREE" for strong visual contrast when idle.
+      label.setColor('#44ff66');
+      label.setText('FREE');
+      label.show();
+      label.opacity = 255;
+    }
+  }
+
+  /**
    * Hides all expired states on the leader.
    * @param {Game_Actor} leader The actor to hide states for.
    */
@@ -958,7 +1207,7 @@ class Window_PartyFrame
 
     this.drawText(`x${trackedState.stackCount}`, ox, y - 30, 64, Window_Base.TextAlignments.Left);
 
-    this.resetFontSettings()
+    this.resetFontSettings();
   }
 
   /**

--- a/src/plugins/jafting/ext/create/_metadata/_annotations.js
+++ b/src/plugins/jafting/ext/create/_metadata/_annotations.js
@@ -2,7 +2,7 @@
 /*:
  * @target MZ
  * @plugindesc
- * [v1.0.1 JAFT-Create] An extension for JAFTING to enable recipe creation.
+ * [v1.0.2 JAFT-Create] An extension for JAFTING to enable recipe creation.
  * @author JE
  * @url https://github.com/je-can-code/rmmz-plugins
  * @base J-Base
@@ -134,6 +134,8 @@
  *
  * ============================================================================
  * CHANGELOG:
+ * - 1.0.2
+ *    Added flag for showing external file load info.
  * - 1.0.1
  *    Recipes & Categories can now be updated for existing save files.
  * - 1.0.0

--- a/src/plugins/jafting/ext/create/_metadata/_pluginMetadata.js
+++ b/src/plugins/jafting/ext/create/_metadata/_pluginMetadata.js
@@ -183,7 +183,7 @@ class J_CraftingCreatePluginMetadata
      */
     this.categoriesMap = categoriesMap;
 
-    if (this.#hasMinimumBaseVersion() && J.BASE.Metadata.ShowExternalFileLoadInfo)
+    if (J_CraftingCreatePluginMetadata.#hasMinimumBaseVersion() && J.BASE.Metadata.ShowExternalFileLoadInfo)
     {
       console.log(`loaded:
       - ${this.recipes.length} recipes
@@ -289,7 +289,7 @@ class J_CraftingCreatePluginMetadata
    * Checks if the BASE plugin meets the minimum version requirement for this plugin.
    * @return {boolean}
    */
-  #hasMinimumBaseVersion()
+  static #hasMinimumBaseVersion()
   {
     // identify the two versions for comparison.
     const minimumVersion = this.#minimumBaseVersion();
@@ -309,7 +309,7 @@ class J_CraftingCreatePluginMetadata
    * Gets the current minimum version of the J-BASE system this plugin requires.
    * @returns {PluginVersion}
    */
-  #minimumBaseVersion()
+  static #minimumBaseVersion()
   {
     return PluginVersion.builder
       .major('2')

--- a/src/plugins/jafting/ext/create/_metadata/_pluginMetadata.js
+++ b/src/plugins/jafting/ext/create/_metadata/_pluginMetadata.js
@@ -72,7 +72,8 @@ class J_CraftingCreatePluginMetadata
         mappableRecipe.maskedUntilCrafted,
         parsedIngredients,
         parsedTools,
-        parsedOutputs);
+        parsedOutputs
+      );
 
       return newJaftingRecipe;
     };
@@ -101,7 +102,7 @@ class J_CraftingCreatePluginMetadata
         unlockedByDefault
       } = mappableCategory;
       const newCategory = new CraftingCategory(name, key, iconIndex, description, unlockedByDefault);
-      return newCategory
+      return newCategory;
     };
 
     // iterate over each category to classify the data.
@@ -182,10 +183,17 @@ class J_CraftingCreatePluginMetadata
      */
     this.categoriesMap = categoriesMap;
 
-    console.log(`loaded:
+    if (this.#hasMinimumBaseVersion() && J.BASE.Metadata.ShowExternalFileLoadInfo)
+    {
+      console.log(`loaded:
       - ${this.recipes.length} recipes
       - ${this.categories.length} categories
       from file ${J_CraftingCreatePluginMetadata.CONFIG_PATH}.`);
+    }
+    else
+    {
+      console.log(`loaded from file ${J_CraftingCreatePluginMetadata.CONFIG_PATH}.`);
+    }
   }
 
   /**
@@ -274,6 +282,39 @@ class J_CraftingCreatePluginMetadata
       .major('2')
       .minor('0')
       .patch('0')
+      .build();
+  }
+
+  /**
+   * Checks if the BASE plugin meets the minimum version requirement for this plugin.
+   * @return {boolean}
+   */
+  #hasMinimumBaseVersion()
+  {
+    // identify the two versions for comparison.
+    const minimumVersion = this.#minimumBaseVersion();
+    const actualVersion = new PluginVersion(J.BASE.Metadata.Version);
+
+    // check if we meet the minimum version threshold.
+    const meetsThreshold = actualVersion.satisfiesPluginVersion(minimumVersion);
+
+    // if the version isn't high enough, then we cannot proceed.
+    if (!meetsThreshold) return false;
+
+    // we're good!
+    return true;
+  }
+
+  /**
+   * Gets the current minimum version of the J-BASE system this plugin requires.
+   * @returns {PluginVersion}
+   */
+  #minimumBaseVersion()
+  {
+    return PluginVersion.builder
+      .major('2')
+      .minor('3')
+      .patch('1')
       .build();
   }
 }

--- a/src/plugins/jafting/ext/create/_metadata/initialization.js
+++ b/src/plugins/jafting/ext/create/_metadata/initialization.js
@@ -17,7 +17,7 @@ J.JAFTING.EXT.CREATE = {};
 /**
  * The metadata associated with this plugin.
  */
-J.JAFTING.EXT.CREATE.Metadata = new J_CraftingCreatePluginMetadata('J-JAFTING-Creation', '1.0.0');
+J.JAFTING.EXT.CREATE.Metadata = new J_CraftingCreatePluginMetadata('J-JAFTING-Creation', '1.0.2');
 
 /**
  * A collection of all aliased methods for this plugin.

--- a/src/plugins/omni/ext/quest/_metadata/_annotations.js
+++ b/src/plugins/omni/ext/quest/_metadata/_annotations.js
@@ -2,14 +2,15 @@
 /*:
  * @target MZ
  * @plugindesc
- * [v1.0.2 OMNI-QUEST] Extends the Omnipedia with a Questopedia entry.
+ * [v1.0.3 OMNI-QUEST] Extends the Omnipedia with a Questopedia entry.
  * @author JE
  * @url https://github.com/je-can-code/rmmz-plugins
  * @base J-Base
  * @base J-Omnipedia
  * @orderAfter J-Base
- * @orderAfter J-MessageTextCodes
  * @orderAfter J-Omnipedia
+ * @orderAfter J-HUD
+ * @orderAfter J-MessageTextCodes
  * @help
  * ============================================================================
  * OVERVIEW
@@ -94,6 +95,9 @@
  *
  * ============================================================================
  * CHANGELOG:
+ * - 1.0.3
+ *    Updated to accommodate for mapping shortcut to view quest log.
+ *    Added flag for showing external file load info.
  * - 1.0.2
  *    Adapted for updates to J-ABS-InputManager (input namespace).
  * - 1.0.1

--- a/src/plugins/omni/ext/quest/_metadata/_pluginMetadata.js
+++ b/src/plugins/omni/ext/quest/_metadata/_pluginMetadata.js
@@ -25,9 +25,9 @@ class J_QUEST_PluginMetadata
     {
       // validate the name is not one of the organizational names for the editor-only.
       const questName = parsedQuest.name;
-      if (questName.startsWith("__")) return;
-      if (questName.startsWith("==")) return;
-      if (questName.startsWith("--")) return;
+      if (questName.startsWith('__')) return;
+      if (questName.startsWith('==')) return;
+      if (questName.startsWith('--')) return;
 
       const builtQuest = OmniQuest.Builder()
         .name(parsedQuest.name)
@@ -40,7 +40,7 @@ class J_QUEST_PluginMetadata
         .objectives(parsedQuest.objectives)
         .build();
 
-      parsedQuests.push(builtQuest)
+      parsedQuests.push(builtQuest);
     };
 
     parsedBlob.forEach(foreacher, this);
@@ -123,11 +123,18 @@ class J_QUEST_PluginMetadata
      */
     this.tagsMap = tagMap;
 
-    console.log(`loaded:
-      - ${this.quests.length} quests
-      - ${this.categories.length} categories
-      - ${this.tags.length} tags
-      from file ${J_QUEST_PluginMetadata.CONFIG_PATH}.`);
+    if (this.#hasMinimumBaseVersion() && J.BASE.Metadata.ShowExternalFileLoadInfo)
+    {
+      console.log(`loaded:
+        - ${this.quests.length} quests
+        - ${this.categories.length} categories
+        - ${this.tags.length} tags
+        from file ${J_QUEST_PluginMetadata.CONFIG_PATH}.`);
+    }
+    else
+    {
+      console.log(`loaded from file ${J_QUEST_PluginMetadata.CONFIG_PATH}.`);
+    }
   }
 
   /**
@@ -154,18 +161,51 @@ class J_QUEST_PluginMetadata
       /**
        * The name of the command when viewed from the Omnipedia.
        */
-      Name: "Questopedia",
+      Name: 'Questopedia',
 
       /**
        * The symbol of the command in the command list.
        */
-      Symbol: "quest-pedia",
+      Symbol: 'quest-pedia',
 
       /**
        * The icon for the command anywhere it is viewed.
        */
       IconIndex: 2564,
     };
+  }
+
+  /**
+   * Checks if the BASE plugin meets the minimum version requirement for this plugin.
+   * @return {boolean}
+   */
+  #hasMinimumBaseVersion()
+  {
+    // identify the two versions for comparison.
+    const minimumVersion = this.#minimumBaseVersion();
+    const actualVersion = new PluginVersion(J.BASE.Metadata.Version);
+
+    // check if we meet the minimum version threshold.
+    const meetsThreshold = actualVersion.satisfiesPluginVersion(minimumVersion);
+
+    // if the version isn't high enough, then we cannot proceed.
+    if (!meetsThreshold) return false;
+
+    // we're good!
+    return true;
+  }
+
+  /**
+   * Gets the current minimum version of the J-BASE system this plugin requires.
+   * @returns {PluginVersion}
+   */
+  #minimumBaseVersion()
+  {
+    return PluginVersion.builder
+      .major('2')
+      .minor('3')
+      .patch('1')
+      .build();
   }
 }
 

--- a/src/plugins/omni/ext/quest/_metadata/_pluginMetadata.js
+++ b/src/plugins/omni/ext/quest/_metadata/_pluginMetadata.js
@@ -123,7 +123,7 @@ class J_QUEST_PluginMetadata
      */
     this.tagsMap = tagMap;
 
-    if (this.#hasMinimumBaseVersion() && J.BASE.Metadata.ShowExternalFileLoadInfo)
+    if (J_QUEST_PluginMetadata.#hasMinimumBaseVersion() && J.BASE.Metadata.ShowExternalFileLoadInfo)
     {
       console.log(`loaded:
         - ${this.quests.length} quests
@@ -179,7 +179,7 @@ class J_QUEST_PluginMetadata
    * Checks if the BASE plugin meets the minimum version requirement for this plugin.
    * @return {boolean}
    */
-  #hasMinimumBaseVersion()
+  static #hasMinimumBaseVersion()
   {
     // identify the two versions for comparison.
     const minimumVersion = this.#minimumBaseVersion();
@@ -199,7 +199,7 @@ class J_QUEST_PluginMetadata
    * Gets the current minimum version of the J-BASE system this plugin requires.
    * @returns {PluginVersion}
    */
-  #minimumBaseVersion()
+  static #minimumBaseVersion()
   {
     return PluginVersion.builder
       .major('2')

--- a/src/plugins/omni/ext/quest/_metadata/initialization.js
+++ b/src/plugins/omni/ext/quest/_metadata/initialization.js
@@ -18,7 +18,7 @@ J.OMNI.EXT.QUEST = {};
 /**
  * The metadata associated with this plugin.
  */
-J.OMNI.EXT.QUEST.Metadata = new J_QUEST_PluginMetadata('J-Omni-Questopedia', '1.0.2');
+J.OMNI.EXT.QUEST.Metadata = new J_QUEST_PluginMetadata('J-Omni-Questopedia', '1.0.3');
 
 /**
  * A collection of all aliased methods for this plugin.

--- a/src/plugins/prof/_metadata/_annotations.js
+++ b/src/plugins/prof/_metadata/_annotations.js
@@ -2,7 +2,7 @@
 /*:
  * @target MZ
  * @plugindesc
- * [v2.0.0 PROF] Enables skill proficiency tracking.
+ * [v2.0.1 PROF] Enables skill proficiency tracking.
  * @author JE
  * @url https://github.com/je-can-code/rmmz-plugins
  * @base J-Base
@@ -147,6 +147,9 @@
  * - Decreasing the proficiency will NOT undo rewards gained.
  * ============================================================================
  * CHANGELOG:
+ * - 2.0.1
+ *    Added flag for showing external file load info.
+ *    Removed dead plugin parameters for conditionals.
  * - 2.0.0
  *    THIS UPDATE BREAKS WEB DEPLOY FUNCTIONALITY FOR YOUR GAME.
  *    Updated to extend common plugin metadata patterns.
@@ -156,12 +159,6 @@
  * - 1.0.0
  *    The initial release.
  * ============================================================================
- * @param conditionals
- * @type struct<ProficiencyConditionalStruct>[]
- * @text Proficiency Conditionals
- * @desc A set of conditions that when met reward the player.
- * @default []
- *
  * @command modifyActorSkillProficiency
  * @text Modify Actor's Proficiency
  * @desc Increase/decrease one or more actor's proficiency with one or more skills.

--- a/src/plugins/prof/_metadata/_pluginMetadata.js
+++ b/src/plugins/prof/_metadata/_pluginMetadata.js
@@ -21,14 +21,16 @@ class J_ProficiencyPluginMetadata
         .map(requirement => new ProficiencyRequirement(
           requirement.skillId,
           requirement.proficiency,
-          requirement.secondarySkillIds));
+          requirement.secondarySkillIds
+        ));
 
       return new ProficiencyConditional(
         conditional.key,
         conditional.actorIds,
         requirements,
         conditional.skillRewards,
-        conditional.jsRewards);
+        conditional.jsRewards
+      );
     });
   }
 
@@ -85,11 +87,18 @@ class J_ProficiencyPluginMetadata
         data.push(conditional);
         this.actorConditionalsMap.set(actorId, data);
       });
-    })
+    });
 
-    console.log(`loaded:
+    if (J.BASE.Metadata.ShowExternalFileLoadInfo)
+    {
+      console.log(`loaded:
       - ${this.conditionals.length} proficiency conditionals
       from file ${J_ProficiencyPluginMetadata.CONFIG_PATH}.`);
+    }
+    else
+    {
+      console.log(`loaded from file ${J_ProficiencyPluginMetadata.CONFIG_PATH}.`);
+    }
   }
 }
 

--- a/src/plugins/prof/_metadata/initialization.js
+++ b/src/plugins/prof/_metadata/initialization.js
@@ -12,7 +12,7 @@ J.PROF = {};
  * The metadata associated with this plugin.
  * @type {J_ProficiencyPluginMetadata}
  */
-J.PROF.Metadata = new J_ProficiencyPluginMetadata('J-Proficiency', '2.0.0');
+J.PROF.Metadata = new J_ProficiencyPluginMetadata('J-Proficiency', '2.0.1');
 
 /**
  * The various aliases associated with this plugin.

--- a/src/plugins/sdp/_metadata/_annotations.js
+++ b/src/plugins/sdp/_metadata/_annotations.js
@@ -3,7 +3,7 @@
 /*:
  * @target MZ
  * @plugindesc
- * [v2.1.0 SDP] Enables the SDP system, aka Stat Distribution Panels.
+ * [v2.1.1 SDP] Enables the SDP system, aka Stat Distribution Panels.
  * @author JE
  * @url https://github.com/je-can-code/rmmz-plugins
  * @base J-Base
@@ -197,6 +197,8 @@
  *
  * ============================================================================
  * CHANGELOG:
+ * - 2.1.1
+ *    Added flag for showing external file load info.
  * - 2.1.0
  *    Removed association of SDPs being backed by actual database items.
  *    Implemented JABS-centric basis for dynamically generating drops.

--- a/src/plugins/sdp/_metadata/_pluginMetadata.js
+++ b/src/plugins/sdp/_metadata/_pluginMetadata.js
@@ -143,7 +143,7 @@ class J_SdpPluginMetadata
      */
     this.panelsMap = panelMap;
 
-    if (this.#hasMinimumBaseVersion() && J.BASE.Metadata.ShowExternalFileLoadInfo)
+    if (J_SdpPluginMetadata.#hasMinimumBaseVersion() && J.BASE.Metadata.ShowExternalFileLoadInfo)
     {
       console.log(`loaded:
       - ${this.panels.length} panels
@@ -203,7 +203,7 @@ class J_SdpPluginMetadata
    * Checks if the BASE plugin meets the minimum version requirement for this plugin.
    * @return {boolean}
    */
-  #hasMinimumBaseVersion()
+  static #hasMinimumBaseVersion()
   {
     // identify the two versions for comparison.
     const minimumVersion = this.#minimumBaseVersion();
@@ -223,7 +223,7 @@ class J_SdpPluginMetadata
    * Gets the current minimum version of the J-BASE system this plugin requires.
    * @returns {PluginVersion}
    */
-  #minimumBaseVersion()
+  static #minimumBaseVersion()
   {
     return PluginVersion.builder
       .major('2')

--- a/src/plugins/sdp/_metadata/_pluginMetadata.js
+++ b/src/plugins/sdp/_metadata/_pluginMetadata.js
@@ -21,9 +21,9 @@ class J_SdpPluginMetadata
     {
       // validate the name is not one of the organizational names for the editor-only.
       const panelName = parsedPanel.name;
-      if (panelName.startsWith("__")) return;
-      if (panelName.startsWith("==")) return;
-      if (panelName.startsWith("--")) return;
+      if (panelName.startsWith('__')) return;
+      if (panelName.startsWith('==')) return;
+      if (panelName.startsWith('--')) return;
 
       // destructure the details we care about.
       const {
@@ -40,7 +40,8 @@ class J_SdpPluginMetadata
           parseInt(parsedParameter.parameterId),
           parseFloat(parsedParameter.perRank),
           parsedParameter.isFlat,
-          parsedParameter.isCore);
+          parsedParameter.isCore
+        );
         parsedPanelParameters.push(panelParameter);
       });
 
@@ -54,7 +55,8 @@ class J_SdpPluginMetadata
           const panelReward = new PanelRankupReward(
             parsedReward.rewardName,
             parseInt(parsedReward.rankRequired),
-            parsedReward.effect);
+            parsedReward.effect
+          );
           parsedPanelRewards.push(panelReward);
         });
       }
@@ -77,7 +79,7 @@ class J_SdpPluginMetadata
         .build();
 
       parsedPanels.push(panel);
-    }
+    };
 
     // build an SDP from each parsed item provided.
     parsedBlob.forEach(foreacher, this);
@@ -141,9 +143,16 @@ class J_SdpPluginMetadata
      */
     this.panelsMap = panelMap;
 
-    console.log(`loaded:
+    if (this.#hasMinimumBaseVersion() && J.BASE.Metadata.ShowExternalFileLoadInfo)
+    {
+      console.log(`loaded:
       - ${this.panels.length} panels
       from file ${J_SdpPluginMetadata.CONFIG_PATH}.`);
+    }
+    else
+    {
+      console.log(`loaded from file ${J_SdpPluginMetadata.CONFIG_PATH}.`);
+    }
   }
 
   initializeMetadata()
@@ -187,7 +196,40 @@ class J_SdpPluginMetadata
      * Both menus are shown/hidden by the menu switch id.
      * @type {boolean}
      */
-    this.jabsShowInBothMenus = this.parsedPluginParameters['showInBoth'] === "true";
+    this.jabsShowInBothMenus = this.parsedPluginParameters['showInBoth'] === 'true';
+  }
+
+  /**
+   * Checks if the BASE plugin meets the minimum version requirement for this plugin.
+   * @return {boolean}
+   */
+  #hasMinimumBaseVersion()
+  {
+    // identify the two versions for comparison.
+    const minimumVersion = this.#minimumBaseVersion();
+    const actualVersion = new PluginVersion(J.BASE.Metadata.Version);
+
+    // check if we meet the minimum version threshold.
+    const meetsThreshold = actualVersion.satisfiesPluginVersion(minimumVersion);
+
+    // if the version isn't high enough, then we cannot proceed.
+    if (!meetsThreshold) return false;
+
+    // we're good!
+    return true;
+  }
+
+  /**
+   * Gets the current minimum version of the J-BASE system this plugin requires.
+   * @returns {PluginVersion}
+   */
+  #minimumBaseVersion()
+  {
+    return PluginVersion.builder
+      .major('2')
+      .minor('3')
+      .patch('1')
+      .build();
   }
 }
 

--- a/src/plugins/sdp/_metadata/initialization.js
+++ b/src/plugins/sdp/_metadata/initialization.js
@@ -3,19 +3,6 @@
  */
 var J = J || {};
 
-//region version checks
-(() =>
-{
-  // Check to ensure we have the minimum required version of the J-Base plugin.
-  const requiredBaseVersion = '2.1.3';
-  const hasBaseRequirement = J.BASE.Helpers.satisfies(J.BASE.Metadata.Version, requiredBaseVersion);
-  if (!hasBaseRequirement)
-  {
-    throw new Error(`Either missing J-Base or has a lower version than the required: ${requiredBaseVersion}`);
-  }
-})();
-//endregion version check
-
 /**
  * The plugin umbrella that governs all things related to this plugin.
  */
@@ -24,7 +11,7 @@ J.SDP = {};
 /**
  * The metadata associated with this plugin.
  */
-J.SDP.Metadata = new J_SdpPluginMetadata('J-SDP', '2.1.0');
+J.SDP.Metadata = new J_SdpPluginMetadata('J-SDP', '2.1.1');
 
 /**
  * A collection of all aliased methods for this plugin.

--- a/src/plugins/utils/_metadata/_annotations.js
+++ b/src/plugins/utils/_metadata/_annotations.js
@@ -1,7 +1,7 @@
 /*:
  * @target MZ
  * @plugindesc
- * [v1.1.0 UTIL] Various system utilities.
+ * [v1.1.1 UTIL] Various system utilities.
  * @author JE
  * @url https://github.com/je-can-code/rmmz-plugins
  * @base J-Base
@@ -17,6 +17,8 @@
  * - pull up devtools window in background upon testplay (always).
  * ============================================================================
  * CHANGELOG:
+ * - 1.1.1
+ *    Added debugger for gamepad inputs.
  * - 1.1.0
  *    Implements strongly-typed plugin metadata.
  *    Added "pull up devtools upon testplay" functionality.

--- a/src/plugins/utils/_metadata/initialization.js
+++ b/src/plugins/utils/_metadata/initialization.js
@@ -11,7 +11,7 @@ J.UTILS = {};
 /**
  * The metadata associated with this plugin, such as name and version.
  */
-J.UTILS.Metadata = new J_UtilsPluginMetadata('J-SystemUtilities', '1.0.1');
+J.UTILS.Metadata = new J_UtilsPluginMetadata('J-SystemUtilities', '1.1.1');
 
 /**
  * A collection of all aliased methods for this plugin.
@@ -19,6 +19,7 @@ J.UTILS.Metadata = new J_UtilsPluginMetadata('J-SystemUtilities', '1.0.1');
 J.UTILS.Aliased = {
   Game_Actor: new Map(),
   Game_Temp: new Map(),
+  Input: new Map(),
   Scene_Base: new Map(),
   Scene_Boot: new Map(),
   Scene_Map: new Map(),
@@ -38,9 +39,99 @@ J.UTILS.Helpers = {};
  * @param {any} o The object to check.
  * @returns {number} Chances are if this returns a number you're fine, otherwise it'll hang.
  */
+/* eslint-disable indent */
 J.UTILS.Helpers.depth = (o) => Object(o) === o
   ? 1 + Math.max(
   -1,
   ...Object.values(o)
-    .map(J.UTILS.Helpers.depth))
+    .map(J.UTILS.Helpers.depth)
+)
   : 0;
+/* eslint-enable indent */
+
+//region gamepad logging
+// create the lightweight gamepad logging namespace.
+J.UTILS.GamepadLog ||= {};
+
+// whether or not logging is enabled (opt-in).
+J.UTILS.GamepadLog.enabled = J.UTILS.GamepadLog.enabled || false;
+
+/**
+ * Enables console logging of fresh gamepad presses.
+ */
+J.UTILS.GamepadLog.enable = function()
+{
+  // mark logging as enabled.
+  this.enabled = true;
+
+  // inform the console that logging is now active.
+  console.log('[InputLog] Enabled.');
+};
+
+/**
+ * Disables console logging of fresh gamepad presses.
+ */
+J.UTILS.GamepadLog.disable = function()
+{
+  // mark logging as disabled.
+  this.enabled = false;
+
+  // inform the console that logging is now inactive.
+  console.log('[InputLog] Disabled.');
+};
+
+/**
+ * Logs only newly-pressed physical inputs resolved through Input.gamepadMapper.
+ * Uses centralized symbols from J.ABS.EXT.INPUT when available.
+ * @param {Gamepad} pad The active gamepad instance.
+ * @param {boolean[]} prev The previous button-state array (by index).
+ * @param {boolean[]} next The new button-state array (by index).
+ */
+J.UTILS.GamepadLog.logFreshPresses = function(pad, prev, next)
+{
+  // do not process if disabled.
+  if (this.enabled === false)
+  {
+    return;
+  }
+
+  // collect mapped symbols that transitioned from false -> true.
+  const symbols = [];
+
+  // iterate over the next-state buttons.
+  for (let i = 0; i < next.length; i++)
+  {
+    // determine current and previous pressed states.
+    const now = next[i] === true;
+    const was = prev[i] === true;
+
+    // only emit fresh presses.
+    if (now && was === false)
+    {
+      // resolve the physical symbol via the centralized mapper.
+      const mapped = Input.gamepadMapper[i];
+
+      // only log if the index is mapped to a known symbol.
+      if (mapped)
+      {
+        // add the resolved symbol to the list.
+        symbols.push(mapped);
+      }
+    }
+  }
+
+  // skip logging when there are no fresh presses.
+  if (symbols.length === 0)
+  {
+    return;
+  }
+
+  // build a concise pad label.
+  const label = pad.id
+    ? `${pad.id} (Index ${pad.index})`
+    : `Gamepad ${pad.index}`;
+
+  // emit a single consolidated log for this frame.
+  console.log(`[InputLog] ${label} pressed:`, symbols.join(', '));
+};
+//endregion gamepad logging

--- a/src/plugins/utils/managers/Input.js
+++ b/src/plugins/utils/managers/Input.js
@@ -9,4 +9,24 @@ Input.keyMapper = {
   // F6, the volume toggle key.
   117: 'volumeToggle',
 };
+
+/**
+ * Extends/Overrides {@link #_updateGamepadState}.<br/>
+ * Also logs only freshly pressed gamepad buttons/directions.
+ */
+J.UTILS.Aliased.Input.set("_updateGamepadState", Input._updateGamepadState);
+Input._updateGamepadState = function(gamepad)
+{
+  // capture the last known button state array for this pad.
+  const prev = this._gamepadStates[gamepad.index] || [];
+
+  // perform the original update to refresh internal states.
+  J.UTILS.Aliased.Input.get("_updateGamepadState").call(this, gamepad);
+
+  // extract the updated button state array populated by the original logic.
+  const next = this._gamepadStates[gamepad.index] || [];
+
+  // log only fresh presses resolved through the centralized mapper.
+  J.UTILS.GamepadLog.logFreshPresses(gamepad, prev, next);
+};
 //endregion Input


### PR DESCRIPTION
- Implements an update for JABS to recognize being "in combat" outside of the standard "engaged" tracking.
- Updates JABS to replace the "sprint" functionality with the "mobility skill" while "in combat".
- Adds "on cast animation" tag for skills that executes once a skill is done casting.