### PR TITLE
feature: aptitude system

### DIFF
--- a/.junie/guidelines.md
+++ b/.junie/guidelines.md
@@ -9,9 +9,12 @@
 ## Primary Directives
 
 * **NEVER** use terminal commands like `cat`, `sed`, `grep`, `awk`, `head`, or `tail` to read or search file contents.
-* To read or examine file contents, you **MUST** use the provided internal tools (like `open`, `open_entire_file`, `get_file_structure`, or `search_project`) to bring the file data directly into your context.
+* To read or examine file contents, you **MUST** use the provided internal tools (like `open`, `open_entire_file`,
+  `get_file_structure`, or `search_project`) to bring the file data directly into your context.
 * You should NEVER write to the filesystem, ever. I will choose what files to add and what to add to them.
-* Prefer your own internal tools over various terminal commands for parsing/searching code (ex: open_file instead of cat).
+* Prefer your own internal tools over various terminal commands for parsing/searching code (ex: open_file instead of
+  cat).
+* Before presenting code drop-ins, make sure you've established a full implementation plan in phases.
 
 ---
 
@@ -20,113 +23,168 @@
 * This codebase is a monorepo of plugins for the RPG Maker MZ (often called RMMZ) engine.
 * All code responses should use the same coding style and formatting as exists across the codebase.
 * There are zero automated tests in this codebase, not for lack of want but low priority.
-* When providing code samples, provide full-method drop-in replacements including the updated logic, and specify the file, path, and line the method starts on for clarity- this is a huge codebase.
-* This project does not support modules, we purely use prototypes and sequential ordering of code, but can use whatever a browser/nodejs may have available in 2025.
-  * Do not use import/export in files under `/src/plugins/**`.
-  * `import`/`export` may be used in `/src/build-tools` and `/src/defs` if already present in the repo’s patterns.
-* This project does not use IIFEs, instead we leverage object-driven namespacing (such as `J.ABS.EXT.SHIELD` etc) and aliasing.
-* Do not use ternary operators with `typeof something` to check if functions or properties exist- instead just open the file and review what the actual functions are.
-  * If a function or property is missing- but necessary- provide implementation for them if nothing else satisfies the need (such as a function or property with a different name that accomplishes the same thing).
+* When providing code samples, provide full-method drop-in replacements including the updated logic, and specify the
+  file, path, and line the method starts on for clarity- this is a huge codebase.
+* This project does not support modules, we purely use prototypes and sequential ordering of code, but can use whatever
+  a browser/nodejs may have available in 2025.
+    * Do not use import/export in files under `/src/plugins/**`.
+    * `import`/`export` may be used in `/src/build-tools` and `/src/defs` if already present in the repo’s patterns.
+* This project does not use IIFEs, instead we leverage object-driven namespacing (such as `J.ABS.EXT.SHIELD` etc) and
+  aliasing.
+* Do not use ternary operators with `typeof something` to check if functions or properties exist- instead just open the
+  file and review what the actual functions are.
+    * If a function or property is missing- but necessary- provide implementation for them if nothing else satisfies the
+      need (such as a function or property with a different name that accomplishes the same thing).
 * Never add arbitrary nested blocks that violate that violate eslint "no-lone-blocks" rule.
+* Any time you're about tell me "make sure this exists somewhere..." or "ensure you implement this...", instead go look
+  around and see if it exists or is already implemented, or warn me that its not if its not anywhere.
+* It is forbidden to include anything that would or should live in "initialization.js" inside of any of the other source
+  files (such as alias map instantiation- assume it exists, and provide that update to the initialization.js file).
 
 ## DRY and Complexity
+
 - Target cyclomatic complexity ≤ 20 for all methods. If a method risks exceeding 20, prefer extracting private helpers.
 - Avoid pasting duplicate code blocks longer than ~8 lines. Extract a helper and call it instead.
 - Prefer data-driven rendering (build arrays and iterate) over repeated if-blocks when drawing similar rows.
-- When two functions differ only by a small behavior (ex: rounding), implement one and have the other delegate with a flag, or wrap the one‑off behavior in a small conditional inside the helper.
-
+- When two functions differ only by a small behavior (ex: rounding), implement one and have the other delegate with a
+  flag, or wrap the one‑off behavior in a small conditional inside the helper.
 
 ## Development Environment
 
 * The project uses Bun as the package manager instead of npm.
 * You should never need to execute any commands related to package.json- they are all for compiling the plugins.
-* Target ESNext- I keep all my plugins on the latest stable Node.js and so anything that reaches mainstream should be available.
-  * The project policy forbids module syntax for anything in the `/src/plugins/**` directory; also avoid features that require compilation/transformations in the plugin layer. 
+* Target ESNext- I keep all my plugins on the latest stable Node.js and so anything that reaches mainstream should be
+  available.
+    * The project policy forbids module syntax for anything in the `/src/plugins/**` directory; also avoid features that
+      require compilation/transformations in the plugin layer.
 * Engine globals guard policy
-  * Assume RMMZ engine globals (e.g., Game_*, Scene_*, Window_*, Spriteset_*, DataManager, SceneManager) exist when plugins are evaluated. Do not guard engine classes during prototype extension.
-  * Guard only optional dependencies from external plugins by namespace (e.g., if (J.ABS) { ... }).
-  * If a check concerns runtime state (for example, current scene or constructed instances), perform it inside the executing method at runtime, not around the prototype definition.
-  * If a check is related to a new method that was added by a plugin (such as Game_Event.prototype.isErased from the J.BASE plugin), then instead ensure the owning plugin is available before using the method (ex: `if (J.BASE) { /* safe to use event.isErased() */}`).
-  * Never guard against a method potentially not existing directly, only use namespace validation- which also shouldn't be guarded against.
+    * Assume RMMZ engine globals (e.g., Game_*, Scene_*, Window_*, Spriteset_*, DataManager, SceneManager) exist when
+      plugins are evaluated. Do not guard engine classes during prototype extension.
+    * Guard only optional dependencies from external plugins by namespace (e.g., if (J.ABS) { ... }).
+    * If a check concerns runtime state (for example, current scene or constructed instances), perform it inside the
+      executing method at runtime, not around the prototype definition.
+    * If a check is related to a new method that was added by a plugin (such as Game_Event.prototype.isErased from the
+      J.BASE plugin), then instead ensure the owning plugin is available before using the method (ex:
+      `if (J.BASE) { /* safe to use event.isErased() */}`).
+    * Never guard against a method potentially not existing directly, only use namespace validation- which also
+      shouldn't be guarded against.
 
 ## Project Structure
 
 * `/docs` - Contains various markdown documentation relating to the plugins, but is mostly incomplete.
 * `/project` - Contains a test project that is largely deprecated and shouldn't be used or referenced at this time.
-* `/src` - Contains the source code for the plugins as well as a number of other niceties like custom build tools and type definitions.
-  * `/src/build-tools` - a few custom build tools used in the root `package.json` file.
-  * `/src/defs` - where custom definitions live representing much of the RPG Maker MZ core definitions.
-  * `/src/plugin-template` - a directory containing a structure that is cloned when generating new plugins into the `src/plugins` directory.
-  * `/src/plugins` - A parent directory of all plugins, where each child directory represents a plugin or plugin w/ extension plugins.
-    * `/src/plugins/__ca-mods` - A plugin that contains modifications to various other plugins that are exclusive to a game project I'm working on called "Chef Adventure" aka "CA".
-    * `/src/plugins/_base` - A plugin that acts as a base that all other plugins build upon. Common logic that is reused in other plugins lives here.
-    * `/src/plugins/abs` - The "JABS" or "J's Action Battle System" plugin. It is a custom action battle system for RMMZ that I wrote that has many extensions.
-      * `/src/plugins/abs/core` - The core source code for JABS.
-      * `/src/plugins/abs/ext` - A parent directory for all JABS-related extensions.
-        * `/src/plugins/abs/ext/allyai` - A JABS extension that enables followers to function as allies in JABS combat.
-        * `/src/plugins/abs/ext/charge` - A JABS extension that enables the ability to charge skills to perform other skills.
-        * `/src/plugins/abs/ext/cycle` - A JABS extension that functions as an adapter between JABS and the Cyclone-Movement plugin (not authored by me).
-        * `/src/plugins/abs/ext/danger` - A JABS extension that enables small icons to be rendered that represent enemy danger levels relative to the player.
-        * `/src/plugins/abs/ext/diag` - A JABS extension that enables 8-directional movement.
-        * `/src/plugins/abs/ext/formula` - A JABS extension that is intended to allow skills to have one to many formulas that all execute on a target.
-        * `/src/plugins/abs/ext/input` - A JABS extension that owns user input management and integration with JABS functionality.
-        * `/src/plugins/abs/ext/pixel` - An incomplete JABS extension that enables lesser-than full-tile movement (aka pixel movement).
-        * `/src/plugins/abs/ext/poses` - A JABS extension that owns management of poses and the like for battlers often during skill execution.
-        * `/src/plugins/abs/ext/speed` - A JABS extension that enables decimal-based movement speed for characters/events/battlers.
-        * `/src/plugins/abs/ext/star` - An incomplete JABS extension that "Star Ocean"-like battling (aka battles teleport player to a separate battle map and return the player when combat is over).
-        * `/src/plugins/abs/ext/timing` - A JABS extension that owns management of cooldown and casting time modifications.
-        * `/src/plugins/abs/ext/tools` - A JABS extension that owns the management of various "tools" and such in JABS (such as a hookshot).
-    * `/src/plugins/cms` - A parent directory for all Custom Menu System plugins. There is no "core" or "extensions", they are just divided by the scene they replace. 
-      * `/src/plugins/cms/equip` - The CMS scene replacement for the equip scene.
-      * `/src/plugins/cms/main` - The CMS scene replacement for the main menu scene.
-      * `/src/plugins/cms/skill` - The CMS scene replacement for the skill scene.
-      * `/src/plugins/cms/status` - The CMS scene replacement for the status scene.
-    * `/src/plugins/crit` - A plugin that provides extended control over critical hits against battlers.
-    * `/src/plugins/diff` - A plugin that enables a "difficulty layer" system, such as "easy", "normal", "hard", where any of them can be combined at once.
-    * `/src/plugins/drops` - A plugin that provides extended control over loot that enemies drop, including more than the core 3 as well as percentage based drops.
-    * `/src/plugins/elem` - A plugin that provides extended control over elemental effects in damage formulas.
-    * `/src/plugins/escribe` - A plugin that allows rendering of text and icons over an event's head on the map.
-    * `/src/plugins/extend` - A plugin that provides the ability for skills to "inherit" from one another.
-    * `/src/plugins/hud` - A plugin that renders a HUD while on the map- specifically designed for use with JABS.
-      * `/src/plugins/hud/core` - The core source code for the HUD.
-      * `/src/plugins/hud/ext` - A parent directory for all HUD-related extensions.
-        * `/src/plugins/hud/ext/boss` - A HUD extension that places a boss enemy frame on the screen.
-        * `/src/plugins/hud/ext/input` - A HUD extension that renders the various inputs and their cooldowns on the screen.
-        * `/src/plugins/hud/ext/party` - A HUD extension that draws your party members above the party leader- designed for use with my JABS Ally AI extension.
-        * `/src/plugins/hud/ext/quest` - A HUD extension that displays tracked quests on the screen.
-        * `/src/plugins/hud/ext/target` - A HUD extension that shows what enemy was most recently hit- superseded by the boss frame if applicable.
-    * `/src/plugins/jafting` - A plugin that is a crossover of the words "J's" and "Crafting", aka JAFTING. It enables a crafting system.
-      * `/src/plugins/jafting/core` - The core source code for the JAFTING.
-      * `/src/plugins/jafting/ext` - A parent directory for all JAFTING-related extensions.
-        * `/src/plugins/jafting/ext/create` - A JAFTING extension that is the core crafting functionality: consume items per a recipe to create another item.
-        * `/src/plugins/jafting/ext/freestyle` - An incomplete JAFTING extension that enables crafting one of a variety of items from a single recipe.
-        * `/src/plugins/jafting/ext/refine` - A JAFTING extension that enables bestowing traits from one equip to another with limits.
-    * `/src/plugins/level` - A plugin that provides extended control over levels for allies and enemies.
-    * `/src/plugins/log` - A plugin that enables various forms of logging on the map scene.
-    * `/src/plugins/map` - A plugin that enables a minimap on the map scene.
-    * `/src/plugins/message` - A plugin that provides additional control over choice visibility as well as additional code parsing.
-    * `/src/plugins/natural` - A plugin that provides extended control over parameter growth and buffs via tags.
-    * `/src/plugins/omni` - A plugin that provides an "encyclopedia"-like functionality- thus the name "Omnipedia".
-      * `/src/plugins/omni/core` - The core source code for the Omnipedia.
-      * `/src/plugins/omni/ext` - A parent directory for all Omnipedia-related extensions.
-        * `/src/plugins/omni/ext/monster` - An Omnipedia extension that provides a "bestiary" of sorts with integrations to other plugins I have written.
-        * `/src/plugins/omni/ext/quest` - An Omnipedia extension that provides a "quest journal" of sorts.
-    * `/src/plugins/otib` - A plugin that provides one-time permanent bonuses upon item consumption.
-    * `/src/plugins/passive` - A plugin that enables "passive" functionality from items or states.
-    * `/src/plugins/popups` - A plugin that enables popup functionality on the map- designed for use with JABS to do things like experience popups.
-    * `/src/plugins/prof` - A plugin that enables a "skill proficiency" system, allowing battlers to track skill usage to potentially learn/empower skills.
-    * `/src/plugins/regions` - A plugin that enables "hazard"-like effects associated with regions on the map.
-      * `/src/plugins/regions/core` - The core source code for the regions.
-      * `/src/plugins/regions/ext` - A parent directory for all regions-related extensions.
-        * `/src/plugins/regions/ext/skills` - A regions extension that executes skills when stepping on a particular region.
-        * `/src/plugins/regions/ext/states` - A regions extension that inflicts states when stepping on a particular region.
-    * `/src/plugins/sdp` - A plugin that enables a "stat distribution panel" system, for permanently modifying actor stats.
-    * `/src/plugins/time` - A plugin that enables a "time" functionality, including date and time-based events, either real or artificial timing.
-    * `/src/plugins/utils` - A plugin that has helpful developer functionalities 
+* `/src` - Contains the source code for the plugins as well as a number of other niceties like custom build tools and
+  type definitions.
+    * `/src/build-tools` - a few custom build tools used in the root `package.json` file.
+    * `/src/defs` - where custom definitions live representing much of the RPG Maker MZ core definitions.
+    * `/src/plugin-template` - a directory containing a structure that is cloned when generating new plugins into the
+      `src/plugins` directory.
+    * `/src/plugins` - A parent directory of all plugins, where each child directory represents a plugin or plugin w/
+      extension plugins.
+        * `/src/plugins/__ca-mods` - A plugin that contains modifications to various other plugins that are exclusive to
+          a game project I'm working on called "Chef Adventure" aka "CA".
+        * `/src/plugins/_base` - A plugin that acts as a base that all other plugins build upon. Common logic that is
+          reused in other plugins lives here.
+        * `/src/plugins/abs` - The "JABS" or "J's Action Battle System" plugin. It is a custom action battle system for
+          RMMZ that I wrote that has many extensions.
+            * `/src/plugins/abs/core` - The core source code for JABS.
+            * `/src/plugins/abs/ext` - A parent directory for all JABS-related extensions.
+                * `/src/plugins/abs/ext/allyai` - A JABS extension that enables followers to function as allies in JABS
+                  combat.
+                * `/src/plugins/abs/ext/charge` - A JABS extension that enables the ability to charge skills to perform
+                  other skills.
+                * `/src/plugins/abs/ext/cycle` - A JABS extension that functions as an adapter between JABS and the
+                  Cyclone-Movement plugin (not authored by me).
+                * `/src/plugins/abs/ext/danger` - A JABS extension that enables small icons to be rendered that
+                  represent enemy danger levels relative to the player.
+                * `/src/plugins/abs/ext/diag` - A JABS extension that enables 8-directional movement.
+                * `/src/plugins/abs/ext/formula` - A JABS extension that is intended to allow skills to have one to many
+                  formulas that all execute on a target.
+                * `/src/plugins/abs/ext/input` - A JABS extension that owns user input management and integration with
+                  JABS functionality.
+                * `/src/plugins/abs/ext/pixel` - An incomplete JABS extension that enables lesser-than full-tile
+                  movement (aka pixel movement).
+                * `/src/plugins/abs/ext/poses` - A JABS extension that owns management of poses and the like for
+                  battlers often during skill execution.
+                * `/src/plugins/abs/ext/speed` - A JABS extension that enables decimal-based movement speed for
+                  characters/events/battlers.
+                * `/src/plugins/abs/ext/star` - An incomplete JABS extension that "Star Ocean"-like battling (aka
+                  battles teleport player to a separate battle map and return the player when combat is over).
+                * `/src/plugins/abs/ext/timing` - A JABS extension that owns management of cooldown and casting time
+                  modifications.
+                * `/src/plugins/abs/ext/tools` - A JABS extension that owns the management of various "tools" and such
+                  in JABS (such as a hookshot).
+        * `/src/plugins/cms` - A parent directory for all Custom Menu System plugins. There is no "core" or "
+          extensions", they are just divided by the scene they replace.
+            * `/src/plugins/cms/equip` - The CMS scene replacement for the equip scene.
+            * `/src/plugins/cms/main` - The CMS scene replacement for the main menu scene.
+            * `/src/plugins/cms/skill` - The CMS scene replacement for the skill scene.
+            * `/src/plugins/cms/status` - The CMS scene replacement for the status scene.
+        * `/src/plugins/crit` - A plugin that provides extended control over critical hits against battlers.
+        * `/src/plugins/diff` - A plugin that enables a "difficulty layer" system, such as "easy", "normal", "hard",
+          where any of them can be combined at once.
+        * `/src/plugins/drops` - A plugin that provides extended control over loot that enemies drop, including more
+          than the core 3 as well as percentage based drops.
+        * `/src/plugins/elem` - A plugin that provides extended control over elemental effects in damage formulas.
+        * `/src/plugins/escribe` - A plugin that allows rendering of text and icons over an event's head on the map.
+        * `/src/plugins/extend` - A plugin that provides the ability for skills to "inherit" from one another.
+        * `/src/plugins/hud` - A plugin that renders a HUD while on the map- specifically designed for use with JABS.
+            * `/src/plugins/hud/core` - The core source code for the HUD.
+            * `/src/plugins/hud/ext` - A parent directory for all HUD-related extensions.
+                * `/src/plugins/hud/ext/boss` - A HUD extension that places a boss enemy frame on the screen.
+                * `/src/plugins/hud/ext/input` - A HUD extension that renders the various inputs and their cooldowns on
+                  the screen.
+                * `/src/plugins/hud/ext/party` - A HUD extension that draws your party members above the party leader-
+                  designed for use with my JABS Ally AI extension.
+                * `/src/plugins/hud/ext/quest` - A HUD extension that displays tracked quests on the screen.
+                * `/src/plugins/hud/ext/target` - A HUD extension that shows what enemy was most recently hit-
+                  superseded by the boss frame if applicable.
+        * `/src/plugins/jafting` - A plugin that is a crossover of the words "J's" and "Crafting", aka JAFTING. It
+          enables a crafting system.
+            * `/src/plugins/jafting/core` - The core source code for the JAFTING.
+            * `/src/plugins/jafting/ext` - A parent directory for all JAFTING-related extensions.
+                * `/src/plugins/jafting/ext/create` - A JAFTING extension that is the core crafting functionality:
+                  consume items per a recipe to create another item.
+                * `/src/plugins/jafting/ext/freestyle` - An incomplete JAFTING extension that enables crafting one of a
+                  variety of items from a single recipe.
+                * `/src/plugins/jafting/ext/refine` - A JAFTING extension that enables bestowing traits from one equip
+                  to another with limits.
+        * `/src/plugins/level` - A plugin that provides extended control over levels for allies and enemies.
+        * `/src/plugins/log` - A plugin that enables various forms of logging on the map scene.
+        * `/src/plugins/map` - A plugin that enables a minimap on the map scene.
+        * `/src/plugins/message` - A plugin that provides additional control over choice visibility as well as
+          additional code parsing.
+        * `/src/plugins/natural` - A plugin that provides extended control over parameter growth and buffs via tags.
+        * `/src/plugins/omni` - A plugin that provides an "encyclopedia"-like functionality- thus the name "Omnipedia".
+            * `/src/plugins/omni/core` - The core source code for the Omnipedia.
+            * `/src/plugins/omni/ext` - A parent directory for all Omnipedia-related extensions.
+                * `/src/plugins/omni/ext/monster` - An Omnipedia extension that provides a "bestiary" of sorts with
+                  integrations to other plugins I have written.
+                * `/src/plugins/omni/ext/quest` - An Omnipedia extension that provides a "quest journal" of sorts.
+        * `/src/plugins/otib` - A plugin that provides one-time permanent bonuses upon item consumption.
+        * `/src/plugins/passive` - A plugin that enables "passive" functionality from items or states.
+        * `/src/plugins/popups` - A plugin that enables popup functionality on the map- designed for use with JABS to do
+          things like experience popups.
+        * `/src/plugins/prof` - A plugin that enables a "skill proficiency" system, allowing battlers to track skill
+          usage to potentially learn/empower skills.
+        * `/src/plugins/regions` - A plugin that enables "hazard"-like effects associated with regions on the map.
+            * `/src/plugins/regions/core` - The core source code for the regions.
+            * `/src/plugins/regions/ext` - A parent directory for all regions-related extensions.
+                * `/src/plugins/regions/ext/skills` - A regions extension that executes skills when stepping on a
+                  particular region.
+                * `/src/plugins/regions/ext/states` - A regions extension that inflicts states when stepping on a
+                  particular region.
+        * `/src/plugins/sdp` - A plugin that enables a "stat distribution panel" system, for permanently modifying actor
+          stats.
+        * `/src/plugins/time` - A plugin that enables a "time" functionality, including date and time-based events,
+          either real or artificial timing.
+        * `/src/plugins/utils` - A plugin that has helpful developer functionalities
 
 When constructing new extensions, typically the structure defined is as such:
+
 - `__models` for models that may need to exist in a part of the `initialization.js` file for some reason.
-- `_metadata` for the plugin metadata including the `_annotations.js`, `initialization.js`, `pluginMetadata.js` and `pluginCommands.js`.
+- `_metadata` for the plugin metadata including the `_annotations.js`, `initialization.js`, `pluginMetadata.js` and
+  `pluginCommands.js`.
 - `database` for RPG_* files.
 - `managers/` for Manager classes or other static singletons.
 - `objects/` for Game_* and some data models.
@@ -137,101 +195,209 @@ When constructing new extensions, typically the structure defined is as such:
 ## Architecture & Patterns
 
 * The code is written purely in JavaScript, but makes heavy usage of JSDocs annotations for type recognition.
-* Due to the way RMMZ works, the plugins make heavy usage of prototype extension and replacement to perform their various functions.
+* Due to the way RMMZ works, the plugins make heavy usage of prototype extension and replacement to perform their
+  various functions.
 * The application is organized into "plugins", designated by their respective folders under the `/src/plugins`.
-* In some cases, there is a `/src/plugins/some_plugin/core` and `/src/plugins/some_plugin/ext` which represents the plugin has a base plugin, as well as a number of independent extensions that expand the core functionality.
-* The app uses a pattern of parsing and modifying "notes" fields from RPG Maker objects, primarily through the RPGManager static class.
-* When providing code samples, one should always assume the global variables or methods referenced from other plugins exist.
-  * If a validation check needs to be made on a method, instead check if the namespace of the plugin exists (ex: `if (J.ABS) { /* do JABS-related logic here */ }`).
-  * Always be optimistic in validation, or ask for clarity instead of adding excessive validation by default.
+* In some cases, there is a `/src/plugins/some_plugin/core` and `/src/plugins/some_plugin/ext` which represents the
+  plugin has a base plugin, as well as a number of independent extensions that expand the core functionality.
+* The app uses a pattern of parsing and modifying "notes" fields from RPG Maker objects, primarily through the
+  RPGManager static class.
+* When providing code samples, one should always assume the global variables or methods referenced from other plugins
+  exist.
+    * If a validation check needs to be made on a method, instead check if the namespace of the plugin exists (ex:
+      `if (J.ABS) { /* do JABS-related logic here */ }`).
+    * Always be optimistic in validation, or ask for clarity instead of adding excessive validation by default.
 * Due to the nature of RMMZ game projects, `async`/`await` shouldn't be used.
+* Do use regions to wrap the code inside each file, but the region name should only ever be the file name (ex:
+  Window_Command.js -> `// #region Window_Command` and `// #endregion Window_Command`).
 
+### Authoring rules: augment vs inherit (and editing our own classes)
+
+To avoid confusion between augmenting existing implementations and creating new classes, follow these rules.
+
+- Terminology
+    - Augment: modify/extend methods on a class that is defined outside this plugin (RMMZ core or another plugin). You
+      are not creating a new class; you’re changing behavior on one that already exists at runtime.
+    - Inherit: create a new class that derives from a base type.
+    - Edit our own class: change a class whose source of truth lives in this plugin (we authored it here).
+
+- Which syntax to use
+  1) Augment existing implementation (engine or other plugin)
+     - Use prototype syntax and our alias map pattern.
+     - Do not use `class` or `extends` for augmentation.
+     - Example:
+       ```javascript
+       /**
+        * Extends {@link #initMembers}.<br/>
+        * Also initializes SOME members.
+        */
+       J.SOME.Aliased.Game_Actor.set('initMembers', Game_Actor.prototype.initMembers);
+       Game_Actor.prototype.initMembers = function()
+       {
+         J.SOME.Aliased.Game_Actor.get('initMembers').call(this);
+         this.initSomeMembers();
+       };
+       ```
+  2) Create a new class that derives from an engine base (Scene_*, Window_*, Spriteset_*, etc.)
+     - Use modern `class NewThing extends BaseThing { ... }`.
+     - Exception: if instances of this class will be serialized into save data, use a prototype constructor instead.
+  3) Edit a class defined in this plugin (it “already exists” because we wrote it here)
+     - Keep the style it was authored with.
+         - If it was authored as a modern class, keep editing it as a modern class.
+         - If it was authored as a prototype constructor, keep editing it as prototype.
+     - Do not switch to prototype syntax merely because the class now exists.
+  4) New helper/manager that does NOT inherit from engine classes and is NOT serialized
+     - Prefer modern `class`.
+  5) New data model that WILL be serialized into save data
+     - Use prototype constructors (function + `prototype`).
+     - Store only JSON‑safe fields (numbers, strings, arrays, plain objects). No Map/Set/Date/RegExp/Functions in stored
+       fields.
+
+- One‑look decision flow
+  - Am I augmenting an engine/other‑plugin class? → Prototype + alias.
+  - Else, is this a brand‑new class that derives from an engine base? → Modern `class extends`, unless it’s
+    serialized → then prototype constructor.
+  - Else, is this class defined in this plugin already? → Keep its original style (do not convert because it
+    “exists”).
+  - Else, is this a helper/manager, not serialized? → Modern `class`.
+  - Else, will instances be saved? → Prototype constructor with JSON‑safe fields.
+- Rationale
+  - Keeps aliasing predictable and inter‑plugin safe.
+  - Matches RMMZ runtime expectations.
+  - Avoids save/load pitfalls for data models.
 
 ## When Providing Drop-in Code Replacements
 
 * When providing drop-in code replacements, prefer using RPGManager and its methods from the J.BASE plugin.
 * All new methods should be documented using JsDocs with sensible descriptions.
-  * These descriptions should not include explicit tag contents
-  * These descriptions should not include correction information for when you messed up and I corrected you.
+    * These descriptions should not include explicit tag contents
+    * These descriptions should not include correction information.
 * Always consider the purpose of a function by its name and JsDocs description.
 * Prefer readability over conciseness.
-  * Do not be bashful about writing a method that does some menial calculations/transformations, it is preferred when possible so you can read through the parent method and just understand what is happening by function names.
-  * When naming variables, prefer camelCase over one or two letters unless it is for coordinates (like x/y/cs/cy/etc.)
-* We should never use optional method chaining, that is strictly forbidden in this codebase and code we write should be rewritten to never need it.
-  * Assume methods we are adding exist and that all drop-in replacements will be provided simultaneously before merged into the main codebase.
-* Prefer the pattern of `if (condition === false)` versus `(if (!condition))` (or the inverse) where possible- it improves readability.
-* New properties on objects should NEVER be dynamically instantiated if at all possible- they should be created in the `initMembers` of the respective class- or in the corresponding plugin variant (such as `initJabsMembers`)
-  * Such properties should also never directly be interacted with- they should be masked behind getter/setter functions to centralize the property access and management.
+    * Do not be bashful about writing a method that does some menial calculations/transformations, it is preferred when
+      possible so you can read through the parent method and just understand what is happening by function names.
+    * When naming variables, prefer camelCase over one or two letters unless it is for coordinates (like x/y/cs/cy/etc.)
+* We should never use optional method chaining, that is strictly forbidden in this codebase and code we write should be
+  rewritten to never need it.
+    * Assume methods we are adding exist and that all drop-in replacements will be provided simultaneously before merged
+      into the main codebase.
+* Prefer the pattern of `if (condition === false)` versus `(if (!condition))` (or the inverse) where possible- it
+  improves readability.
+* New properties on objects should NEVER be dynamically instantiated if at all possible- they should be created in the
+  `initMembers` of the respective class- or in the corresponding plugin variant (such as `initJabsMembers`)
+    * Such properties should also never directly be interacted with- they should be masked behind getter/setter
+      functions to centralize the property access and management.
 * When building new functions, consider cognitive/cyclomatic complexity and try not to exceed 20.
-  * Functions should always be written with one of two mindsets in mind:
-    * This function is an orchestration function and will be calling many functions consecutively to perform some sort of overarching behavior or process.
-    * This function is a helper for an orchestration function and should have 1 job.
+    * Functions should always be written with one of two mindsets in mind:
+        * This function is an orchestration function and will be calling many functions consecutively to perform some
+          sort of overarching behavior or process.
+        * This function is a helper for an orchestration function and should have 1 job.
 
 ## Code Formatting Style
 
-* All drop-in code replacements should obey the eslint rules of the project.
-* When possible, almost every line should have an inline comment above it, describing what it does using proper sentence casing.
-  * Examples of this are plentiful throughout the codebase.
-  * Add the comments on the line preceding the line the comment is written about.
-  * There should never be comments above the line and also on the line.
-  * The only exception to this rule is if the function is 1 line, then the JsDocs will suffice.
+* There should never be more than one class (prototype-based or modern) in a single file.
+* All drop-in code replacements should obey the eslint rules of the project wtihout exception.
+* When possible, almost every line should have an inline comment above it, describing what it does using proper sentence
+  casing.
+    * Examples of this are plentiful throughout the codebase.
+    * Add the comments on the line preceding the line the comment is written about.
+    * There should never be comments above the line and also on the line.
+    * The only exception to this rule is if the function is 1 line, then the JsDocs will suffice.
 * Always document methods with JsDocs.
-  * Never echo my feedback into the JsDocs- only write what the purpose of the function is so someone who reads it will understand the purpose of the function and not the iterative changes that occurred to the method as it was being built.
+    * Never echo my feedback into the JsDocs- only write what the purpose of the function is so someone who reads it
+      will understand the purpose of the function and not the iterative changes that occurred to the method as it was
+      being built.
+    * all jsdocs should be multiline and complete. 1 line comments are not allowed.
+    * JsDocs should be written in the following format:
+        * `/**`
+        * ` * Some meaningful description of the function or property being documented.`
+        * ` * @param {type} name - description of the parameter`
+        * ` * @returns {type} - description of the return value`
+    * if the JsDocs are for a regex (regular expression), they should contain the structure breakdown, and usage example, all within a <pre></pre> block for readability.
+    * here is an example from my aptitude plugin:
+```js
+  /**
+   * The AP reward an enemy yields on defeat.
+   *
+   * <pre>
+   * Structure:
+   *  <ap:AMOUNT>
+   *
+   * Example:
+   *  <ap:12>
+   *
+   * Translation:
+   *  AP gained: 12
+   * </pre>
+   * @type {RegExp}
+   */
+  J.APT.RegExp.ApReward = /<ap: ?(\d+)>/i;
+```
+* When writing with modern class syntax, properties that are declared in the constructor or initialize function or initMembers function should be declared in the class body with default values, above the constructor, with jsdocs (as described above).
 * Always terminate statements with semicolons.
 * Always indent with 2 spaces, where applicable.
 * Prefer single quotes for strings.
 * Prefer to destructure objects and arrays if more than one property/item is being leveraged from the object/array.
 * Never write nested ternary operators.
-  * If you need to nest ternary operators, spell out the conditions with if blocks.
-* Prefer modern syntax where possible (such as `this._j ||= {}` instead of `if (!this._j) this._j = {}` or `this._j = this._j || {}` instead of `this._j = this._j || {}`).
+    * If you need to nest ternary operators, spell out the conditions with if blocks.
+* Prefer modern syntax where possible (such as `this._j ||= {}` instead of `if (!this._j) this._j = {}` or
+  `this._j = this._j || {}` instead of `this._j = this._j || {}`).
 * Always prefer to expose new properties with getter and setter functions rather than direct property mutation.
 * Always use template literals for interpolation instead of `const someString = anotherString + yetAnotherString;`.
-* All example snippets in this document (including aliasing examples) should follow the same style rules (double quotes, semicolons, 2-space indent).
-* Trailing commas in arrays/objects are acceptable and even encouraged in some cases to indicate there are other (possibly useful but currently ignored) parameters available.
+* All example snippets in this document (including aliasing examples) should follow the same style rules (double quotes,
+  semicolons, 2-space indent).
+* Trailing commas in arrays/objects are acceptable and even encouraged in some cases to indicate there are other (
+  possibly useful but currently ignored) parameters available.
 * Line length should be capped at 120 for all source files except `_annotations.js` files.
-  * `_annotations.js` files are special:
-    * The whole file is effectively a metadata file that gets parsed explicitly by the RPG Maker MZ editor.
-    * It is very much an oversized JSDoc, and uses multi-line comments, opening with `/**`, having ` * ` on every line, and closing with `*/`.
-    * There are a number of special @ annotations and multi-line structures (see existing examples for reference).
+    * `_annotations.js` files are special:
+        * The whole file is effectively a metadata file that gets parsed explicitly by the RPG Maker MZ editor.
+        * It is very much an oversized JSDoc, and uses multi-line comments, opening with `/**`, having ` * ` on every
+          line, and closing with `*/`.
+        * There are a number of special @ annotations and multi-line structures (see existing examples for reference).
 * do not needlessly/defensively attempt to validate/coerce state- it should be assumed that the state is valid.
 * When working with state, use this formula to determine the structure:
-  * `this._j.SENSIBLE_PLUGIN_ABBREVATION.FUNCTION_CONTAINER_NAME.SOME_STATE_NAME = default state`.
-    * for example, `this._j._abs._input._lastInput = null;`.
-  * always provide getter and setter functions for accessing and mutating state.
-  * never mutate state outside of a setter function.
-  * when a state represents a boolean, the getter may be named like `hasSomeState` or `isSomeState`.
-  * when a state represents a boolean, the setter may be named like `flagSomeState` or `toggleSomeState` or more appropriately based on the intended functionality.
-  * state should never be initialized in a getter or setter function, with one exception:
-    * if state is in a window, and properties need to be calculated upon initialization, then the getter/setter may need property initialization- use a common "init state" function (like _root()) to establish state default if it doesn't exist.
+    * `this._j.SENSIBLE_PLUGIN_ABBREVATION.FUNCTION_CONTAINER_NAME.SOME_STATE_NAME = default state`.
+        * for example, `this._j._abs._input._lastInput = null;`.
+    * always provide getter and setter functions for accessing and mutating state.
+    * never mutate state outside of a setter function.
+    * when a state represents a boolean, the getter may be named like `hasSomeState` or `isSomeState`.
+    * when a state represents a boolean, the setter may be named like `flagSomeState` or `toggleSomeState` or more
+      appropriately based on the intended functionality.
+    * state should never be initialized in a getter or setter function, with one exception:
+        * if state is in a window, and properties need to be calculated upon initialization, then the getter/setter may
+          need property initialization- use a common "init state" function (like _root()) to establish state default if
+          it doesn't exist.
 * **Braces placement**:
-  * Opening braces `{` should always be on a new line if syntactically possible
-  * Closing braces `}` are on their own line
-  * Example:
-    ```javascript
-    function example()
-    {
-      // code here
-    }
-    ```
-  * Arrow functions follow the same pattern:
-    ```javascript
-    lines.forEach(line =>
-    {
-      // code here
-    });
-    ```
-  * array functions such as `someArray.forEach(line => {...});` should be preferred over `for..of` loops.
+    * Opening braces `{` should always be on a new line if syntactically possible
+    * Closing braces `}` are on their own line
+    * Example:
+      ```javascript
+      function example()
+      {
+        // code here
+      }
+      ```
+    * Arrow functions follow the same pattern:
+      ```javascript
+      lines.forEach(line =>
+      {
+        // code here
+      });
+      ```
+    * array functions such as `someArray.forEach(line => {...});` should be preferred over `for..of` loops.
 * When providing aliasing, use this pattern:
+
 ```javascript
 /**
- * Extends/Overrides {@link #SOME_METHOD}.<br/>
+ * Extends {@link #SOME_METHOD}.<br/>
  * Also does or Now does [INSERT THE THING THAT IS HAPPENING HERE].
  */
 J.SOME_NAMESPACE.Aliased.SOME_TYPE.set("SOME_METHOD", SOME_TYPE.prototype.SOME_METHOD);
 SOME_TYPE.prototype.SOME_METHOD = function(...args)
 {
   // perform original logic.
-  const original = J.SOME_NAMESPACE.Aliased.SOME_TYPE.get("SOME_METHOD").call(this, ...args);
+  const original = J.SOME_NAMESPACE.Aliased.SOME_TYPE.get("SOME_METHOD")
+    .call(this, ...args);
 
   // new/modified logic here that may or may not potentially generate an updatedOriginal variable.
   this.SOME_SIDE_EFFECT_FUNCTION(original);
@@ -240,9 +406,13 @@ SOME_TYPE.prototype.SOME_METHOD = function(...args)
   return original;
 };
 ```
-* When providing drop-in replacements, provide the path relative to the plugin folder, the method, and the line number, as well as the entire method being replaced.
-  * When I say ‘line number,’ it refers to the source file under `/src/**`, not the built files under `/project/js/plugins/**`.
-  * The sample below should always be three lines- no one-liners! It makes it hard to parse :(
+
+* When providing drop-in replacements, provide the path relative to the plugin folder, the method, and the line number,
+  as well as the entire method being replaced.
+    * When I say ‘line number,’ it refers to the source file under `/src/**`, not the built files under
+      `/project/js/plugins/**`.
+    * The sample below should always be three lines- no one-liners! It makes it hard to parse :(
+
 ```text
 File: /src/plugins/map/sprites/Sprite_MiniMap.js
 
@@ -250,14 +420,20 @@ Method: update (or Sprite_MiniMap.prototype.update if using prototype syntax ove
 
 Starts at: line 123
 ```
-* When providing drop-in replacements, if the drop-in code is being inserted into a modern class, then be sure to match the style as seen below:
+
+* When providing drop-in replacements, if the drop-in code is being inserted into a modern class, then be sure to match
+  the style as seen below:
+
 ```javascript
 someNewMethodBeingAdded()
 {
   // ... the new logic.
 }
 ```
-* When providing drop-in replacements, if the drop-in code is using prototype-based classes, then be sure to match the style as seen below:
+
+* When providing drop-in replacements, if the drop-in code is using prototype-based classes, then be sure to match the
+  style as seen below:
+
 ```javascript
 SomeClass.prototype.someNewMethod = function(/* args if required */)
 {
@@ -266,33 +442,40 @@ SomeClass.prototype.someNewMethod = function(/* args if required */)
 ```
 
 * When deciding new tags to author, the format should generally be one of:
-  * `<tag:value>` for stuff like `<sight:5>`
-  * `<tag:[value1, value2, ...]>` for stuff like `<drop:[item, 1, 25%]>`
-  * `<tagForBooleanValue>` for stuff like `<showMinimap>` or `<hideMinimap>`
-  * Duplicate tag validity is contextual. Some plugins allow multiple instances of certain tags while others do not. You should ask for clarity when unsure- do not deduce unless you have contextual knowledge about the tag in question.
-  * When building regex tag structures, typically if there is a `:`, it should be followed with a single optional space `: ?` before the capture value(s).
-  * I do not currently use any multi-line and am not against them, but prefer generally to keep each line representing a single value/concept.
-  * All tags should be case insensitive unless casing matters semantically.
-  * Situationally, multiple tags on a single object may be acceptable- reference the context for acceptability.
-  * Generally, if a tag is matched, it is already validated. If it doesn't match the regex, it is simply invalid and should be ignored for the plugin in question.
-* Logging is never acceptable in production code, only for debugging, and we should use `console.log(..)`, the J.LOG namespace is for in-game logging.
+    * `<tag:value>` for stuff like `<sight:5>`
+    * `<tag:[value1, value2, ...]>` for stuff like `<drop:[item, 1, 25%]>`
+    * `<tagForBooleanValue>` for stuff like `<showMinimap>` or `<hideMinimap>`
+    * Duplicate tag validity is contextual. Some plugins allow multiple instances of certain tags while others do not.
+      You should ask for clarity when unsure- do not deduce unless you have contextual knowledge about the tag in
+      question.
+    * When building regex tag structures, typically if there is a `:`, it should be followed with a single optional
+      space `: ?` before the capture value(s).
+    * I do not currently use any multi-line and am not against them, but prefer generally to keep each line representing
+      a single value/concept.
+    * All tags should be case insensitive unless casing matters semantically.
+    * Situationally, multiple tags on a single object may be acceptable- reference the context for acceptability.
+    * Generally, if a tag is matched, it is already validated. If it doesn't match the regex, it is simply invalid and
+      should be ignored for the plugin in question.
+* Logging is never acceptable in production code, only for debugging, and we should use `console.log(..)`, the J.LOG
+  namespace is for in-game logging.
 
 * **Spacing**:
-  * Spaces around operators: `const [ , traitName ] = match;` (not `[,traitName]`)
-  * Spaces after commas in parameter lists
-  * Spaces inside array brackets: `[ , traitName ]` not `[, traitName]`
-  * Spaces before opening braces
+    * Spaces around operators: `const [ , traitName ] = match;` (not `[,traitName]`)
+    * Spaces after commas in parameter lists
+    * Spaces inside array brackets: `[ , traitName ]` not `[, traitName]`
+    * Spaces before opening braces
 
 * **Method structure**:
-  * Static methods with clear documentation
-  * Private methods/properties with `#` prefix when using modern class syntax. For prototype class syntax, prefixing with underscore is what others do, but I use it very very rarely.
+    * Static methods with clear documentation
+    * Private methods/properties with `#` prefix when using modern class syntax. For prototype class syntax, prefixing
+      with underscore is what others do, but I use it very very rarely.
 
 * **Conditional blocks**:
-  * `if` statements have braces on new lines even for single-line blocks
-  * Example:
-    ```javascript
-    if (condition)
-    {
-      doSomething();
-    }
-    ```
+    * `if` statements have braces on new lines even for single-line blocks
+    * Example:
+      ```javascript
+      if (condition)
+      {
+        doSomething();
+      }
+      ```

--- a/package.json
+++ b/package.json
@@ -35,6 +35,8 @@
     "build:utils": "node ./src/build-tools/combine.js ./src/plugins/utils ./out J-SystemUtilities.js",
     "build:base": "node ./src/build-tools/combine.js ./src/plugins/_base ./out J-Base.js",
 
+    "build:apt": "node ./src/build-tools/combine.js ./src/plugins/apt/core ./out/apt J-Aptitude.js",
+
     "build:crit": "node ./src/build-tools/combine.js ./src/plugins/crit ./out J-CriticalFactors.js",
     "build:diff": "node ./src/build-tools/combine.js ./src/plugins/diff ./out J-Difficulty.js",
     "build:drops": "node ./src/build-tools/combine.js ./src/plugins/drops ./out J-DropsControl.js",

--- a/project/js/plugins/J-Base.js
+++ b/project/js/plugins/J-Base.js
@@ -92,6 +92,12 @@
  *
  * ============================================================================
  * CHANGELOG:
+ * - 2.3.3
+ *    Extended database object type-checking.
+ *    Provided way for any database object to provide a unique identifier.
+ *    Added gauge-drawing into the Window_Base class.
+ *    Added API on Game_Actor and Game_Party for directly setting levels.
+ *    Added Window_ActorRibbon for re-use.
  * - 2.3.2
  *    Added helper function to determine array intersections.
  *    Added prototype helper class for common prototype operations (unused).

--- a/project/js/plugins/J-Base.js
+++ b/project/js/plugins/J-Base.js
@@ -1709,7 +1709,7 @@ class RPG_Base
    */
   deleteMetadata(key)
   {
-    delete this.meta[key]
+    delete this.meta[key];
   }
 
   /**
@@ -1769,12 +1769,12 @@ class RPG_Base
     if (fromMeta)
     {
       // check if the value was a truthy value.
-      if (fromMeta === true || fromMeta.toLowerCase() === "true")
+      if (fromMeta === true || fromMeta.toLowerCase() === 'true')
       {
         return true;
       }
       // check if the value was a falsey value.
-      else if (fromMeta === false || fromMeta.toLowerCase() === "false")
+      else if (fromMeta === false || fromMeta.toLowerCase() === 'false')
       {
         return false;
       }
@@ -1812,10 +1812,10 @@ class RPG_Base
   #parseObject(obj)
   {
     // check if the object to parse is a string.
-    if (typeof obj === "string")
+    if (typeof obj === 'string')
     {
       // check if the string is an unparsed array.
-      if (obj.startsWith("[") && obj.endsWith("]"))
+      if (obj.startsWith('[') && obj.endsWith(']'))
       {
         // expose the stringified segments of the array.
         const exposedArray = obj
@@ -1850,11 +1850,11 @@ class RPG_Base
   #parseString(str)
   {
     // check if its actually boolean true.
-    if (str.toLowerCase() === "true")
+    if (str.toLowerCase() === 'true')
     {
       return true;
     }// check if its actually boolean false.
-    else if (str.toLowerCase() === "false") return false;
+    else if (str.toLowerCase() === 'false') return false;
 
     // check if its actually a number.
     if (!Number.isNaN(parseFloat(str))) return parseFloat(str);
@@ -2416,6 +2416,33 @@ class RPG_Base
   //endregion note
 
   /**
+   * Whether or not this database entry is an actor.
+   * @returns {boolean}
+   */
+  isActor()
+  {
+    return false;
+  }
+
+  /**
+   * Whether or not this database entry is a class.
+   * @returns {boolean}
+   */
+  isClass()
+  {
+    return false;
+  }
+
+  /**
+   * Whether or not this database entry is an enemy.
+   * @returns {boolean}
+   */
+  isEnemy()
+  {
+    return false;
+  }
+
+  /**
    * Whether or not this database entry is an item.
    * @returns {boolean}
    */
@@ -2449,6 +2476,24 @@ class RPG_Base
   isSkill()
   {
     return false;
+  }
+
+  /**
+   * Whether or not this database entry is a state.
+   * @returns {boolean}
+   */
+  isState()
+  {
+    return false;
+  }
+
+  /**
+   * Gets the type of implementation this database entry is.
+   * @returns {string}
+   */
+  implementationType()
+  {
+    return '@base';
   }
 }
 
@@ -2489,6 +2534,15 @@ class RPG_BaseBattler
     this.battlerName = battler.battlerName;
     this.traits = battler.traits
       .map(trait => new RPG_Trait(trait));
+  }
+
+  /**
+   * Gets the type of implementation this database entry is.
+   * @returns {string}
+   */
+  implementationType()
+  {
+    return `${super.implementationType()}:battler`;
   }
 }
 
@@ -2560,6 +2614,15 @@ class RPG_Traited
     // map the base item's traits.
     this.traits = baseItem.traits.map(trait => new RPG_Trait(trait));
   }
+
+  /**
+   * Gets the type of implementation this database entry is.
+   * @returns {string}
+   */
+  implementationType()
+  {
+    return `${super.implementationType()}:traited`;
+  }
 }
 
 //endregion RPG_Traited
@@ -2629,6 +2692,15 @@ class RPG_EquipItem
   isArmor()
   {
     return this.etypeId > 1;
+  }
+
+  /**
+   * Gets the type of implementation this database entry is.
+   * @returns {string}
+   */
+  implementationType()
+  {
+    return `${super.implementationType()}:equip`;
   }
 }
 
@@ -2727,6 +2799,15 @@ class RPG_UsableItem
     this.successRate = usableItem.successRate;
     this.tpGain = usableItem.tpGain;
   }
+
+  /**
+   * Gets the type of implementation this database entry is.
+   * @returns {string}
+   */
+  implementationType()
+  {
+    return `${super.implementationType()}:usable`;
+  }
 }
 
 //endregion RPG_UsableItem
@@ -2817,7 +2898,7 @@ class RPG_Actor
     super(actor, index);
 
     // map the data.
-    this.initMembers(actor)
+    this.initMembers(actor);
   }
 
   /**
@@ -2837,6 +2918,24 @@ class RPG_Actor
     this.maxLevel = actor.maxLevel;
     this.nickname = actor.nickname;
     this.profile = actor.profile;
+  }
+
+  /**
+   * Whether or not this database entry is an actor.
+   * @returns {boolean}
+   */
+  isActor()
+  {
+    return true;
+  }
+
+  /**
+   * Gets the type of implementation this database entry is.
+   * @returns {string}
+   */
+  implementationType()
+  {
+    return `${super.implementationType()}:actor`;
   }
 }
 
@@ -2886,6 +2985,15 @@ class RPG_Armor
   isArmor()
   {
     return true;
+  }
+
+  /**
+   * Gets the type of implementation this database entry is.
+   * @returns {string}
+   */
+  implementationType()
+  {
+    return `${super.implementationType()}:armor`;
   }
 }
 
@@ -2944,6 +3052,24 @@ class RPG_Class
     this.params = classData.params;
     this.traits = classData.traits
       .map(trait => new RPG_Trait(trait));
+  }
+
+  /**
+   * Whether or not this database entry is a class.
+   * @returns {boolean}
+   */
+  isClass()
+  {
+    return true;
+  }
+
+  /**
+   * Gets the type of implementation this database entry is.
+   * @returns {string}
+   */
+  implementationType()
+  {
+    return `${super.implementationType()}:class`;
   }
 }
 
@@ -3027,6 +3153,24 @@ class RPG_Enemy
     this.gold = enemy.gold;
     this.params = enemy.params;
   }
+
+  /**
+   * Whether or not this database entry is an enemy.
+   * @returns {boolean}
+   */
+  isEnemy()
+  {
+    return true;
+  }
+
+  /**
+   * Gets the type of implementation this database entry is.
+   * @returns {string}
+   */
+  implementationType()
+  {
+    return `${super.implementationType()}:enemy`;
+  }
 }
 
 //endregion RPG_Enemy
@@ -3089,6 +3233,15 @@ class RPG_Item
   isItem()
   {
     return true;
+  }
+
+  /**
+   * Gets the type of implementation this database entry is.
+   * @returns {string}
+   */
+  implementationType()
+  {
+    return `${super.implementationType()}:item`;
   }
 }
 
@@ -3191,6 +3344,15 @@ class RPG_Skill
   isSkill()
   {
     return true;
+  }
+
+  /**
+   * Gets the type of implementation this database entry is.
+   * @returns {string}
+   */
+  implementationType()
+  {
+    return `${super.implementationType()}:skill`;
   }
 }
 
@@ -3364,6 +3526,24 @@ class RPG_State
     this.restriction = state.restriction;
     this.stepsToRemove = state.stepsToRemove;
   }
+
+  /**
+   * Whether or not this database entry is a state.
+   * @returns {boolean}
+   */
+  isState()
+  {
+    return true;
+  }
+
+  /**
+   * Gets the type of implementation this database entry is.
+   * @returns {string}
+   */
+  implementationType()
+  {
+    return `${super.implementationType()}:state`;
+  }
 }
 
 //endregion RPG_State
@@ -3419,6 +3599,15 @@ class RPG_Weapon
   isWeapon()
   {
     return true;
+  }
+
+  /**
+   * Gets the type of implementation this database entry is.
+   * @returns {string}
+   */
+  implementationType()
+  {
+    return `${super.implementationType()}:weapon`;
   }
 }
 
@@ -6881,6 +7070,268 @@ class BuiltWindowCommand
   //endregion getters
 }
 
+//region GaugeOptionsBuilder
+/**
+ * A factory for generating {@link WindowGaugeOptions}.
+ * Comes with sensible defaults.
+ */
+class GaugeOptionsBuilder
+{
+  //region properties
+  /**
+   * The color of the gauge's background.
+   * @type {string}
+   */
+  #backColor = String.empty;
+
+  /**
+   * The color of the gauge's border.
+   * @type {string}
+   */
+  #borderColor = 'rgba(255, 255, 255, 0.85)';
+
+  /**
+   * The left color gradient for the gauge.
+   * Blends to the right color.
+   * @type {string}
+   */
+  #leftColor = 'rgba(179, 89, 0, 1)';
+
+  /**
+   * The right color gradient for the gauge.
+   * Blends from the left color.
+   * @type {string}
+   */
+  #rightColor = 'rgba(255, 166, 77, 1)';
+
+  /**
+   * The thickness of the gauge's border.
+   * @type {number}
+   */
+  #borderThickness = 2;
+
+  /**
+   * The gap between the gauge's border and the inner fill area.
+   * @type {number}
+   */
+  #borderGap = 1;
+
+  /**
+   * The color of the segment dividers.
+   * @type {string}
+   */
+  #dividerColor = 'rgba(255, 255, 255, 0.85)';
+
+  /**
+   * The number of visual segments.
+   * @type {number}
+   */
+  #segments = 8;
+
+  /**
+   * The gap between visual segments in pixels.
+   * @type {number}
+   */
+  #gap = 2;
+
+  /**
+   * The corner radius of the pill gauge in pixels.
+   * @type {number}
+   */
+  #radius = 4;
+
+  /**
+   * The thickness of the radial gauge in pixels.
+   * @type {number}
+   */
+  #thickness = 6;
+
+  /**
+   * The start angle of the radial gauge in radians.
+   * @type {number}
+   */
+  #startAngle = (-Math.PI / 2);
+
+  /**
+   * The type of gauge to render.
+   * @type {string}
+   */
+  #gaugeType = Window_Base.GAUGE_TYPES.Rectangle;
+
+  //endregion properties
+
+  /**
+   * Builds the {@link WindowGaugeOptions}.
+   * @returns {WindowGaugeOptions}
+   */
+  build()
+  {
+    return new WindowGaugeOptions(
+      this.#gaugeType,
+      this.#backColor,
+      this.#leftColor,
+      this.#rightColor,
+      this.#borderColor,
+      this.#borderThickness,
+      this.#borderGap,
+      this.#dividerColor,
+      this.#segments,
+      this.#gap,
+      this.#radius,
+      this.#thickness,
+      this.#startAngle,
+    );
+  }
+
+  //region setters
+  /**
+   * The type of gauge, from {@link Window_Base.GAUGE_TYPES}.
+   * @param {string} type The gauge type.
+   * @returns {GaugeOptionsBuilder}
+   */
+  gaugeType(type)
+  {
+    this.#gaugeType = type;
+    return this;
+  }
+
+  /**
+   * Sets the gauge's background color.
+   * @param {string} color The color to set.
+   * @returns {GaugeOptionsBuilder}
+   */
+  backColor(color)
+  {
+    this.#backColor = color;
+    return this;
+  }
+
+  /**
+   * Sets the left color gradient for the gauge.
+   * @param {string} color The color to set.
+   * @returns {GaugeOptionsBuilder}
+   */
+  leftGradientColor(color)
+  {
+    this.#leftColor = color;
+    return this;
+  }
+
+  /**
+   * Sets the right color gradient for the gauge.
+   * @param {string} color The color to set.
+   * @returns {GaugeOptionsBuilder}
+   */
+  rightGradientColor(color)
+  {
+    this.#rightColor = color;
+    return this;
+  }
+
+  /**
+   * Sets the gauge’s border color.
+   * @param {string} color The outline color.
+   * @returns {GaugeOptionsBuilder}
+   */
+  borderColor(color)
+  {
+    this.#borderColor = color;
+    return this;
+  }
+
+  /**
+   * Sets the border thickness in pixels (>=1).
+   * @param {number} thickness The outline thickness.
+   * @returns {GaugeOptionsBuilder}
+   */
+  borderThickness(thickness)
+  {
+    this.#borderThickness = thickness;
+    return this;
+  }
+
+  /**
+   * Sets the padding between outline and inner fill area (>=0).
+   * @param {number} gap The padding.
+   * @returns {GaugeOptionsBuilder}
+   */
+  borderGap(gap)
+  {
+    this.#borderGap = gap;
+    return this;
+  }
+
+  /**
+   * Sets the color for segment dividers (defaults to borderColor if omitted).
+   * @param {string} color The divider color.
+   * @returns {GaugeOptionsBuilder}
+   */
+  dividerColor(color)
+  {
+    this.#dividerColor = color;
+    return this;
+  }
+
+  /**
+   * Sets the number of visual segments (>=1).
+   * @param {number} count The segment count.
+   * @returns {GaugeOptionsBuilder}
+   */
+  segments(count)
+  {
+    this.#segments = count;
+    return this;
+  }
+
+  /**
+   * Sets the inter‑segment gap in pixels (>=0).
+   * @param {number} px The gap width.
+   * @returns {GaugeOptionsBuilder}
+   */
+  gap(px)
+  {
+    this.#gap = px;
+    return this;
+  }
+
+  /**
+   * Sets the visual corner radius for pill gauges.
+   * @param {number} r The radius in pixels.
+   * @returns {GaugeOptionsBuilder}
+   */
+  radius(r)
+  {
+    this.#radius = r;
+    return this;
+  }
+
+  /**
+   * Sets the ring thickness for radial gauges.
+   * @param {number|null} t The thickness in pixels; null to derive automatically.
+   * @returns {GaugeOptionsBuilder}
+   */
+  thickness(t)
+  {
+    this.#thickness = t;
+    return this;
+  }
+
+  /**
+   * Sets the start angle for radial gauges (radians).
+   * @param {number} radians The start angle.
+   * @returns {GaugeOptionsBuilder}
+   */
+  startAngle(radians)
+  {
+    this.#startAngle = radians;
+    return this;
+  }
+
+  //endregion setters
+}
+
+//endregion GaugeOptionsBuilder
+
 //region J_EventEmitter
 /**
  * A custom event emitter for providing an event-driven approach to targeted
@@ -7790,6 +8241,139 @@ class WindowCommandBuilder
   }
 }
 
+//region WindowGaugeOptions
+/**
+ * The options for a gauge that shows up in the window.
+ */
+class WindowGaugeOptions
+{
+  /**
+   * A factory for generating {@link WindowGaugeOptions}.
+   * @returns {GaugeOptionsBuilder}
+   * @constructor
+   */
+  static Builder = () => new GaugeOptionsBuilder();
+
+  //region properties
+  /**
+   * The type of gauge to render.
+   * @type {string}
+   */
+  gaugeType = String.empty;
+
+  /**
+   * The color of the gauge's background.
+   * @type {string}
+   */
+  backColor = String.empty;
+
+  /**
+   * The left color gradient for the gauge.
+   * @type {string}
+   */
+  leftGradientColor = String.empty;
+
+  /**
+   * The right color gradient for the gauge.
+   * @type {string}
+   */
+  rightGradientColor = String.empty;
+
+  /**
+   * The color of the gauge's border.
+   * @type {string}
+   */
+  borderColor = String.empty;
+
+  /**
+   * The thickness of the gauge's border.
+   * @type {number}
+   */
+  borderThickness = 0;
+
+  /**
+   * The gap between the gauge's border and the inner fill area.
+   * @type {number}
+   */
+  borderGap = 0;
+
+  /**
+   * The color of the segment dividers.
+   * @type {string}
+   */
+  dividerColor = String.empty;
+
+  /**
+   * The number of visual segments.
+   * @type {number}
+   */
+  segments = 1;
+
+  /**
+   * The gap between visual segments in pixels.
+   * @type {number}
+   */
+  gap = 0;
+
+  /**
+   * The corner radius of the pill gauge in pixels.
+   * @type {number}
+   */
+  radius = 0;
+
+  /**
+   * The thickness of the radial gauge in pixels.
+   * @type {number}
+   */
+  thickness = 1;
+
+  /**
+   * The start angle of the radial gauge in radians.
+   * @type {number}
+   */
+  startAngle = 0;
+
+  //endregion properties
+
+  /**
+   * Constructor.
+   */
+  constructor(
+    gaugeType,
+    backColor,
+    leftGradientColor,
+    rightGradientColor,
+    borderColor,
+    borderThickness,
+    borderGap,
+    dividerColor,
+    segments,
+    gap,
+    radius,
+    thickness,
+    startAngle
+  )
+  {
+    this.gaugeType = gaugeType;
+    this.backColor = backColor;
+    this.leftGradientColor = leftGradientColor;
+    this.rightGradientColor = rightGradientColor;
+    this.borderColor = borderColor;
+    this.borderThickness = borderThickness;
+    this.borderGap = borderGap;
+    this.dividerColor = dividerColor;
+    this.segments = segments;
+    this.gap = gap;
+    this.radius = radius;
+    this.thickness = thickness;
+    this.startAngle = startAngle;
+  }
+}
+
+//endregion WindowGaugeOptions
+
+/* eslint-disable no-unused-vars */
+
 //region Game_Actor
 /**
  * Gets the parameter value from the "long" parameter id.
@@ -7918,7 +8502,8 @@ Game_Actor.prototype.getActorNotes = function()
     actor,
 
     // add the actor's class to the source list.
-    this.class(actor.classId) ];
+    this.class(actor.classId)
+  ];
 };
 
 /**
@@ -7936,7 +8521,8 @@ Game_Actor.prototype.getNotesSources = function()
     this.currentClass(),
 
     // add all of the actor's valid equips to the source list.
-    ...this.equippedEquips(), ];
+    ...this.equippedEquips(),
+  ];
 
   // combine the two source lists.
   const combinedNoteSources = baseNoteSources.concat(actorUniqueNoteSources);
@@ -8087,6 +8673,10 @@ Game_Actor.prototype.onEquipChange = function()
   this.onBattlerDataChange();
 };
 
+/**
+ * Extends {@link #changeClass}.<br/>
+ * Adds a hook for performing actions when the actor changes class.
+ */
 J.BASE.Aliased.Game_Actor.set('changeClass', Game_Actor.prototype.changeClass);
 Game_Actor.prototype.changeClass = function(classId, keepExp)
 {
@@ -8255,6 +8845,19 @@ Game_Actor.prototype.equippedEquips = function()
 };
 
 /**
+ * Sets the level of this actor to the given level.
+ * @param {number} level The level to set this actor to.
+ */
+Game_Actor.prototype.setLevel = function(level)
+{
+  // Identify the minimum threshold of experience for the target level.
+  const newExperience = this.expForLevel(level);
+
+  // change the experience for this actor to the new level's amount.
+  this.changeExp(newExperience, false);
+};
+
+/**
  * An event hook fired when this actor levels up.
  */
 Game_Actor.prototype.onLevelUp = function()
@@ -8263,7 +8866,7 @@ Game_Actor.prototype.onLevelUp = function()
 };
 
 /**
- * Extends {@link #levelUp}.<br>
+ * Extends {@link #levelUp}.<br/>
  * Adds a hook for performing actions when an the actor levels up.
  */
 J.BASE.Aliased.Game_Actor.set('levelUp', Game_Actor.prototype.levelUp);
@@ -9549,9 +10152,32 @@ Game_Party.prototype.recoverAllMembers = function()
     .forEach(member => member.recoverAll());
 };
 
+/**
+ * Overrides {@link #maxBattleMembers}.<br/>
+ * Sets the maximum number of battle members to 8.
+ * @returns {number}
+ */
 Game_Party.prototype.maxBattleMembers = function()
 {
   return 8;
+};
+
+/**
+ * Sets the level of all party members to the given level.
+ * @param {number} level The level to set all party members to.
+ */
+Game_Party.prototype.setLevel = function(level)
+{
+  // iterate over each member and set their level to the designated level.
+  this.members()
+    .forEach(member =>
+    {
+      // ensure the level is within the valid range.
+      const normalizedLevel = level.clamp(1, member.maxLevel());
+
+      // set the level.
+      member.setLevel(normalizedLevel);
+    });
 };
 //endregion Game_Party
 
@@ -11086,6 +11712,231 @@ Tilemap.prototype._addShadow = function(layer, shadowBits, dx, dy)
 };
 //endregion TileMap
 
+//region Window_ActorRibbon
+/**
+ * A window for rendering a ribbon of an actor's face.
+ * If the window is made longer or taller, additional info could be rendered around it.
+ */
+class Window_ActorRibbon
+  extends Window_Base
+{
+  //region init
+  /**
+   * @constructor
+   * @param {Rectangle} rect The rectangle that defines this window's shape.
+   */
+  constructor(rect)
+  {
+    // perform original logic.
+    super(rect);
+
+    // initialize our custom members.
+    this.initMembers();
+  }
+
+  /**
+   * Initializes all custom members of this window.
+   */
+  initMembers()
+  {
+    /**
+     * The actor in this window.
+     * @type {Game_Actor|null}
+     */
+    this._actor = null;
+
+    /**
+     * The width of the actor face in the ribbon.
+     * @type {number}
+     */
+    this._faceWidth = 128;
+
+    /**
+     * The height of the actor face in the ribbon.
+     * @type {number}
+     */
+    this._faceHeight = 40;
+
+    /**
+     * The x of the actor's face in the ribbon.
+     * @type {number}
+     */
+    this._faceX = 0;
+
+    /**
+     * The y of the actor's face in the ribbon.
+     * @type {number}
+     */
+    this._faceY = 0;
+  }
+
+  //endregion init
+
+  //region properties
+  //region actor
+  /**
+   * Gets the actor focus for the window.
+   * @returns {Game_Actor|null}
+   */
+  actor()
+  {
+    return this._actor;
+  }
+
+  /**
+   * Sets the actor focus for the window and optionally refreshes.
+   * @param {Game_Actor} actor The actor to display.
+   * @param {boolean} [andRefresh=true] Whether or not to refresh the window; defaults to true.
+   */
+  setActor(actor, andRefresh = true)
+  {
+    // set the actor.
+    this._actor = actor;
+
+    // check if a refresh is desired.
+    if (andRefresh)
+    {
+      // refresh the window.
+      this.refresh();
+    }
+  }
+
+  //endregion actor
+
+  // region face size
+  /**
+   * The width of the actor face in the ribbon.
+   * @returns {number}
+   */
+  faceWidth()
+  {
+    return this._faceWidth;
+  }
+
+  /**
+   * The width of the actor face in the ribbon.
+   * @returns {number}
+   */
+  setFaceWidth(width)
+  {
+    this._faceWidth = width;
+  }
+
+  /**
+   * The height of the actor face in the ribbon.
+   * @returns {number}
+   */
+  faceHeight()
+  {
+    return this._faceHeight;
+  }
+
+  /**
+   * The height of the actor face in the ribbon.
+   * @returns {number}
+   */
+  setFaceHeight(height)
+  {
+    this._faceHeight = height;
+  }
+
+  /**
+   * Gets the size of the actor face in the ribbon.
+   * @returns {[number, number]}
+   */
+  faceSize()
+  {
+    return [ this.faceWidth(), this.faceHeight() ];
+  }
+
+  //endregion face size
+
+  //region face coordinates
+  /**
+   * Gets the x coordinate of the actor face in the ribbon.
+   * @returns {number}
+   */
+  faceX()
+  {
+    return this._faceX;
+  }
+
+  /**
+   * Sets the x coordinate of the actor face in the ribbon.
+   * @param {number} x The x coordinate.
+   */
+  setFaceX(x)
+  {
+    this._faceX = x;
+  }
+
+  /**
+   * Gets the y coordinate of the actor face in the ribbon.
+   * @returns {number}
+   */
+  faceY()
+  {
+    return this._faceY;
+  }
+
+  /**
+   * Sets the y coordinate of the actor face in the ribbon.
+   * @param {number} y The y coordinate.
+   */
+  setFaceY(y)
+  {
+    this._faceY = y;
+  }
+
+  /**
+   * Gets the coordinates of the actor face in the ribbon.
+   * @returns {[number, number]}
+   */
+  faceCoordinates()
+  {
+    return [ this.faceX(), this.faceY() ];
+  }
+
+  //endregion face coordinates
+  //endregion properties
+
+  //region draw
+  /**
+   * Implements {@link #drawContent}.<br/>
+   * Draws the actor face in the ribbon.
+   */
+  drawContent()
+  {
+    // don't draw if the actor is unavailable.
+    if (!this._actor) return;
+
+    // draw the actor face.
+    this.drawActorRibbon();
+  }
+
+  /**
+   * Draws the actor face in the ribbon.
+   */
+  drawActorRibbon()
+  {
+    // grab the actor.
+    const actor = this.actor();
+
+    // grab the coordinates of the face.
+    const [ x, y ] = this.faceCoordinates();
+
+    // grab the size of the face.
+    const [ w, h ] = this.faceSize();
+
+    // draw the face.
+    this.drawFace(actor.faceName(), actor.faceIndex(), x, y, w, h);
+  }
+
+  //endregion draw
+}
+
+//endregion Window_ActorRibbon
+
 //region Window_Base
 /**
  * All alignments available for {@link Window_Base.prototype.drawText}.<br>
@@ -11111,6 +11962,25 @@ Window_Base.TextAlignments = {
    */
   Right: 'right'
 };
+
+/**
+ * Enumerates built-in gauge types for {@link Window_Base#drawGauge}.
+ */
+Window_Base.GAUGE_TYPES = {
+  // a bordered rectangular gauge with gradient fill.
+  Rectangle: 'rect',
+
+  // a segmented gauge.
+  Segmented: 'segmented',
+
+  // a rounded-corner style.
+  Pill: 'pill',
+
+  // a circular ring gauge.
+  Radial: 'radial',
+};
+
+//region draw text
 
 /**
  * Draws a horizontal "line" with the given parameters.
@@ -11276,6 +12146,8 @@ Window_Base.prototype.setFontSize = function(fontSize)
   this.contents.fontSize = normalizedFontSize;
 };
 
+//endregion draw text
+
 /**
  * Renders a "background" of a given rectangle.
  * This is centralized for all windows to leverage if necessary.
@@ -11299,6 +12171,422 @@ Window_Base.prototype.drawBackgroundRect = function(rect)
   this.contentsBack.gradientFillRect(x, y, width, height, color1, color2, true);
   this.contentsBack.strokeRect(x, y, width, height, color1);
 };
+
+// region draw gauge
+
+/**
+ * The height of this gauge.
+ */
+Window_Base.prototype.gaugeHeight = function()
+{
+  return 10;
+};
+
+/**
+ * The backdrop color.
+ * Defaults to black with 50% opacity.
+ * @returns {string}
+ */
+Window_Base.prototype.gaugeBackColor = function()
+{
+  return 'rgba(0, 0, 0, 0.5)';
+};
+
+/**
+ * Draws a gauge using a {@link Rectangle} and a {@link WindowGaugeOptions}.
+ * @param {Rectangle} rect The rectangle area to draw within.
+ * @param {number} rate The 0..1 fill amount.
+ * @param {WindowGaugeOptions} options The gauge options.
+ */
+Window_Base.prototype.drawGauge = function(
+  rect,
+  rate,
+  options,
+)
+{
+  // delegate to the Rectangle-based switch.
+  this.drawGaugeRect(rect, rate, options);
+};
+
+/**
+ * Dispatches to the specific gauge renderer based on the options.
+ * Provides an inner-rect (padding) and delegates shape/back/border to the style.
+ * @param {Rectangle} rect The rectangle area.
+ * @param {number} rate The 0..1 fill amount.
+ * @param {WindowGaugeOptions} options The strongly-typed gauge options.
+ */
+Window_Base.prototype.drawGaugeRect = function(rect, rate, options)
+{
+  // clamp the rate to the 0..1 range.
+  const clampedRate = Math.max(0, Math.min(1, rate));
+
+  // compute the inner rectangle to avoid the border padding.
+  const inner = this._computeGaugeInnerRect(rect, options);
+
+  // extract the inner rectangle coordinates.
+  const {
+    x,
+    y,
+    width,
+    height
+  } = inner;
+
+  // route to the appropriate style.
+  switch (options.gaugeType)
+  {
+    case Window_Base.GAUGE_TYPES.Segmented:
+    {
+      this.drawGaugeSegmented(x, y, width, height, clampedRate, options);
+      break;
+    }
+    case Window_Base.GAUGE_TYPES.Pill:
+    {
+      this.drawGaugePill(x, y, width, height, clampedRate, options);
+      break;
+    }
+    case Window_Base.GAUGE_TYPES.Radial:
+    {
+      this.drawGaugeRadial(x, y, width, height, clampedRate, options);
+      break;
+    }
+    case Window_Base.GAUGE_TYPES.Rectangle:
+    default:
+    {
+      this.drawGaugeBorderedRect(x, y, width, height, clampedRate, options);
+      break;
+    }
+  }
+};
+
+/**
+ * Draws a rectangular gauge with a gradient fill and a rectangle border that
+ * hugs the fill area. Back color is rendered first.
+ * @param {number} x The x coordinate inside the inner rect.
+ * @param {number} y The y coordinate inside the inner rect.
+ * @param {number} w The inner width.
+ * @param {number} h The inner height.
+ * @param {number} rate The 0..1 fill amount.
+ * @param {WindowGaugeOptions} options The strongly-typed gauge options.
+ */
+Window_Base.prototype.drawGaugeBorderedRect = function(x, y, w, h, rate, options)
+{
+  // styling.
+  const { backColor } = options;
+  const { borderColor } = options;
+  const { borderThickness } = options;
+
+  // fill back area.
+  this.contents.fillRect(x, y, w, h, backColor);
+
+  // fill gradient portion.
+  const fw = Math.max(0, Math.floor(w * Math.max(0, Math.min(1, rate))));
+  if (fw > 0 && h > 0)
+  {
+    this.contents.gradientFillRect(x, y, fw, h, options.leftGradientColor, options.rightGradientColor);
+  }
+
+  // stroke rectangular border.
+  const ctx = this.contents._context;
+  ctx.save();
+  ctx.beginPath();
+  ctx.rect(x + 0.5, y + 0.5, w - 1, h - 1);
+  ctx.lineWidth = borderThickness;
+  ctx.strokeStyle = borderColor;
+  ctx.stroke();
+  ctx.restore();
+};
+
+/**
+ * Draws a segmented gauge with a single continuous gradient across the filled length.
+ * Then carves gap bars so color transitions don’t reset per segment.
+ * Border is a simple rectangle following the gauge.
+ * @param {number} x The x coordinate.
+ * @param {number} y The y coordinate.
+ * @param {number} w The inner width.
+ * @param {number} h The inner height.
+ * @param {number} rate The 0..1 fill amount.
+ * @param {WindowGaugeOptions} options The strongly-typed gauge options.
+ */
+Window_Base.prototype.drawGaugeSegmented = function(x, y, w, h, rate, options)
+{
+  // pull styling.
+  const { backColor } = options;
+  const { borderColor } = options;
+  const { borderThickness } = options;
+
+  // divider styling (defaults to border color so it remains visible on any fill).
+  const dividerColor = options.dividerColor || borderColor;
+
+  // coerce parameters.
+  const count = Math.max(1, Number(options.segments));
+  const spacing = Math.max(0, Number(options.gap));
+
+  // compute the filled width and early outs.
+  const clamped = Math.max(0, Math.min(1, rate));
+  const fw = Math.max(0, Math.floor(w * clamped));
+  if (h <= 0) return;
+
+  // BACK: whole rect.
+  this.contents.fillRect(x, y, w, h, backColor);
+
+  // FILL: one continuous gradient across fw.
+  if (fw > 0)
+  {
+    this.contents.gradientFillRect(x, y, fw, h, options.leftGradientColor, options.rightGradientColor);
+
+    // carve gaps without breaking the gradient.
+    if (count > 1 && spacing > 0)
+    {
+      const totalGap = spacing * (count - 1);
+      const segW = Math.max(1, Math.floor((w - totalGap) / count));
+      for (let i = 1; i < count; i++)
+      {
+        // location of the i-th divider (left edge of the gap)
+        const gx = x + i * segW + (i - 1) * spacing;
+
+        // only carve within the filled area.
+        if (gx < x + fw)
+        {
+          // width to carve for this divider (may be truncated if near the fill edge).
+          const carve = Math.min(spacing, (x + fw) - gx);
+
+          // draw the divider using its own color for strong contrast.
+          if (carve > 0)
+          {
+            this.contents.fillRect(gx, y, carve, h, dividerColor);
+          }
+        }
+      }
+    }
+  }
+
+  // BORDER: rectangular stroke around the shape.
+  const ctx = this.contents._context;
+  ctx.save();
+  ctx.beginPath();
+  ctx.rect(x + 0.5, y + 0.5, w - 1, h - 1);
+  ctx.lineWidth = borderThickness;
+  ctx.strokeStyle = borderColor;
+  ctx.stroke();
+  ctx.restore();
+};
+
+/**
+ * Draws a pill gauge with a true rounded-rectangle path (no scanlines),
+ * then outlines it so the border follows the pill shape.
+ * @param {number} x The x coordinate.
+ * @param {number} y The y coordinate.
+ * @param {number} w The inner width.
+ * @param {number} h The inner height.
+ * @param {number} rate The 0..1 fill amount.
+ * @param {WindowGaugeOptions} options The strongly-typed gauge options.
+ */
+Window_Base.prototype.drawGaugePill = function(x, y, w, h, rate, options)
+{
+  // clamp the radius to avoid pointy ends.
+  const maxR = Math.max(0, Math.floor(h / 2) - 1);
+  const r = Math.max(0, Math.min(Number(options.radius), maxR));
+
+  // derive styling.
+  const { backColor } = options;
+  const { borderColor } = options;
+  const { borderThickness } = options;
+
+  // compute the filled width.
+  const fw = Math.max(0, Math.floor(w * Math.max(0, Math.min(1, rate))));
+  if (h <= 0) return;
+
+  // get 2D context and gradient.
+  const ctx = this.contents._context;
+  const grad = ctx.createLinearGradient(x, y, x + w, y);
+  grad.addColorStop(0, options.leftGradientColor);
+  grad.addColorStop(1, options.rightGradientColor);
+
+  // helper to draw a rounded-rect path.
+  const roundedRectPath = () =>
+  {
+    const x2 = x + w;
+    const y2 = y + h;
+    ctx.beginPath();
+    ctx.moveTo(x + r, y);
+    ctx.lineTo(x2 - r, y);
+    ctx.arcTo(x2, y, x2, y + r, r);
+    ctx.lineTo(x2, y2 - r);
+    ctx.arcTo(x2, y2, x2 - r, y2, r);
+    ctx.lineTo(x + r, y2);
+    ctx.arcTo(x, y2, x, y2 - r, r);
+    ctx.lineTo(x, y + r);
+    ctx.arcTo(x, y, x + r, y, r);
+    ctx.closePath();
+  };
+
+  // BACK: pill outline filled with back color.
+  ctx.save();
+  roundedRectPath();
+  ctx.fillStyle = backColor;
+  ctx.fill();
+  ctx.restore();
+
+  // FILL: draw only the left fw portion — clip to the pill shape for clean ends.
+  if (fw > 0)
+  {
+    ctx.save();
+    roundedRectPath();
+    ctx.clip();
+    ctx.fillStyle = grad;
+    ctx.fillRect(x, y, fw, h);
+    ctx.restore();
+  }
+
+  // BORDER: stroke the pill outline.
+  ctx.save();
+  roundedRectPath();
+  ctx.lineWidth = borderThickness;
+  ctx.strokeStyle = borderColor;
+  ctx.stroke();
+  ctx.restore();
+};
+
+/**
+ * Draws an elliptical (oval-capable) radial gauge inside the given rect.
+ * Renders: back ring → filled wedge → border strokes that follow outer+inner ellipses.
+ * @param {number} x The inner-rect x.
+ * @param {number} y The inner-rect y.
+ * @param {number} w The inner-rect width.
+ * @param {number} h The inner-rect height.
+ * @param {number} rate The 0..1 fill amount.
+ * @param {WindowGaugeOptions} options The strongly-typed gauge options.
+ */
+Window_Base.prototype.drawGaugeRadial = function(x, y, w, h, rate, options)
+{
+  // compute outer radii and center.
+  const rx = Math.max(2, Math.floor(w / 2) - 1);
+  const ry = Math.max(2, Math.floor(h / 2) - 1);
+  const cx = x + Math.floor(w / 2);
+  const cy = y + Math.floor(h / 2);
+
+  // clamp rate and angles.
+  const r = Math.max(0, Math.min(1, rate));
+  const a0 = options.startAngle;
+  const a1 = a0 + (Math.PI * 2 * r);
+
+  // inner radii from thickness.
+  const t = Math.max(1, Math.floor(options.thickness));
+  const irx = Math.max(1, rx - t);
+  const iry = Math.max(1, ry - t);
+
+  // styling.
+  const { backColor } = options;
+  const { borderColor } = options;
+  const { borderThickness } = options;
+
+  // acquire 2D context and gradient.
+  const ctx = this.contents._context;
+  const midAngle = a0 + (a1 - a0) / 2;
+  const gx0 = cx + Math.cos(a0) * irx;
+  const gy0 = cy + Math.sin(a0) * iry;
+  const gx1 = cx + Math.cos(midAngle) * rx;
+  const gy1 = cy + Math.sin(midAngle) * ry;
+  const grad = ctx.createLinearGradient(gx0, gy0, gx1, gy1);
+  grad.addColorStop(0, options.leftGradientColor);
+  grad.addColorStop(1, options.rightGradientColor);
+
+  // BACK: full ring.
+  ctx.save();
+  ctx.beginPath();
+  ctx.ellipse(cx, cy, rx, ry, 0, 0, Math.PI * 2, false);
+  ctx.ellipse(cx, cy, irx, iry, 0, Math.PI * 2, 0, true);
+  ctx.closePath();
+  ctx.fillStyle = backColor;
+  ctx.fill();
+  ctx.restore();
+
+  // FILL: wedge slice (donut section) if any progress.
+  if (r > 0)
+  {
+    ctx.save();
+    ctx.beginPath();
+    ctx.ellipse(cx, cy, rx, ry, 0, a0, a1, false);
+    ctx.ellipse(cx, cy, irx, iry, 0, a1, a0, true);
+    ctx.closePath();
+    ctx.fillStyle = grad;
+    ctx.fill();
+    ctx.restore();
+  }
+
+  // BORDER: outer + inner ellipses stroked to match the ring’s shape.
+  ctx.save();
+  ctx.lineWidth = borderThickness;
+  ctx.strokeStyle = borderColor;
+
+  // outer ring border.
+  ctx.beginPath();
+  ctx.ellipse(
+    cx,
+    cy,
+    rx - (borderThickness % 2
+      ? 0.5
+      : 0),
+    ry - (borderThickness % 2
+      ? 0.5
+      : 0),
+    0,
+    0,
+    Math.PI * 2,
+    false
+  );
+  ctx.stroke();
+
+  // inner ring border.
+  ctx.beginPath();
+  ctx.ellipse(
+    cx,
+    cy,
+    irx + (borderThickness % 2
+      ? 0.5
+      : 0),
+    iry + (borderThickness % 2
+      ? 0.5
+      : 0),
+    0,
+    0,
+    Math.PI * 2,
+    false
+  );
+  ctx.stroke();
+  ctx.restore();
+};
+
+/**
+ * Computes the inner rectangle to draw into by applying border/padding options.
+ * This prevents the fill from touching the border while letting each style
+ * render its own border/backdrop shape.
+ * @param {Rectangle} rect The outer rectangle passed to drawGauge.
+ * @param {WindowGaugeOptions} options The gauge options (includes border settings).
+ * @returns {Rectangle} The inner rect.
+ */
+Window_Base.prototype._computeGaugeInnerRect = function(rect, options)
+{
+  // pull padding factors.
+  const borderThickness = Math.max(1, options.borderThickness);
+  const borderGap = Math.max(0, options.borderGap);
+
+  // compute inner rect inside the padding.
+  const ix = rect.x + borderThickness + borderGap;
+  const iy = rect.y + borderThickness + borderGap;
+  const iw = Math.max(0, rect.width - ((borderThickness + borderGap) * 2));
+  const ih = Math.max(0, rect.height - ((borderThickness + borderGap) * 2));
+
+  // return the inner rect.
+  return {
+    x: ix,
+    y: iy,
+    width: iw,
+    height: ih
+  };
+};
+
+//endregion draw gauge
 //endregion Window_Base
 
 //region Window_Command
@@ -11367,7 +12655,7 @@ Window_Command.prototype.drawItem = function(index)
   const rightText = this.commandRightText(index);
 
   // grab the subtext for this command.
-  const isSubtext = this.isCommandSubtext(index)
+  const isSubtext = this.isCommandSubtext(index);
   const subtexts = this.commandSubtext(index);
 
   // grab the extra lines for this command.
@@ -11415,7 +12703,8 @@ Window_Command.prototype.drawItem = function(index)
       commandNameX - 36,
       faceY - 12,
       ImageManager.faceWidth,
-      ImageManager.faceHeight);
+      ImageManager.faceHeight
+    );
     commandNameX += 36;
   }
 
@@ -11459,7 +12748,7 @@ Window_Command.prototype.drawItem = function(index)
     this.processColorChange(this.commandRightColorIndex(index));
 
     // render the right-aligned text.
-    this.drawText(rightText, rightTextX, rightTextY, textWidth, "right");
+    this.drawText(rightText, rightTextX, rightTextY, textWidth, 'right');
 
     // bolden the text if we have subtext to make it stand out.
     this.toggleBold(false);

--- a/project/js/plugins/J-LevelMaster.js
+++ b/project/js/plugins/J-LevelMaster.js
@@ -634,6 +634,7 @@ JABS_AiManager.postConvertMutate = function(battler, jabsBattler)
 /**
  * A helper class for calculating level-based scaling multipliers.
  */
+// eslint-disable-next-line no-unused-vars
 class LevelScaling
 {
   //region properties
@@ -687,7 +688,7 @@ class LevelScaling
    */
   constructor()
   {
-    throw new Error("This is a static class.");
+    throw new Error('This is a static class.');
   }
 
   /**
@@ -946,7 +947,8 @@ Game_Actor.prototype.getLevelSources = function()
     ...this.equips(),
 
     // add all currently applied states to the source list.
-    ...this.allStates(), ];
+    ...this.allStates(),
+  ];
 };
 
 /**

--- a/project/js/plugins/J-Log.js
+++ b/project/js/plugins/J-Log.js
@@ -462,7 +462,7 @@ class ActionLogBuilder
    * The current message that this log contains.
    * @type {string}
    */
-  #message = "message-unset";
+  #message = 'message-unset';
 
   /**
    * Builds the log based on the currently provided info.
@@ -535,14 +535,14 @@ class ActionLogBuilder
     if (isCritical)
     {
       hurtOrHeal = isHealing
-        ? "critically healed"
-        : "landed a critical";
+        ? 'critically healed'
+        : 'landed a critical';
     }
     else
     {
       hurtOrHeal = isHealing
-        ? "healed"
-        : "hit";
+        ? 'healed'
+        : 'hit';
     }
 
     // the text color index is based on whether or not its flagged as healing.
@@ -571,14 +571,14 @@ class ActionLogBuilder
     if (isCritical)
     {
       hurtOrHeal = isHealing
-        ? "critically healed"
-        : "devastatingly damaged";
+        ? 'critically healed'
+        : 'devastatingly damaged';
     }
     else
     {
       hurtOrHeal = isHealing
-        ? "restored"
-        : "struck";
+        ? 'restored'
+        : 'struck';
     }
 
     // the text color index is based on whether or not its flagged as healing.
@@ -715,11 +715,11 @@ class ActionLogBuilder
 
     // construct the message.
     const prefix = isPreciseParry
-      ? "precise-"
-      : "";
+      ? 'precise-'
+      : '';
     const suffix = isPreciseParry
-      ? " with finesse!"
-      : ".";
+      ? ' with finesse!'
+      : '.';
     const message = `${defender} ${prefix}parried ${casterName}'s \\Skill[${skillId}]${suffix}`;
 
     // assign the message to this log.

--- a/project/js/plugins/J-SDP.js
+++ b/project/js/plugins/J-SDP.js
@@ -4641,7 +4641,7 @@ class Window_SdpPoints
     const x = 240;
     const y = 0;
     const textWidth = 300;
-    const alignment = "left";
+    const alignment = 'left';
     this.drawText(points, x, y, textWidth, alignment);
   }
 
@@ -4654,8 +4654,13 @@ class Window_SdpPoints
     if (!this._actor) return;
 
     this.drawFace(
-      this._actor.faceName(), this._actor.faceIndex(), 0, 0,   // x,y
-      128, 40);// w,h
+      this._actor.faceName(),
+      this._actor.faceIndex(),
+      0,
+      0,
+      128,
+      40
+    );
   }
 
   /**

--- a/project/js/plugins/J-TextPops.js
+++ b/project/js/plugins/J-TextPops.js
@@ -608,13 +608,13 @@ class TextPopBuilder
     if (elementalRate < 1)
     {
       // add an arbitrary elipses at the end of the damage.
-      this.setSuffix("...");
+      this.setSuffix('...');
     }
     // check if the rate is above 1, such as 1.5 aka 150% damage.
     else if (elementalRate > 1)
     {
       // add an arbitrary triple bang at the end of the damage.
-      this.setSuffix("!!!");
+      this.setSuffix('!!!');
     }
 
     // return the builder for continuous building.

--- a/project/js/plugins/apt/J-Aptitude.js
+++ b/project/js/plugins/apt/J-Aptitude.js
@@ -1,0 +1,4396 @@
+//region annotations
+/*:
+ * @target MZ
+ * @plugindesc
+ * [v1.0.0 APT] A plugin that grants the ability to learn by gaining points.
+ * @author JE
+ * @url https://github.com/je-can-code/rmmz-plugins
+ * @base J-Base
+ * @orderAfter J-Base
+ * @orderAfter J-ABS
+ * @orderAfter J-LevelMaster
+ * @orderAfter J-Log
+ * @orderAfter J-TextPops
+ * @help
+ * ============================================================================
+ * OVERVIEW
+ * This plugin grants the ability to learn skills by gaining points.
+ *
+ * Integrates with others of mine plugins:
+ * - J-Base; to be honest this is just required for all my plugins.
+ * - J-ABS; acquire points from enemy kills and skill executions.
+ * - J-LevelMaster; considers level difference for an AP multiplier.
+ * - J-Log; log all AP gained.
+ * - J-TextPops; display popups for AP gained.
+ *
+ * ----------------------------------------------------------------------------
+ * DETAILS
+ * This plugin lets actors learn skills by gaining AP (Aptitude Points).
+ * As actors earn AP, it flows into the currently-active sources
+ * (like Class/Weapons/Armor/States/Actor), and when a requirement is met:
+ * the skill is learned.
+ * - Only active sources on the actor receive AP. Change gear/class/state?
+ *   Active sources change too.
+ * - Multiple sources can point at the same skill; progress is tracked per
+ *   source and the moment any teaching crosses its requirement, the skill
+ *   becomes learned for the actor.
+ *
+ * ============================================================================
+ * TEACHABLES
+ * Ever want to have skills “teach themselves” while you play? Well now you
+ * can! By applying the appropriate tags across the various database locations,
+ * your actors will soak up AP from adventures and unlock those skills.
+ *
+ * TAG USAGE:
+ * - Actors
+ * - Classes
+ * - Weapons
+ * - Armor
+ * - States
+ *
+ * TAG FORMAT:
+ *  <aptitude:[SKILL_ID, REQUIRED_AP]>
+ *    Where SKILL_ID is the database id of the skill to learn,
+ *    Where REQUIRED_AP is how much AP that source needs to teach it.
+ *
+ * TAG EXAMPLES:
+ *  <aptitude:[12, 150]>
+ * This source enables learning skill of id 12 once the owner gains 150 AP.
+ * ============================================================================
+ * AP
+ * Ever want to gain AP so that you could learn all those skills that various
+ * sources teach. Well now you can! By applying the appropriate tags onto
+ * enemies, you too can gain AP when chopping up enemies.
+ *
+ * NOTE ABOUT LEVEL DIFFERENCE
+ * There is a limit by default that prevents AP from being gained when the
+ * actor level is too far above the enemy level. This is a plugin parameter
+ * for your convenience. If you set the plugin parameter to -1, the
+ * functionality will be disabled.
+ *
+ * TAG USAGE:
+ * - Enemies only.
+ *
+ * TAG FORMAT:
+ *  <ap:[AMOUNT]>
+ *    Where AMOUNT is the amount of AP to be gained.
+ *
+ * TAG EXAMPLES:
+ *  <ap:6>
+ * This enemy will yield 6 AP upon defeat.
+ *
+ * ============================================================================
+ * TIPS
+ * ----------------------------------------------------------------------------
+ * - Stack learnings: You can define the same skill on multiple sources. The UI
+ *   will aggregate per‑source progress for that skill so you can see total vs.
+ *   source contributions.
+ * - Source lifetime: Only currently active sources on the actor receive AP
+ *   (ex: changing class/equipment/states changes the active set of sources).
+ * - J-ABS synergy: Pair enemy <ap:...> rewards with your encounter balance to
+ *   tune progression alongside EXP.
+ *
+ * ============================================================================
+ * CHANGELOG:
+ * - 1.0.0
+ *    The initial release.
+ * ============================================================================
+ *
+ * @param parentConfig
+ * @text SETUP
+ *
+ * @param menu-switch
+ * @parent parentConfig
+ * @type switch
+ * @text Menu Switch ID
+ * @desc When this switch is ON, then this command is visible in the menu.
+ * @default 107
+ *
+ * @param levelConfig
+ * @text LEVEL-RELATED SETUP
+ *
+ * @param max-level-threshold
+ * @parent levelConfig
+ * @type number
+ * @text Max Level Threshold
+ * @desc The max allowed difference in level between actor and enemy to gain AP from.
+ * @min -1
+ * @default 10
+ *
+ * @command mod-ap-all
+ * @text Add/Remove AP (Party)
+ * @desc Adds or removes a designated amount of AP from all members of the current party.
+ * @arg points
+ * @type number
+ * @min -99999999
+ * @max 99999999
+ * @desc The amount of AP to modify by. Negative removes AP. Per-source never goes below 0.
+ *
+ * @command mod-ap
+ * @text Add/Remove AP
+ * @desc Adds or removes a designated amount of AP from an actor by its id.
+ * @arg actorId
+ * @type actor
+ * @desc The id of the actor to modify AP for.
+ * @arg points
+ * @type number
+ * @min -99999999
+ * @max 99999999
+ * @desc The amount of AP to modify by. Negative removes AP. Per-source never goes below 0.
+ */
+//endregion annotations
+
+//region plugin metadata
+class JAptitude_PluginMetadata
+  extends PluginMetadata
+{
+  /**
+   * Constructor.
+   */
+  constructor(name, version)
+  {
+    super(name, version);
+  }
+
+  /**
+   *  Extends {@link #postInitialize}.<br>
+   *  Includes translation of plugin parameters.
+   */
+  postInitialize()
+  {
+    // execute original logic.
+    super.postInitialize();
+
+    // initialize this plugin from configuration.
+    this.initializeMetadata();
+  }
+
+  /**
+   * Initializes the metadata associated with this plugin.
+   */
+  initializeMetadata()
+  {
+    /**
+     * The id of a switch that represents whether or not this system is accessible in the menu.
+     * @type {number}
+     */
+    this.menuSwitchId = parseInt(this.parsedPluginParameters['menu-switch']);
+
+    /**
+     * The maximum level difference between actor and enemy that allows AP gain.
+     * @type {number}
+     */
+    this.maxLevelThreshold = parseInt(this.parsedPluginParameters['max-level-threshold']);
+
+    /**
+     * Whether or not the level threshold limit is being used.
+     * @type {boolean}
+     */
+    this.usingLevelThresholdLimit = this.maxLevelThreshold > -1;
+  }
+}
+
+//endregion plugin metadata
+
+//region initialization
+/**
+ * The core where all of my extensions live: in the `J` object.
+ */
+var J = J || {};
+
+/**
+ * The plugin umbrella that governs all things related to this plugin.
+ */
+J.APT = {};
+
+/**
+ * The plugin umbrella that governs all extensions related to the parent.
+ */
+J.APT.EXT ||= {};
+
+/**
+ * The metadata associated with this plugin.
+ */
+J.APT.Metadata = new JAptitude_PluginMetadata('J-Aptitude', '1.0.0');
+
+/**
+ * A collection of all aliased methods for this plugin.
+ */
+J.APT.Aliased = {};
+J.APT.Aliased.BattleManager = new Map();
+J.APT.Aliased.Game_Action = new Map();
+J.APT.Aliased.Game_Actor = new Map();
+J.APT.Aliased.JABS_Battler = new Map();
+J.APT.Aliased.JABS_Engine = new Map();
+J.APT.Aliased.Scene_Menu = new Map();
+J.APT.Aliased.Window_MenuCommand = new Map();
+
+/**
+ * All regular expressions used by this plugin.
+ */
+J.APT.RegExp = {};
+
+/**
+ * The structure of a learnable aptitude skill.
+ *
+ * <pre>
+ * Structure:
+ *  <aptitude:[SKILL_ID, REQUIRED_AP]>
+ *
+ * Example:
+ *  <aptitude:[12, 150]>
+ *
+ * Translation:
+ *  Skill Learned: 12
+ *  Required AP  : 150
+ * </pre>
+ * @type {RegExp}
+ */
+J.APT.RegExp.AptitudeTeachable = /<aptitude:[ ]?(\[\d+,[ ]?\d+])>/gi;
+
+/**
+ * The AP reward an enemy yields on defeat.
+ *
+ * <pre>
+ * Structure:
+ *  <ap:AMOUNT>
+ *
+ * Example:
+ *  <ap:12>
+ *
+ * Translation:
+ *  AP gained: 12
+ * </pre>
+ * @type {RegExp}
+ */
+J.APT.RegExp.ApReward = /<ap: ?(\d+)>/i;
+
+//endregion initialization
+
+//region plugin commands
+/**
+ * Plugin command for modifying AP for all actors.
+ */
+PluginManager.registerCommand(
+  J.APT.Metadata.name,
+  'mod-ap-all',
+  ({ points }) =>
+  {
+    // iterate over all members and gain the AP.
+    $gameParty.members()
+      .forEach(actor => ApManager.gainAp(actor, parseInt(points), 'plugin-command'));
+  }
+);
+
+/**
+ * Plugin command for modifying AP for a specific actor.
+ */
+PluginManager.registerCommand(
+  J.APT.Metadata.name,
+  'mod-ap',
+  ({
+    actorId,
+    points
+  }) =>
+  {
+    // grab the chosen actor.
+    const actor = $gameActors.actor(parseInt(actorId));
+
+    // gain the AP.
+    ApManager.gainAp(actor, parseInt(points), 'plugin-command');
+  }
+);
+//endregion plugin commands
+
+//region AptitudeLearning
+/**
+ * The current state of a skill being learned.
+ * @param {number} skillId The skill id to learn.
+ * @param {number} requiredAp The required AP to achieve this learning.
+ * @param {number} currentAp The current AP towards achieving this learning.
+ * @constructor
+ */
+function AptitudeLearning(skillId, requiredAp, currentAp)
+{
+  this.initialize(skillId, requiredAp, currentAp);
+}
+
+AptitudeLearning.prototype = {};
+AptitudeLearning.prototype.constructor = AptitudeLearning;
+
+/**
+ * Initializes the learning.
+ * @param {number} skillId The skill id to learn.
+ * @param {number} requiredAp The required AP to achieve this learning.
+ * @param {number} currentAp The current AP towards achieving this learning.
+ */
+AptitudeLearning.prototype.initialize = function(skillId, requiredAp, currentAp)
+{
+  /**
+   * The id of the skill learned when achieving this learning.
+   * @type {number}
+   */
+  this.skillId = skillId;
+
+  /**
+   * The current AP towards achieving this learning.
+   * @type {number}
+   */
+  this.currentAp = currentAp;
+
+  /**
+   * The required amount of AP to achieve this learning.
+   * @type {number}
+   */
+  this.requiredAp = requiredAp;
+};
+
+/**
+ * Gains AP towards achieving this learning.
+ * @param {number} ap The amount of AP to gain.
+ */
+AptitudeLearning.prototype.gainAp = function(ap)
+{
+  this.currentAp += ap;
+};
+
+/**
+ * Sets the current AP towards achieving this learning.
+ * @param {number} ap The amount of AP to set.
+ */
+AptitudeLearning.prototype.setAp = function(ap)
+{
+  this.currentAp = ap;
+}
+
+/**
+ * Whether or not this learning is achieved.
+ * @returns {boolean} True if the learning is achieved, false otherwise.
+ */
+AptitudeLearning.prototype.isLearned = function()
+{
+  return this.currentAp >= this.requiredAp;
+};
+//endregion AptitudeLearning
+
+//region AptitudeProgress
+/**
+ * The structure of an object and its potential {@link AptitudeLearning}s.
+ * @param {string} key "type:id" unique key of the aptitude being learned.
+ * @param {Record<number, AptitudeLearning>} aptitudeLearnings The current state of learnings.
+ * @constructor
+ */
+function AptitudeProgress(key, aptitudeLearnings)
+{
+  this.initialize(key, aptitudeLearnings);
+}
+
+AptitudeProgress.prototype = {};
+AptitudeProgress.prototype.constructor = AptitudeProgress;
+
+/**
+ * Initializes the learning.
+ * @param {string} key "type:id" unique key of the aptitude being learned.
+ * @param {Record<number, AptitudeLearning>} [aptitudeLearnings] The current state of learnings; defaults to nothing.
+ */
+AptitudeProgress.prototype.initialize = function(key, aptitudeLearnings = {})
+{
+  /**
+   * The "type:id" unique key of the aptitude being learned.
+   * @type {string}
+   */
+  this.key = key;
+
+  /**
+   * The current state of learnings.
+   * @type {Record<number, AptitudeLearning>}
+   */
+  this._learnings = aptitudeLearnings;
+};
+
+/**
+ * Gets the current progress for a skill.
+ * @param {number} skillId The skill id to learn.
+ * @returns {AptitudeLearning|null} The current learning for the skill, or null if it doesn't exist.
+ */
+AptitudeProgress.prototype.learningBySkillId = function(skillId)
+{
+  // get the current progress for the skill, or politely coalesce to null if it doesn't exist.
+  return this._learnings[skillId] ?? null;
+};
+
+/**
+ * Determines whether or not this aptitude progress has a learning for the given skill.
+ * @param {number} skillId The skill id to check for.
+ * @returns {boolean} True if the skill exists on this progress, false otherwise.
+ */
+AptitudeProgress.prototype.hasLearning = function(skillId)
+{
+  return this._learnings[skillId] !== undefined;
+};
+
+/**
+ * Adds or updates a learning for this aptitude progress.
+ * @param {number} skillId The skill id to learn.
+ * @param {number} [amount] The current amount of AP for the learning; defaults to 0.
+ */
+AptitudeProgress.prototype.setLearning = function(skillId, amount = 0)
+{
+  // check if we have the learning already.
+  if (this.hasLearning(skillId) === false) return;
+
+  // we do, so just grab what exists.
+  const learning = this.learningBySkillId(skillId);
+
+  // update the AP for it.
+  learning.setAp(amount);
+};
+
+/**
+ * Creates a new learning for this aptitude progress.
+ * @param {number} skillId The id of the skill for the learning.
+ * @param {number} requiredAp The amount of AP required for the learning.
+ * @param {number} [amount] The current amount of AP for the learning; defaults to 0.
+ */
+AptitudeProgress.prototype.initializeLearning = function(skillId, requiredAp, amount = 0)
+{
+  // we don't have it, so create a new one with this amount.
+  this._learnings[skillId] = new AptitudeLearning(skillId, requiredAp, amount);
+};
+
+/**
+ * Gets the current state of learnings for this aptitude progress tracker.
+ * @returns {Record<number, AptitudeLearning>}
+ */
+AptitudeProgress.prototype.learnings = function()
+{
+  return this._learnings;
+};
+//endregion AptitudeProgress
+
+//region AptitudeSkill
+/**
+ * The structure of an object and the skill that was learned.
+ * @param {skillId} skillId The skill id that was learned.
+ * @param {boolean} [learned] Whether or not the skill was learned; defaults to false.
+ * @constructor
+ */
+function AptitudeSkill(skillId, learned = false)
+{
+  this.initialize(skillId, learned);
+}
+
+AptitudeSkill.prototype = {};
+AptitudeSkill.prototype.constructor = AptitudeSkill;
+
+/**
+ * Initializes the learning.
+ * @param {skillId} skillId The skill id that was learned.
+ * @param {boolean} [learned] Whether or not the skill was learned; defaults to false.
+ */
+AptitudeSkill.prototype.initialize = function(skillId, learned = false)
+{
+  /**
+   * The skill id that was learned.
+   * @type {number}
+   */
+  this.skillId = skillId;
+
+  /**
+   * Whether or not this aptitude skill is learned.
+   * @type {boolean}
+   */
+  this.learned = learned;
+
+  /**
+   * The "type:id" key of the aptitude that this skill was learned from.
+   * @type {string}
+   */
+  this._learnedFrom = String.empty;
+};
+
+/**
+ * Learns the skill.
+ * @param {AptitudeProgress} learnedFrom The aptitude from which this skill was learned.
+ */
+AptitudeSkill.prototype.learnSkill = function(learnedFrom)
+{
+  // flag the aptitude as learned.
+  this.learned = true;
+
+  // identify what aptitude it was learned from.
+  this._learnedFrom = learnedFrom.key;
+};
+
+/**
+ * Forgets the skill.
+ */
+AptitudeSkill.prototype.forgetSkill = function()
+{
+  // flag the aptitude as not learned.
+  this.learned = false;
+
+  // clear the aptitude that it was learned from.
+  this._learnedFrom = String.empty;
+};
+
+/**
+ * Gets the key of the aptitude that this skill was learned from.
+ * @returns {string}
+ */
+AptitudeSkill.prototype.learnedFrom = function()
+{
+  // TODO: map this to something meaningful for output.
+  return this._learnedFrom;
+};
+//endregion AptitudeSkill
+
+// #region AptitudeSkillAggregate
+
+/**
+ * Represents one skill learned via aptitudes across all sources on an actor.
+ * Holds per‑source progress and exposes convenience accessors for list/details UIs.
+ */
+class AptitudeSkillAggregate
+{
+  /**
+   * The skill id.
+   * @type {number}
+   */
+  #skillId = 0;
+
+  /**
+   * The database skill.
+   * @type {RPG_Skill}
+   */
+  #skill = null;
+
+  /**
+   * The sources that this skill reside in.
+   * @type {AptitudeSkillSourceProgress[]}
+   */
+  #sources = [];
+
+  /**
+   * @param {number} skillId The skill id.
+   * @param {RPG_Skill} skillData The database skill for name/icon/desc.
+   */
+  constructor(skillId, skillData)
+  {
+    // store the skill id.
+    this.#skillId = skillId;
+
+    // store the database skill reference.
+    this.#skill = skillData;
+
+    // initialize the per‑source rows.
+    this.#sources = [];
+  }
+
+  /**
+   * Adds one per‑source progress row to this aggregate.
+   * @param {AptitudeSkillSourceProgress} src The per‑source row.
+   */
+  addSource(src)
+  {
+    // push the source row into this aggregate.
+    this.sources()
+      .push(src);
+  }
+
+  /**
+   * The skill id for this aggregate.
+   * @returns {number}
+   */
+  skillId()
+  {
+    return this.#skillId;
+  }
+
+  /**
+   * The database object for the skill.
+   * @returns {RPG_Skill}
+   */
+  skill()
+  {
+    return this.#skill;
+  }
+
+  /**
+   * The name of the skill.
+   * @returns {string}
+   */
+  name()
+  {
+    return this.#skill.name;
+  }
+
+  /**
+   * The icon index of the skill.
+   * @returns {number}
+   */
+  iconIndex()
+  {
+    return this.#skill.iconIndex;
+  }
+
+  /**
+   * The sources that this skill resides in.
+   * @returns {AptitudeSkillSourceProgress[]}
+   */
+  sources()
+  {
+    return this.#sources;
+  }
+
+  /**
+   * Whether or not this skill has been learned in any source.
+   * @returns {boolean}
+   */
+  learnedAny()
+  {
+    return this.sources()
+      .some(source => source.learned() === true);
+  }
+
+  /**
+   * Finds the source with the minimum remaining AP among not‑yet‑learned sources.
+   * If all sources are learned, returns the first source for display context.
+   * @returns {AptitudeSkillSourceProgress|null}
+   */
+  cheapestSource()
+  {
+    // start with no cheapest found.
+    let cheapest = null;
+
+    const sources = this.sources();
+
+    // iterate all sources.
+    sources.forEach(s =>
+    {
+      // skip learned sources when searching cheapest remaining.
+      if (s.learned() === true)
+      {
+        return;
+      }
+
+      // compute the remaining AP for this source.
+      const remaining = s.remainingAp();
+
+      // select if first or cheaper than previous.
+      if (cheapest === null || remaining < cheapest.remainingAp())
+      {
+        cheapest = s;
+      }
+    });
+
+    // if all sources were learned but we have sources, return the first.
+    if (cheapest === null && sources.length > 0)
+    {
+      return sources[0];
+    }
+
+    // return the cheapest or null.
+    return cheapest;
+  }
+
+  /**
+   * Convenience: current AP of the cheapest path for list UI.
+   * @returns {number}
+   */
+  currentAp()
+  {
+    // find the cheapest source.
+    const cheapest = this.cheapestSource();
+
+    // return its current AP, or 0 if none.
+    return cheapest
+      ? cheapest.currentAp()
+      : 0;
+  }
+
+  /**
+   * Convenience: required AP of the cheapest path for list UI.
+   * @returns {number}
+   */
+  requiredAp()
+  {
+    // find the cheapest source.
+    const cheapest = this.cheapestSource();
+
+    // return its required AP, or 1 if none to prevent div‑by‑zero gauges.
+    return cheapest
+      ? cheapest.requiredAp()
+      : 1;
+  }
+}
+
+// #endregion AptitudeSkillAggregate
+
+//region AptitudeSkillSourceProgress
+/**
+ * Represents per‑source progress for learning a skill via aptitudes.
+ */
+class AptitudeSkillSourceProgress
+{
+  /**
+   * The source key (e.g., equipment/state/skill source id string).
+   * @type {string}
+   */
+  #sourceKey = String.empty;
+
+  /**
+   * The skill id this source contributes AP toward.
+   * @type {number}
+   */
+  #skillId = 0;
+
+  /**
+   * The current AP accumulated toward the skill.
+   * @type {number}
+   */
+  #currentAp = 0;
+
+  /**
+   * The total AP required to learn the skill.
+   * @type {number}
+   */
+  #requiredAp = 0;
+
+  /**
+   * Whether or not the skill has been learned from this source.
+   * @type {boolean}
+   */
+  #learned = false;
+
+  /**
+   * Constructor.
+   * @param {string} sourceKey - The source key (e.g., equipment/state/skill source id string).
+   * @param {number} skillId - The skill id this source contributes AP toward.
+   * @param {number} currentAp - The current AP accumulated for this source toward the skill.
+   * @param {number} requiredAp - The total AP required to learn from this source.
+   * @param {boolean} learned - Whether this source already granted the skill (complete).
+   */
+  constructor(sourceKey, skillId, currentAp, requiredAp, learned)
+  {
+    // store the source key.
+    this.#sourceKey = sourceKey;
+
+    this.#skillId = skillId;
+
+    // store current AP.
+    this.#currentAp = currentAp;
+
+    // store required AP.
+    this.#requiredAp = requiredAp;
+
+    // store learned flag.
+    this.#learned = learned === true;
+  }
+
+  /**
+   * The key of the source.
+   * @returns {string}
+   */
+  sourceKey()
+  {
+    return this.#sourceKey;
+  }
+
+  /**
+   * The skill id this source contributes AP toward.
+   * @returns {number}
+   */
+  skillId()
+  {
+    return this.#skillId;
+  }
+
+  /**
+   * The current AP accumulated toward the skill.
+   * @returns {number}
+   */
+  currentAp()
+  {
+    return this.#currentAp;
+  }
+
+  /**
+   * The total AP required to learn the skill.
+   * @returns {number}
+   */
+  requiredAp()
+  {
+    return this.#requiredAp;
+  }
+
+  /**
+   * Whether or not the skill has been learned from this source.
+   * @returns {boolean}
+   */
+  learned()
+  {
+    return this.#learned;
+  }
+
+  /**
+   * The remaining AP needed to learn the skill.
+   * @returns {number}
+   */
+  remainingAp()
+  {
+    // compute how much is left to reach required AP.
+    return Math.max(0, this.requiredAp() - this.currentAp());
+  }
+}
+
+//endregion AptitudeSkillSourceProgress
+
+//region AptitudeTeachable
+/**
+ * The runtime shape of a learnable skill and its requirements.
+ * @param {number} skillId The skill id to learn.
+ * @param {number} requiredAp The required AP to learn the skill.
+ * @constructor
+ */
+function AptitudeTeachable(skillId, requiredAp)
+{
+  this.initialize(skillId, requiredAp);
+}
+
+AptitudeTeachable.prototype = {};
+AptitudeTeachable.prototype.constructor = AptitudeTeachable;
+
+/**
+ * Initializes the learning.
+ * @param {number} skillId The skill id to learn.
+ * @param {number} requiredAp The required AP to learn the skill.
+ */
+AptitudeTeachable.prototype.initialize = function(skillId, requiredAp)
+{
+  /**
+   * The id of the skill to learn.
+   * @type {number}
+   */
+  this.skillId = skillId;
+
+  /**
+   * The required AP to learn the skill.
+   * @type {number}
+   */
+  this.requiredAp = requiredAp;
+};
+//endregion AptitudeTeachable
+
+//region JABS_Battler
+if (J.ABS)
+{
+  /**
+   * Extends {@link #gainBasicRewards}.<br/>
+   * Also includes AP when defeating an enemy.
+   * @param {Game_Battler} enemy The target battler that was defeated.
+   * @param {JABS_Battler} actor The map battler that defeated the target.
+   */
+  J.APT.Aliased.JABS_Engine.set('gainBasicRewards', JABS_Engine.prototype.gainBasicRewards);
+  JABS_Engine.prototype.gainBasicRewards = function(enemy, actor)
+  {
+    // perform original logic.
+    J.APT.Aliased.JABS_Engine.get('gainBasicRewards')
+      .call(this, enemy, actor);
+
+    // grab the AP amount from the enemy.
+    const ap = enemy.apPoints();
+
+    // if there is no AP, do nothing.
+    if (ap === 0) return;
+
+    // gain the AP.
+    this.gainAptitudeReward(ap, actor, enemy);
+  };
+
+  /**
+   * Gains AP from battle rewards.
+   * @param {number} ap The AP to gain.
+   * @param {JABS_Battler} actor The map battler that defeated the target.
+   * @param {JABS_Battler} enemy The map battler that was defeated.
+   */
+  JABS_Engine.prototype.gainAptitudeReward = function(ap, actor, enemy)
+  {
+    // don't do anything if the enemy didn't grant any sdp points.
+    if (ap === 0) return;
+
+    // Award AP to the full party; per-actor distribution happens in ApManager.
+    $gameParty.members()
+      .filter(member => this.canGainAptitudeReward(member, enemy))
+      .forEach(member =>
+      {
+        // identify the JABS battler that owns this member.
+        const jabsBattler = JABS_AiManager.getBattlerByUuid(member.getUuid());
+
+        // if somehow we have no battler here, then do nothing.
+        if (!jabsBattler) return;
+
+        // apply level scaling multiplier if applicable.
+        const levelMultiplier = this.getRewardScalingMultiplier(enemy, jabsBattler);
+
+        // round in favor of the player.
+        const actualAp = Math.ceil(ap * levelMultiplier);
+
+        // gain the applicable points.
+        ApManager.gainAp(member, actualAp, 'on-kill');
+
+        // generate the popup.
+        this.generatePopAp(actualAp, jabsBattler.getCharacter());
+
+        // create the log entry.
+        this.createLogAp(actualAp, jabsBattler);
+      });
+  };
+
+  /**
+   * Determines whether or not the actor can gain AP from the enemy.
+   * @param {Game_Actor} actor The map battler that defeated the target.
+   * @param {Game_Enemy} enemy The map battler that was defeated.
+   * @returns {boolean} True if the actor can gain AP, false otherwise.
+   */
+  JABS_Engine.prototype.canGainAptitudeReward = function(actor, enemy)
+  {
+    // check if we are using the level plugin.
+    if (J.LEVEL && J.LEVEL.Metadata.enabled && J.APT.Metadata.usingLevelThresholdLimit === true)
+    {
+      // identify the level difference between the battlers.
+      const levelDifference = actor.level - enemy.level;
+
+      // if the level difference was too great, then no AP is gained.
+      if (levelDifference > J.APT.Metadata.maxLevelThreshold) return false;
+    }
+
+    // gain that AP!
+    return true;
+  };
+
+  /**
+   * Generates a popup.
+   * @param {number} apPoints The amount to display.
+   * @param {Game_Character} character The character to show the popup on.
+   */
+  JABS_Engine.prototype.generatePopAp = function(apPoints, character)
+  {
+    // if we are not using popups, then don't do this.
+    if (!J.POPUPS) return;
+
+    // generate the textpop.
+    const apPop = new TextPopBuilder(apPoints)
+      .isAptitude()
+      .build();
+
+    // add the pop to the caster's tracking.
+    character.addTextPop(apPop);
+    character.requestTextPop();
+  };
+
+  /**
+   * Creates the log entry.
+   * @param {number} apPoints The AP gained.
+   * @param {JABS_Battler} battler The battler gaining the AP.
+   */
+  JABS_Engine.prototype.createLogAp = function(apPoints, battler)
+  {
+    // if we are not logging, then don't do this.
+    if (!J.LOG) return;
+
+    // build the log entry.
+    const apLog = new ActionLogBuilder()
+      .setMessage(`\\C[16]${battler.battlerName()}\\C[0] gained \\C[29]\\*${apPoints}\\*\\C[0] AP.`)
+      .build();
+
+    // add the log to the action log manager.
+    $actionLogManager.addLog(apLog);
+  };
+}
+//endregion JABS_Battler
+
+if (J.POPUPS)
+{
+  /**
+   * The popup type of "ap", for displaying AP gain pops.
+   */
+  Map_TextPop.Types.Ap = 'ap';
+}
+
+if (J.POPUPS)
+{
+  /**
+   * Add some convenient defaults for configuring AP points popups.
+   * @returns {TextPopBuilder} The builder, for fluent chaining.
+   */
+  TextPopBuilder.prototype.isAptitude = function()
+  {
+    // set the popup type to be an AP point acquisition.
+    this.setPopupType(Map_TextPop.Types.Ap);
+
+    // set the text color to be lovely pink.
+    this.setTextColorIndex(17);
+
+    // set the icon index to the learned skill's icon.
+    this.setIconIndex(86);
+
+    // add no x variance when working with AP points.
+    this.setXVariance(48);
+
+    // add some y variance when working with AP points.
+    this.setYVariance(96);
+
+    // return the builder for fluent chaining.
+    return this;
+  };
+}
+
+//region RPG_Base
+/**
+ * Gets all {@link AptitudeTeachable}s associated with this database object.
+ * @type {AptitudeTeachable[]}
+ */
+Object.defineProperty(RPG_Base.prototype, 'aptitudeTeachings', {
+  get()
+  {
+    // extract the data from the notes- should be [skillId, requiredAp].
+    const raw = RPGManager.getArraysFromNotesByRegex(this, J.APT.RegExp.AptitudeTeachable, true) ?? [];
+
+    // map all the raw data to DTOs.
+    return raw.map(([ skillId, requiredAp ]) => new AptitudeTeachable(skillId, requiredAp));
+  },
+});
+
+//endregion RPG_Base
+
+//region RPG_Enemy
+/**
+ * The number of AP this enemy will yield upon defeat.
+ * @type {number}
+ */
+Object.defineProperty(RPG_Enemy.prototype, 'apPoints', {
+  get()
+  {
+    // get the AP amount from this enemy's notes.
+    return RPGManager.getNumberFromNoteByRegex(this, J.APT.RegExp.ApReward);
+  },
+});
+//endregion RPG_Enemy
+
+//region ApManager
+class ApManager
+{
+  /**
+   * Awards AP to the given actor, distributing to all active APT sources
+   * and resolving any skill learns that cross their thresholds.
+   * @param {Game_Actor} actor The actor gaining AP.
+   * @param {number} amount The amount of AP awarded.
+   * @param {string} cause A short label describing the cause (ex: 'victory').
+   */
+  static gainAp(actor, amount, cause = 'victory')
+  {
+    // don't bother if the AP gained is zero.
+    if (this.canGainAp(actor, amount) === false) return;
+
+    // build the list of active sources for this actor.
+    const teachableSources = this.#activeTeachables(actor);
+
+    // iterate each active source to apply AP.
+    teachableSources.forEach(source =>
+    {
+      // deconstruct the source for readability.
+      const {
+        key,
+        teachables
+      } = source;
+
+      // apply the AP to this source's taught skills.
+      this.#applyApToSource(actor, key, teachables, amount, cause);
+    });
+  }
+
+  /**
+   * Determines whether the actor can gain AP.
+   * @param {Game_Actor} actor The actor to evaluate.
+   * @param {number} amount The amount of AP to check.
+   * @returns {boolean} True if the actor can gain AP, false otherwise.
+   */
+  static canGainAp(actor, amount)
+  {
+    // dead actors cannot gain AP.
+    if (actor.isDead()) return false;
+
+    // zero AP cannot be gained.
+    if (amount === 0) return false;
+
+    // gain the AP!
+    return true;
+  }
+
+  /**
+   * Derives a stable key for a source.
+   * @param {RPG_Base} source The source to derive a key for.
+   * @returns {string} The stable key.
+   */
+  static deriveKey(source)
+  {
+    return `${source.implementationType()}:${source.id}`;
+  }
+
+  /**
+   * Resolves a `sourceKey` (as produced by {@link ApManager.deriveKey}) back to the
+   * concrete RPG object currently contributing aptitude teachables for the actor.
+   *
+   * Notes:
+   * - This searches the actor’s current aptitude sources and matches by the same
+   *   `deriveKey(source)` used during AP distribution, guaranteeing a stable pair.
+   * - If the matched source is a skill, this returns the actor’s live skill entry
+   *   (`actor.skill(id)`) to mirror the behavior in `#activeTeachables`.
+   *
+   * @param {Game_Actor} actor - The actor whose sources are searched.
+   * @param {string} sourceKey - The stable key (e.g., "@base:usable:skill:17").
+   * @returns {RPG_Actor|RPG_Class|RPG_Skill|RPG_Weapon|RPG_Armor|RPG_State|null} - The found source object.
+   */
+  static resolveSourceByKey(actor, sourceKey)
+  {
+    // guard against missing inputs.
+    if (!actor) return null;
+
+    // gather all current aptitude sources from the actor.
+    const sources = actor.getAptitudeSources();
+
+    // iterate the sources to find a matching key.
+    for (let i = 0; i < sources.length; i++)
+    {
+      // grab the candidate source.
+      const candidate = sources[i];
+
+      // re-derive the stable key from this source.
+      const key = this.deriveKey(candidate);
+
+      // if the key matches, we have our source.
+      if (key === sourceKey)
+      {
+        // if this is a skill, resolve to the actor's live skill entry.
+        if (candidate.isSkill() === true)
+        {
+          // return the actor's known version of the database skill.
+          return actor.skill(candidate.id);
+        }
+
+        // otherwise, return the source as-is.
+        return candidate;
+      }
+    }
+
+    // no matching source was found.
+    return null;
+  }
+
+  /**
+   * Resolves a `sourceKey` into a database object (ignores actor state).
+   * @param {string} sourceKey
+   * @returns {RPG_Actor|RPG_Class|RPG_Skill|RPG_Weapon|RPG_Armor|RPG_State|RPG_Item|null}
+   */
+  static resolveStaticSourceByKey(sourceKey)
+  {
+    const parsed = this.parseKey(sourceKey);
+    if (!parsed || Number.isFinite(parsed.id) === false) return null;
+    const {
+      types,
+      id
+    } = parsed;
+    const terminal = types[types.length - 1];
+    switch (terminal)
+    {
+      case 'skill':
+        return $dataSkills[id] || null;
+      case 'weapon':
+        return $dataWeapons[id] || null;
+      case 'armor':
+        return $dataArmors[id] || null;
+      case 'state':
+        return $dataStates[id] || null;
+      case 'class':
+        return $dataClasses[id] || null;
+      case 'actor':
+        return $dataActors[id] || null;
+      case 'item':
+        return $dataItems[id] || null;
+      default:
+        return null;
+    }
+  }
+
+  static isSourceActive(actor, sourceKey)
+  {
+    if (!actor) return false;
+    // Build a set of current keys once per call; S is usually small.
+    const sources = actor.getAptitudeSources();
+    for (let i = 0; i < sources.length; i++)
+    {
+      const key = this.deriveKey(sources[i]);
+      if (key === sourceKey) return true;
+    }
+    return false;
+  }
+
+  /**
+   * Resolves a list of `sourceKey`s into their concrete source objects.
+   *
+   * @param {Game_Actor} actor - The actor whose sources are searched.
+   * @param {string[]} sourceKeys - The list of stable keys to resolve.
+   * @returns {(RPG_Base|null)[]} - Array of resolved sources (null where missing).
+   */
+  static resolveAllSourcesByKeys(actor, sourceKeys)
+  {
+    // coalesce an empty list if none provided.
+    const keys = Array.isArray(sourceKeys)
+      ? sourceKeys
+      : [];
+
+    // map each key through the single-key resolver.
+    const resolved = keys.map(key => this.resolveSourceByKey(actor, key));
+
+    // return the resolved list.
+    return resolved;
+  }
+
+  /**
+   * Parses a `sourceKey` produced by {@link ApManager.deriveKey}.
+   *
+   * A key looks like: "@base:traited:equip:weapon:12" or "@base:usable:skill:17".
+   * The final segment is always the numeric id; all preceding segments are the
+   * type chain assembled via `implementationType()` across the inheritance stack.
+   *
+   * @param {string} sourceKey - The stable key to parse.
+   * @returns {{ types: string[], id: number }} - The parsed components.
+   */
+  static parseKey(sourceKey)
+  {
+    // split on ':' to separate type chain and id.
+    const parts = String(sourceKey)
+      .split(':');
+
+    // if we don't have at least type+id, return a minimal shape.
+    if (parts.length < 2)
+    {
+      // provide a safe fallback.
+      return {
+        types: [],
+        id: NaN
+      };
+    }
+
+    // extract the id (final segment).
+    const idText = parts[parts.length - 1];
+
+    // parse into a number.
+    const id = Number(idText);
+
+    // everything before the id is the type chain.
+    const types = parts.slice(0, parts.length - 1);
+
+    // return the parsed structure.
+    return {
+      types,
+      id
+    };
+  }
+
+  /**
+   * Builds the list of currently active APT sources for the actor.
+   * Each source contains a stringy `key` and a {@link AptitudeTeachable[]} `teachables`.
+   * @param {Game_Actor} actor The actor to evaluate.
+   * @returns {{ key: string, teachables: AptitudeTeachable[] }[]} The active teachable sources.
+   */
+  static #activeTeachables(actor)
+  {
+    // acquire all potential sources.
+    const sources = actor.getAptitudeSources();
+
+    // draw up a set for keys to prevent dupes.
+    const foundKeys = new Set();
+
+    // all the results with teachables.
+    const results = [];
+
+    // iterate once; conditionally add entries that matter.
+    sources.forEach(source =>
+    {
+      // derive stable key like 'equip:weapon:5'.
+      const key = this.deriveKey(source);
+
+      // skip duplicate sources.
+      if (foundKeys.has(key)) return;
+
+      // this might be a skill requiring extension.
+      let trueSource = source;
+
+      // check if the source is a skill.
+      if (source.isSkill())
+      {
+        // get the full skill.
+        trueSource = actor.skill(source.id);
+      }
+
+      // grab all the teachables.
+      const teachables = trueSource.aptitudeTeachings;
+
+      // only include if there is at least one teachable.
+      if (teachables.length === 0) return;
+
+      // flag this key as found to prevent dupes.
+      foundKeys.add(key);
+
+      // record this source for downstream AP application.
+      results.push({
+        key,
+        teachables
+      });
+    });
+
+    // Return only meaningful sources.
+    return results;
+  }
+
+  /**
+   * Applies AP to all relevant skill tracks for a single source, then resolves learns.
+   * @param {Game_Actor} actor The actor gaining AP.
+   * @param {string} sourceKey The stable key for this source.
+   * @param {AptitudeTeachable[]} teachables The skills this source teaches.
+   * @param {number} amount The AP awarded for this tick.
+   * @param {string} cause The cause string for debugging/toasts.
+   */
+  static #applyApToSource(actor, sourceKey, teachables, amount, cause)
+  {
+    // iterate each teachable to add progress and check thresholds.
+    teachables.forEach(teachable =>
+    {
+      // destructure the teachable for readability.
+      const {
+        skillId,
+        requiredAp
+      } = teachable;
+
+      // skip if already learned permanently.
+      if (actor.hasLearnedAptitudeSkill(skillId)) return;
+
+      // validate the progress exists on the actor.
+      if (actor.hasAptitudeProgress(sourceKey) === false)
+      {
+        // initialize the progress for this source.
+        actor.initializeAptitudeProgress(sourceKey, skillId, requiredAp, 0);
+      }
+
+      // Get current progress for this skill from this source.
+      const aptitudeProgress = actor.getAptitudeProgress(sourceKey);
+
+      // validate the learning exists on the progress.
+      if (aptitudeProgress.hasLearning(skillId) === false)
+      {
+        // initialize the learning.
+        aptitudeProgress.initializeLearning(skillId, requiredAp, 0);
+      }
+
+      // grab the learning from the progress.
+      const aptitudeLearning = aptitudeProgress.learningBySkillId(skillId);
+
+      // the previous amount of AP acquired.
+      const before = aptitudeLearning.currentAp;
+
+      // Calculate updated progress.
+      const unclamped = before + amount;
+      const after = Math.max(0, Math.min(unclamped, requiredAp));
+
+      // Persist the updated progress.
+      actor.setAptitudeProgress(sourceKey, skillId, after);
+
+      // Check if the threshold was crossed this tick.
+      if (aptitudeLearning.isLearned())
+      {
+        // Resolve the learn and emit feedback.
+        this.#resolveLearn(actor, sourceKey, skillId, cause);
+      }
+    });
+  }
+
+  /**
+   * Resolves learning the skill permanently and emits any feedback.
+   * @param {Game_Actor} actor The actor learning a skill.
+   * @param {string} sourceKey The source that triggered the learn.
+   * @param {number} skillId The id of the learned skill.
+   * @param {string} cause A short label describing why this occurred.
+   */
+  // eslint-disable-next-line no-unused-vars
+  static #resolveLearn(actor, sourceKey, skillId, cause)
+  {
+    // Mark the skill as learned in the actor's APT data.
+    actor.learnAptitudeSkill(skillId, sourceKey);
+
+    // Learn it in the engine if not already known.
+    if (actor.isLearnedSkill(skillId) === false)
+    {
+      // Add the skill to the actor's known skills.
+      actor.learnSkill(skillId);
+    }
+
+    // Emit a toast or other UI feedback via your popups integration (hook later).
+    // Example idea (pseudo): J.POPUPS.pushLearnedSkill(actor, skillId, sourceKey, cause);
+  }
+}
+
+//endregion ApManager
+
+//region BattleManager
+/**
+ * Extends {@link #makeRewards}.<br/>
+ * Also includes the aptitude AP earned.
+ */
+J.APT.Aliased.BattleManager.set('makeRewards', BattleManager.makeRewards);
+BattleManager.makeRewards = function()
+{
+  // Perform original logic.
+  J.APT.Aliased.BattleManager.get('makeRewards')
+    .call(this);
+
+  // Extend the rewards to include AP.
+  this._rewards = {
+    ...this._rewards,
+    aptitudeAp: $gameTroop.aptitudeApTotal(),
+  };
+};
+
+/**
+ * Extends {@link #gainRewards}.<br/>
+ * Also awards the aptitude AP to party members via ApManager.
+ */
+J.APT.Aliased.BattleManager.set('gainRewards', BattleManager.gainRewards);
+BattleManager.gainRewards = function()
+{
+  // Perform original logic.
+  J.APT.Aliased.BattleManager.get('gainRewards')
+    .call(this);
+
+  // Also gain the APT AP rewards.
+  this.gainAptitudeApRewards();
+};
+
+/**
+ * Performs the AP award for all members of the party after battle.
+ */
+BattleManager.gainAptitudeApRewards = function()
+{
+  // Extract the AP that was earned.
+  const { aptitudeAp } = this._rewards;
+
+  // If there was no AP, then there is nothing to do.
+  if (!aptitudeAp) return;
+
+  // Iterate over each current party member and award AP.
+  $gameParty.members()
+    .forEach(actor => ApManager.gainAp(actor, aptitudeAp, 'victory'));
+};
+
+/**
+ * Extends {@link #displayRewards}.<br/>
+ * Also displays the AP victory text.
+ */
+J.APT.Aliased.BattleManager.set('displayRewards', BattleManager.displayRewards);
+BattleManager.displayRewards = function()
+{
+  // Also display AP rewards first.
+  this.displayAptitudeAp();
+
+  // Perform original logic.
+  J.APT.Aliased.BattleManager.get('displayRewards')
+    .call(this);
+};
+
+/**
+ * Displays the AP victory text in the victory log.
+ */
+BattleManager.displayAptitudeAp = function()
+{
+  // Extract the AP that was earned.
+  const { aptitudeAp } = this._rewards;
+
+  // If no AP was earned, do not display anything.
+  if (!aptitudeAp) return;
+
+  // Define the message to add (tune to taste or i18n).
+  const text = `\\. ${aptitudeAp} AP gained`;
+
+  // Add it to the victory log.
+  $gameMessage.add(text);
+};
+//endregion BattleManager
+
+//region Game_Actor
+/**
+ * Extends {@link #initMembers}.<br/>
+ * Also initializes aptitude members.
+ */
+J.APT.Aliased.Game_Actor.set('initMembers', Game_Actor.prototype.initMembers);
+Game_Actor.prototype.initMembers = function()
+{
+  // perform original logic.
+  J.APT.Aliased.Game_Actor.get('initMembers')
+    .call(this);
+
+  // also initialize aptitude members.
+  this.initAptitudeMembers();
+};
+
+/**
+ * Initializes the aptitude members.
+ */
+Game_Actor.prototype.initAptitudeMembers = function()
+{
+  /**
+   * The shared root namespace for all of J's plugin data.
+   */
+  this._j ||= {};
+
+  /**
+   * A grouping of all properties associated with this plugin.
+   */
+  this._j._aptitude ||= {};
+
+  /**
+   * A collection of all aptitudes that are presently being learned.
+   * @type {Record<string, AptitudeProgress>}
+   */
+  this._j._aptitude._progress = {};
+
+  /**
+   * The aptitude skills for this actor.
+   * @type {Record<number, AptitudeSkill>}
+   */
+  this._j._aptitude._learned = {};
+};
+
+/**
+ * Gets all aptitude progress for this actor.
+ * @returns {Record<string, AptitudeProgress>}
+ */
+Game_Actor.prototype.getAllAptitudeProgresses = function()
+{
+  return this._j._aptitude._progress;
+};
+
+/**
+ * Gets all learned aptitude skills for this actor.
+ * @returns {Record<number, AptitudeSkill>}
+ */
+Game_Actor.prototype.getAllAptitudeSkillsLearned = function()
+{
+  return this._j._aptitude._learned;
+};
+
+/**
+ * Builds per‑skill aptitude aggregates across all current sources on this actor.
+ * Each aggregate contains the database skill and all per‑source progress rows.
+ * @returns {AptitudeSkillAggregate[]} The list of aggregates, one per skill id.
+ */
+Game_Actor.prototype.getAptitudeSkillAggregates = function()
+{
+  // acquire all aptitude progresses keyed by source.
+  const progresses = this.getAllAptitudeProgresses();
+
+  // build index keyed by skillId.
+  /** @type {{ [skillId: string]: AptitudeSkillAggregate }} */
+  const perSkill = {};
+
+  // iterate each source → progress.
+  Object.entries(progresses)
+    .forEach(([ sourceKey, progress ]) =>
+    {
+      // iterate each learning under this progress.
+      Object.entries(progress.learnings())
+        .forEach(([ skillId, learning ]) =>
+        {
+          // create the aggregate if not present.
+          if (!perSkill[skillId])
+          {
+            // retrieve the database skill for name/icon/desc.
+            const skillData = this.skill(skillId);
+
+            // initialize the aggregate bucket.
+            perSkill[skillId] = new AptitudeSkillAggregate(skillId, skillData);
+          }
+
+          // build the per‑source row for this skill (now includes skillId).
+          const row = new AptitudeSkillSourceProgress(
+            sourceKey,
+            skillId,
+            learning.currentAp,
+            learning.requiredAp,
+            learning.isLearned()
+          );
+
+          // add this source row into the aggregate.
+          perSkill[skillId].addSource(row);
+        });
+    });
+
+  // return the aggregates as an array in numeric skillId order by default.
+  return Object.values(perSkill)
+    .sort((a, b) => a.skillId() - b.skillId());
+};
+
+/**
+ * Gets the aptitude progress for the given key.
+ * @param {string} key The key to get the progress for.
+ * @returns {AptitudeProgress|null} The aptitude progress for the given key.
+ */
+Game_Actor.prototype.getAptitudeProgress = function(key)
+{
+  // get the progress, or coalesce politely to null if it doesn't exist.
+  return this._j._aptitude._progress[key] ?? null;
+};
+
+/**
+ * Determines whether or not the actor has a progress for the given key.
+ * @param {string} key The key to check for progress.
+ * @returns {boolean} True if the actor has progress for the key, false otherwise.
+ */
+Game_Actor.prototype.hasAptitudeProgress = function(key)
+{
+  return this._j._aptitude._progress[key] !== undefined;
+};
+
+/**
+ * Sets the aptitude progress for the given key, skill id, and current AP.
+ * @param {string} key The key to set the progress for.
+ * @param {number} skillId The skill id to learn.
+ * @param {number} [currentAp] The current AP for the learning; defaults to 0.
+ */
+Game_Actor.prototype.setAptitudeProgress = function(key, skillId, currentAp = 0)
+{
+  // check if the progress exists.
+  if (this.hasAptitudeProgress(key) === false) return;
+
+  // grab the progress of the key.
+  const progress = this.getAptitudeProgress(key);
+
+  // update the progress with the new learning.
+  progress.setLearning(skillId, currentAp);
+};
+
+/**
+ * Initializes the aptitude progress for the given key, skill id, and current AP.
+ * @param {string} key The key to create the progress for.
+ * @param {number} skillId The skill id to learn.
+ * @param {number} requiredAp The amount of AP required for the learning.
+ * @param {number} currentAp The current AP for the learning.
+ */
+Game_Actor.prototype.initializeAptitudeProgress = function(key, skillId, requiredAp, currentAp = 0)
+{
+  // we don't have one, so create a new progress.
+  const newProgress = this.createAptitudeProgress(key, skillId, requiredAp, currentAp);
+
+  // update the mapping with the new progress.
+  this._j._aptitude._progress[key] = newProgress;
+};
+
+/**
+ * Creates a new aptitude progress for the given key and skill id.
+ * @param {string} key The key to create the progress for.
+ * @param {number} skillId The skill id to learn.
+ * @param {number} requiredAp The amount of AP required for the learning.
+ * @param {number} initialAp The initial AP to set for the learning.
+ * @returns {AptitudeProgress} The created aptitude progress.
+ */
+Game_Actor.prototype.createAptitudeProgress = function(key, skillId, requiredAp, initialAp)
+{
+  // we don't have one, so create a new progress.
+  const newProgress = new AptitudeProgress(key);
+
+  // add the new learning to this progress with the initial AP.
+  newProgress.setLearning(skillId, requiredAp, initialAp);
+
+  // return the built aptitude progress.
+  return newProgress;
+};
+
+/**
+ * Gets the aptitude learning for the given key and skill id.
+ * @param {string} key The key to get the learning for.
+ * @param {number} skillId The skill id to learn.
+ * @returns {AptitudeLearning|null} The aptitude learning for the given key and skill id, or null if it doesn't exist.
+ */
+Game_Actor.prototype.getAptitudeLearning = function(key, skillId)
+{
+  // check if we have an aptitude progress for the key.
+  if (this.hasAptitudeProgress(key) === false) return null;
+
+  // grab the progress of the key.
+  const progress = this.getAptitudeProgress(key);
+
+  // if its null, then the key didn't map to anything.
+  if (progress.hasLearning(skillId) === false) return null;
+
+  // return the learning.
+  return progress.learningBySkillId(skillId);
+};
+
+/**
+ * Gets all aptitude sources for this actor.
+ * This is typed as {@link RPG_Base}, but can yield many of its subclasses.
+ * @returns {(RPG_Actor|RPG_Class|RPG_EquipItem|RPG_Weapon|RPG_Armor|RPG_Skill|RPG_State)[]}
+ */
+Game_Actor.prototype.getAptitudeSources = function()
+{
+  // get literally everything.
+  return this.getAllNotes()
+    // exclude skills since we are learning skills.
+    .filter(obj => obj.isSkill() === false);
+};
+
+/**
+ * Gets whether or not this actor has the aptitude skill registered.
+ * @param {number} skillId The skill id to check.
+ * @returns {boolean} True if the actor has the aptitude skill registered, false otherwise.
+ */
+Game_Actor.prototype.hasAptitudeSkill = function(skillId)
+{
+  return this._j._aptitude._learned[skillId] !== undefined;
+};
+
+/**
+ * Gets the aptitude skill for the given skill id.
+ * @param {number} skillId The skill id to check.
+ * @returns {AptitudeSkill|null} The aptitude skill for the given skill id, or null if it doesn't exist.
+ */
+Game_Actor.prototype.getAptitudeSkill = function(skillId)
+{
+  return this._j._aptitude._learned[skillId];
+};
+
+/**
+ * Sets the aptitude skill for the given skill id.
+ * @param {number} skillId The skill id to set.
+ * @param {AptitudeSkill} aptitudeSkill The aptitude skill to set.
+ */
+Game_Actor.prototype.setAptitudeSkill = function(skillId, aptitudeSkill)
+{
+  // set the aptitude.
+  this._j._aptitude._learned[skillId] = aptitudeSkill;
+};
+
+/**
+ * Gets whether or not this actor has learned the given skill from an aptitude.
+ * @param {number} skillId The skill id to check.
+ * @returns {boolean} True if the actor has learned the skill, false otherwise.
+ */
+Game_Actor.prototype.hasLearnedAptitudeSkill = function(skillId)
+{
+  // if we don't have the aptitude skill, then we can't possibly have learned it.
+  if (this.hasAptitudeSkill(skillId) === false) return false;
+
+  // grab the aptitude skill.
+  const aptitudeSkill = this.getAptitudeSkill(skillId);
+
+  // return whether or not the skill is learned.
+  return aptitudeSkill.learned === true;
+};
+
+/**
+ * Marks the given skill as learned from an aptitude.
+ * @param {number} skillId The skill id to mark as learned.
+ * @param {string} sourceKey The source key for the aptitude.
+ */
+Game_Actor.prototype.learnAptitudeSkill = function(skillId, sourceKey)
+{
+  // don't process the learning if we already learned it.
+  if (this.hasLearnedAptitudeSkill(skillId)) return;
+
+  // check if we're missing the aptitude skill.
+  if (this.hasAptitudeSkill(skillId) === false)
+  {
+    // create a new aptitude skill.
+    const newAptitudeSkill = this.createAptitudeSkill(skillId);
+
+    // set the aptitude skill.
+    this.setAptitudeSkill(skillId, newAptitudeSkill);
+  }
+
+  // grab the aptitude skill.
+  const aptitudeSkill = this.getAptitudeSkill(skillId);
+
+  // grab the progress of the source key.
+  const aptitudeProgress = this.getAptitudeProgress(sourceKey);
+
+  // stamp the skill as learned with the given progress.
+  aptitudeSkill.learnSkill(aptitudeProgress);
+};
+
+/**
+ * Creates a new aptitude skill for the given skill id.
+ * @param {number} skillId The skill id to create the skill for.
+ * @param {boolean} [isLearned] Whether or not the skill is already learned; defaults to false.
+ * @returns {AptitudeSkill} The created aptitude skill.
+ */
+Game_Actor.prototype.createAptitudeSkill = function(skillId, isLearned = false)
+{
+  // generate the new aptitude skill.
+  return new AptitudeSkill(skillId, isLearned);
+};
+//endregion Game_Actor
+
+//region Game_Battler
+/**
+ * Gets the AP points this battler yields upon defeat..
+ * @returns {number}
+ */
+Game_Battler.prototype.apPoints = function()
+{
+  return this.databaseData().apPoints;
+};
+
+//endregion Game_Battler
+
+//region Game_Troop (APT)
+/**
+ * Gets the amount of AP earned from all defeated enemies in the troop.
+ * @returns {number}
+ */
+Game_Troop.prototype.aptitudeApTotal = function()
+{
+  // Initialize the total to zero.
+  let ap = 0;
+
+  // Sum the AP from all dead enemies in this troop.
+  this.deadMembers()
+    .forEach(enemy => ap += enemy.apPoints);
+
+  // Return the summed AP.
+  return ap;
+};
+//endregion Game_Troop (APT)
+
+//region Scene_Aptitude
+/**
+ * The scene for viewing aptitude progress.
+ */
+class Scene_Aptitude
+  extends Scene_MenuBase
+{
+  /**
+   * Pushes this current scene onto the stack, forcing it into action.
+   */
+  static callScene()
+  {
+    SceneManager.push(this);
+  }
+
+  /**
+   * The available view modes for the aptitude windows.
+   */
+  static viewMode = {
+    /**
+     * The view mode for viewing aggregates of aptitudes.
+     */
+    AGGREGATE: 'aggregate',
+
+    /**
+     * The view mode for viewing aptitude sources.
+     */
+    SOURCE: 'source'
+  };
+
+  //region init
+  /**
+   * Extends {@link #initMembers}.<br/>
+   * Also initializes the aptitude members.
+   */
+  initMembers()
+  {
+    // perform original logic.
+    super.initMembers();
+
+    // initialize the core aptitude namespace.
+    this.initCoreMembers();
+
+    // initialize the primary members for the scene.
+    this.initPrimaryMembers();
+  }
+
+  /**
+   * Initializes the core aptitude members.
+   */
+  initCoreMembers()
+  {
+    /**
+     * The shared root namespace for all of J's plugin data.
+     */
+    this._j ||= {};
+
+    /**
+     * A grouping of all properties associated with the aptitude system.
+     */
+    this._j._aptitude = {};
+  }
+
+  /**
+   * Initializes the primary members for the scene.
+   */
+  initPrimaryMembers()
+  {
+    /**
+     * The last index tracked in the aggregate list window, per-actor.
+     * Keyed by actorId → number.
+     * @type {{[actorId:number]: number}}
+     */
+    this._j._aptitude._lastAggregateIndexByActor = {};
+
+    /**
+     * The last index tracked in the source list window, per-actor.
+     * Keyed by actorId → number.
+     * @type {{[actorId:number]: number}}
+     */
+    this._j._aptitude._lastSourceIndexByActor = {};
+
+    /**
+     * The current view mode for the aptitude windows.
+     * Toggle between "aggregate" and "source" views.
+     * @type {string}
+     */
+    this._j._aptitude._viewMode = Scene_Aptitude.viewMode.AGGREGATE;
+
+    /**
+     * The aptitude aggregates for the current actor.
+     * @type {AptitudeSkillAggregate[]}
+     */
+    this._j._aptitude._aggregates = [];
+
+    /**
+     * The aptitude sources for the current actor.
+     * @type {(RPG_Actor|RPG_Class|RPG_EquipItem|RPG_Weapon|RPG_Armor|RPG_Skill|RPG_State)[]}
+     */
+    this._j._aptitude._sources = [];
+
+    /**
+     * A grouping of all windows for this scene.
+     */
+    this._j._aptitude._windows = {};
+
+    /**
+     * The ribbon window to display the actor and their name.
+     * @type {Window_AptitudeRibbon|null}
+     */
+    this._j._aptitude._windows._ribbon = null;
+
+    /**
+     * The list window that displays the per-skill aggregates.
+     * @type {Window_AptitudeAggregateList|null}
+     */
+    this._j._aptitude._windows._aggregateList = null;
+
+    /**
+     * The list window that displays the actor's sources.
+     * @type {Window_AptitudeSourceList|null}
+     */
+    this._j._aptitude._windows._sourceList = null;
+
+    /**
+     * The details window that displays all sources and respective progress towards learning the skill.
+     * @type {Window_AptitudeAggregateDetails|null}
+     */
+    this._j._aptitude._windows._aggregateDetails = null;
+
+    /**
+     * The details window that displays what this aptitude source is teaching.
+     * @type {Window_AptitudeSourceDetails|null}
+     */
+    this._j._aptitude._windows._sourceDetails = null;
+  }
+
+  //endregion init
+
+  //region accessors
+  /**
+   * Gets the last index tracked in the aggregate list window for the current actor.
+   * @returns {number}
+   */
+  lastAggregateIndex()
+  {
+    // get the current actor id.
+    const actorId = this.actor().actorId();
+
+    // pull from the map; default to 0 if not yet set.
+    const map = this._j._aptitude._lastAggregateIndexByActor;
+    if (map[actorId] === undefined)
+    {
+      map[actorId] = 0;
+    }
+
+    // return the remembered index.
+    return map[actorId];
+  }
+
+  /**
+   * Sets the last index tracked in the aggregate list window for the current actor.
+   * @param {number} index - The new index to track.
+   */
+  setLastAggregateIndex(index)
+  {
+    // get the current actor id.
+    const actorId = this.actor().actorId();
+
+    // update the remembered index for this actor.
+    this._j._aptitude._lastAggregateIndexByActor[actorId] = index;
+  }
+
+  /**
+   * Gets the last index tracked in the source list window for the current actor.
+   * @returns {number}
+   */
+  lastSourceIndex()
+  {
+    // get the current actor id.
+    const actorId = this.actor().actorId();
+
+    // pull from the map; default to 0 if not yet set.
+    const map = this._j._aptitude._lastSourceIndexByActor;
+    if (map[actorId] === undefined)
+    {
+      map[actorId] = 0;
+    }
+
+    // return the remembered index.
+    return map[actorId];
+  }
+
+  /**
+   * Sets the last index tracked in the source list window for the current actor.
+   * @param {number} index - The new index to track.
+   */
+  setLastSourceIndex(index)
+  {
+    // get the current actor id.
+    const actorId = this.actor().actorId();
+
+    // update the remembered index for this actor.
+    this._j._aptitude._lastSourceIndexByActor[actorId] = index;
+  }
+
+  /**
+   * Ensures selection tracker indices exist for the current actor without overwriting them.
+   * This initializes to 0 only if the current actor does not yet have entries.
+   */
+  resetSelectionTrackers()
+  {
+    // get the current actor id.
+    const actorId = this.actor().actorId();
+
+    // ensure aggregate index exists.
+    const aggMap = this._j._aptitude._lastAggregateIndexByActor;
+    if (aggMap[actorId] === undefined)
+    {
+      aggMap[actorId] = 0;
+    }
+
+    // ensure source index exists.
+    const srcMap = this._j._aptitude._lastSourceIndexByActor;
+    if (srcMap[actorId] === undefined)
+    {
+      srcMap[actorId] = 0;
+    }
+  }
+
+  /**
+   * Gets the cached list of per‑skill aggregates for the current actor.
+   * @returns {AptitudeSkillAggregate[]}
+   */
+  aggregates()
+  {
+    // return the cached aggregates.
+    return this._j._aptitude._aggregates;
+  }
+
+  /**
+   * Rebuilds the aggregates cache for the current actor.
+   */
+  rebuildAggregatesForActor()
+  {
+    // compute new aggregates from the actor.
+    const next = this.actor()
+      .getAptitudeSkillAggregates();
+
+    // replace the cache.
+    this._j._aptitude._aggregates = next;
+  }
+
+  /**
+   * Gets the aptitude sources for the current actor.
+   * @returns {(RPG_Actor|RPG_Class|RPG_EquipItem|RPG_Weapon|RPG_Armor|RPG_Skill|RPG_State)[]}
+   */
+  sources()
+  {
+    return this._j._aptitude._sources;
+  }
+
+  /**
+   * Sets the aptitude sources for the current actor.
+   * @param {(RPG_Actor|RPG_Class|RPG_EquipItem|RPG_Weapon|RPG_Armor|RPG_Skill|RPG_State)[]} sources The new sources.
+   */
+  setSources(sources)
+  {
+    this._j._aptitude._sources = sources;
+  }
+
+  /**
+   * Rebuilds the sources cache for the current actor.
+   */
+  rebuildSourcesForActor()
+  {
+    // compute new sources from the actor.
+    const next = this.actor()
+      .getAptitudeSources();
+
+    // replace the cache.
+    this._j._aptitude._sources = next;
+  }
+
+  /**
+   * Gets the current view mode for the aptitude windows.
+   * Should be one of {@link Scene_Aptitude.viewMode}.
+   * @returns {string}
+   */
+  viewMode()
+  {
+    return this._j._aptitude._viewMode;
+  }
+
+  /**
+   * Sets the current view mode to the aggregate view.
+   */
+  setViewModeToAggregate()
+  {
+    this._j._aptitude._viewMode = Scene_Aptitude.viewMode.AGGREGATE;
+
+    this.aptitudeRibbonWindow()
+      .setToggleHintTarget('the sources');
+  }
+
+  /**
+   * Sets the current view mode to the source view.
+   */
+  setViewModeToSource()
+  {
+    this._j._aptitude._viewMode = Scene_Aptitude.viewMode.SOURCE;
+
+    this.aptitudeRibbonWindow()
+      .setToggleHintTarget('your skills');
+  }
+
+  /**
+   * Gets the current active list window for the view mode.
+   * @returns {Window_AptitudeAggregateList|Window_AptitudeSourceList|null} - The active list window.
+   */
+  currentListWindow()
+  {
+    // return the list window based on the current view mode.
+    if (this.viewMode() === Scene_Aptitude.viewMode.AGGREGATE)
+    {
+      return this.aptitudeAggregateListWindow();
+    }
+    else if (this.viewMode() === Scene_Aptitude.viewMode.SOURCE)
+    {
+      return this.aptitudeSourceListWindow();
+    }
+
+    return null;
+  }
+
+  /**
+   * Gets the currently inactive list window for the view mode.
+   * @returns {Window_AptitudeAggregateList|Window_AptitudeSourceList|null} - The inactive list window.
+   */
+  inactiveListWindow()
+  {
+    // return the opposite list window based on the current view mode.
+    if (this.viewMode() === Scene_Aptitude.viewMode.AGGREGATE)
+    {
+      return this.aptitudeSourceListWindow();
+    }
+    else if (this.viewMode() === Scene_Aptitude.viewMode.SOURCE)
+    {
+      return this.aptitudeAggregateListWindow();
+    }
+
+    return null;
+  }
+
+  /**
+   * Gets the current active details window for the view mode.
+   * @returns {Window_AptitudeAggregateDetails|Window_AptitudeSourceDetails|null} - The active details window.
+   */
+  currentDetailsWindow()
+  {
+    // return the details window based on the current view mode.
+    if (this.viewMode() === Scene_Aptitude.viewMode.AGGREGATE)
+    {
+      return this.aptitudeAggregateDetailsWindow();
+    }
+    else if (this.viewMode() === Scene_Aptitude.viewMode.SOURCE)
+    {
+      return this.aptitudeSourceDetailsWindow();
+    }
+
+    return null;
+  }
+
+  //endregion accessors
+
+  //region create
+  /**
+   * Initialize all resources required for this scene.
+   */
+  create()
+  {
+    // perform original logic.
+    super.create();
+
+    // create the various display objects on the screen.
+    this.createDisplayObjects();
+  }
+
+  /**
+   * Creates the display objects for this scene.
+   */
+  createDisplayObjects()
+  {
+    // create all our windows.
+    this.createAllWindows();
+  }
+
+  /**
+   * Creates all windows for this scene.
+   */
+  createAllWindows()
+  {
+    // rebuild aggregates once for the initial actor.
+    this.rebuildAggregatesForActor();
+
+    // rebuild sources once for the initial actor.
+    this.rebuildSourcesForActor();
+
+    // create the ribbon window.
+    this.createAptitudeRibbonWindow();
+
+    // create the list window for aptitudes aggregations.
+    this.createAptitudeAggregateListWindow();
+
+    // create the list window for aptitudes sources.
+    this.createAptitudeSourceListWindow();
+
+    // create the details window that responds to aggregate selection.
+    this.createAptitudeAggregateDetailsWindow();
+
+    // create the details window that responds to source selection.
+    this.createAptitudeSourceDetailsWindow();
+  }
+
+  //region ribbon
+  /**
+   * Creates the aptitude ribbon window.
+   */
+  createAptitudeRibbonWindow()
+  {
+    // define the rectangle.
+    const rect = this.aptitudeRibbonRect();
+
+    // build the window.
+    const win = new Window_AptitudeRibbon(rect);
+
+    // initialize the actor.
+    win.setActor(this.actor());
+
+    // assign the view mode for the toggle hint.
+    win.setToggleHintTarget('the sources');
+
+    // assign the window.
+    this._j._aptitude._windows._ribbon = win;
+
+    // add the window to the scene.
+    this.addWindow(win);
+  }
+
+  /**
+   * Gets the rectangle for the aptitude ribbon window.
+   * @returns {Rectangle}
+   */
+  aptitudeRibbonRect()
+  {
+    // compute the centered container width (~66% of the screen width).
+    const containerW = Math.floor(Graphics.boxWidth * this.containerWidthPercent());
+
+    // compute the x offset to center the container.
+    const containerX = Math.floor((Graphics.boxWidth - containerW) / 2);
+
+    // place the ribbon at the top of the container.
+    const x = containerX;
+    const y = 0;
+
+    // keep ribbon width proportional to list column (25% of container width).
+    const w = Math.floor(containerW * 0.25);
+
+    // keep the same visual height used previously for ribbon rows.
+    const height = (36 * 3);
+
+    // return the rectangle for the ribbon window.
+    return new Rectangle(x, y, w, height);
+  }
+
+  /**
+   * Gets the aptitude ribbon window.
+   * @returns {Window_AptitudeRibbon|null}
+   */
+  aptitudeRibbonWindow()
+  {
+    return this._j._aptitude._windows._ribbon;
+  }
+
+  //endregion ribbon
+
+  //region aggregate list
+  /**
+   * Creates the aptitude aggregate list window.
+   */
+  createAptitudeAggregateListWindow()
+  {
+    // build the rectangle for the list window.
+    const rect = this.aptitudeAggregateListWindowRect();
+
+    // create the list window instance.
+    const win = new Window_AptitudeAggregateList(rect);
+
+    // set the actor for the list.
+    win.setActor(this.actor());
+
+    // provide the prebuilt aggregates.
+    win.setAggregates(this.aggregates());
+
+    // wire basic handlers.
+    win.setHandler('ok', this.onListOk.bind(this));
+    win.setHandler('cancel', this.popScene.bind(this));
+    win.setHandler('more', this.toggleViewMode.bind(this));
+
+    // also wire page navigation keys (Q/W or shoulder buttons).
+    win.setHandler('pageup', this.onCycleActorLeft.bind(this));
+    win.setHandler('pagedown', this.onCycleActorRight.bind(this));
+
+    // store and add to the scene.
+    this._j._aptitude._windows._aggregateList = win;
+    this.addWindow(win);
+  }
+
+  /**
+   * Builds the rectangle for the aptitude aggregate list window.
+   * @returns {Rectangle}
+   */
+  aptitudeAggregateListWindowRect()
+  {
+    // compute the centered container width (~66% of the screen width).
+    const containerW = Math.floor(Graphics.boxWidth * this.containerWidthPercent());
+
+    // compute the x offset to center the container.
+    const containerX = Math.floor((Graphics.boxWidth - containerW) / 2);
+
+    // grab some data from the ribbon window.
+    const {
+      y: ribbonY,
+      height: ribbonHeight
+    } = this.aptitudeRibbonRect();
+
+    // compute the top of the list to sit directly under the ribbon.
+    const wy = ribbonY + ribbonHeight;
+
+    // use the main area height for window height.
+    const wh = Graphics.boxHeight - ribbonHeight;
+
+    // keep the list width at 25% of the container width.
+    const listW = Math.floor(containerW * 0.25);
+
+    // return the rectangle for the list on the left of the container.
+    return new Rectangle(containerX, wy, listW, wh);
+  }
+
+  /**
+   * Gets the aptitude aggregate list window.
+   * @returns {Window_AptitudeAggregateList|null}
+   */
+  aptitudeAggregateListWindow()
+  {
+    // return the list window or null.
+    return this._j._aptitude._windows._aggregateList;
+  }
+
+  //endregion aggregate list
+
+  //region source list
+  /**
+   * Creates the aptitude source list window.
+   */
+  createAptitudeSourceListWindow()
+  {
+    // build the rectangle for the list window.
+    const rect = this.aptitudeSourceListWindowRect();
+
+    // create the list window instance.
+    const win = new Window_AptitudeSourceList(rect);
+
+    // set the actor for the list.
+    win.setActor(this.actor());
+
+    // provide the prebuilt sources.
+    win.setSources(this.sources());
+
+    // wire basic handlers.
+    win.setHandler('ok', this.onListOk.bind(this));
+    win.setHandler('cancel', this.popScene.bind(this));
+    win.setHandler('more', this.toggleViewMode.bind(this));
+
+    // also wire page navigation keys (Q/W or shoulder buttons).
+    win.setHandler('pageup', this.onCycleActorLeft.bind(this));
+    win.setHandler('pagedown', this.onCycleActorRight.bind(this));
+
+    // hide this window initially.
+    win.hide();
+    win.deactivate();
+
+    // store and add to the scene.
+    this._j._aptitude._windows._sourceList = win;
+    this.addWindow(win);
+  }
+
+  /**
+   * Builds the rectangle for the aptitude source list window.
+   * @returns {Rectangle}
+   */
+  aptitudeSourceListWindowRect()
+  {
+    return this.aptitudeAggregateListWindowRect();
+  }
+
+  /**
+   * Gets the aptitude source list window.
+   * @returns {Window_AptitudeSourceList|null}
+   */
+  aptitudeSourceListWindow()
+  {
+    return this._j._aptitude._windows._sourceList;
+  }
+
+  //endregion source list
+
+  //region aggregate details
+  /**
+   * Creates the aptitude aggregate details window.
+   */
+  createAptitudeAggregateDetailsWindow()
+  {
+    // build the rectangle for the details window.
+    const rect = this.aptitudeAggregateDetailsWindowRect();
+
+    // create the details window instance.
+    const win = new Window_AptitudeAggregateDetails(rect);
+
+    // set the actor for the details window.
+    win.setActor(this.actor());
+
+    // store and add to the scene.
+    this._j._aptitude._windows._aggregateDetails = win;
+    this.addWindow(win);
+  }
+
+  /**
+   * Builds the rectangle for the aptitude aggregate details window.
+   * @returns {Rectangle}
+   */
+  aptitudeAggregateDetailsWindowRect()
+  {
+    // compute the centered container width (~66% of the screen width).
+    const containerW = Math.floor(Graphics.boxWidth * this.containerWidthPercent());
+
+    // compute the x offset to center the container.
+    const containerX = Math.floor((Graphics.boxWidth - containerW) / 2);
+
+    // use the same main area vertical bounds.
+    const wy = this.mainAreaTop();
+    const wh = Graphics.boxHeight;
+
+    // split container 25/75 between list and details (same proportions as before).
+    const listW = Math.floor(containerW * 0.25);
+    const detailsW = containerW - listW;
+
+    // place details immediately to the right of the list.
+    const dx = containerX + listW;
+
+    // return the rectangle for the details window.
+    return new Rectangle(dx, wy, detailsW, wh);
+  }
+
+  /**
+   * Gets the aptitude aggregate details window.
+   * @returns {Window_AptitudeAggregateDetails|null}
+   */
+  aptitudeAggregateDetailsWindow()
+  {
+    // return the details window or null.
+    return this._j._aptitude._windows._aggregateDetails;
+  }
+
+  //endregion aggregate details
+
+  //region source details
+  /**
+   * Creates the aptitude source details window.
+   */
+  createAptitudeSourceDetailsWindow()
+  {
+    // build the rectangle for the details window.
+    const rect = this.aptitudeSourceDetailsWindowRect();
+
+    // create the details window instance.
+    const win = new Window_AptitudeSourceDetails(rect);
+
+    // set the actor for the details window.
+    win.setActor(this.actor());
+
+    // hide this window initially.
+    win.hide();
+
+    // store and add to the scene.
+    this._j._aptitude._windows._sourceDetails = win;
+    this.addWindow(win);
+  }
+
+  /**
+   * Builds the rectangle for the aptitude source details window.
+   * @returns {Rectangle}
+   */
+  aptitudeSourceDetailsWindowRect()
+  {
+    return this.aptitudeAggregateDetailsWindowRect();
+  }
+
+  /**
+   * Gets the aptitude source details window.
+   * @returns {Window_AptitudeSourceDetails|null}
+   */
+  aptitudeSourceDetailsWindow()
+  {
+    return this._j._aptitude._windows._sourceDetails;
+  }
+
+  //endregion source details
+
+  containerWidthPercent()
+  {
+    return 0.90;
+  }
+
+  containerHeightPercent()
+  {
+    return 0.80;
+  }
+
+  //endregion create
+
+  //region update
+  /**
+   * Extends {@link #update}.<br/>
+   * Also updates the details window when the list selection changes.
+   */
+  update()
+  {
+    // grab the previous view mode.
+    const previousViewMode = this.viewMode();
+
+    // perform original logic.
+    super.update();
+
+    // if the list is not present, do nothing.
+    const list = this.aptitudeAggregateListWindow();
+    if (!list) return;
+
+    // manage the details content based on whether or not the list index changed.
+    this.updateDetails();
+
+    // manage visibility based on view mode.
+    this.updateVisibility(previousViewMode);
+  }
+
+  /**
+   * Updates the aptitude details window based on the current list selection.
+   */
+  updateDetails()
+  {
+    switch (this.viewMode())
+    {
+      case Scene_Aptitude.viewMode.AGGREGATE:
+      {
+        const previousIndex = this.lastAggregateIndex();
+        this.updateAggregateDetails(previousIndex);
+        break;
+      }
+      case Scene_Aptitude.viewMode.SOURCE:
+      {
+        const previousIndex = this.lastSourceIndex();
+        this.updateSourceDetails(previousIndex);
+        break;
+      }
+    }
+  }
+
+  /**
+   * Updates the aptitude aggregate details window.
+   * @param {number} previousIndex The previous index of the list.
+   */
+  updateAggregateDetails(previousIndex)
+  {
+    // grab the list window.
+    const listWindow = this.aptitudeAggregateListWindow();
+
+    // if the index has not changed, do nothing.
+    if (previousIndex === listWindow.index()) return;
+
+    // acquire the selected entry if available.
+    const aggregate = listWindow.currentExt();
+
+    // update the details window context.
+    const details = this.aptitudeAggregateDetailsWindow();
+
+    // update both actor and entry for completeness.
+    details.setActor(this.actor());
+    details.setAggregate(aggregate);
+
+    // update our tracker.
+    this.setLastAggregateIndex(listWindow.index());
+  }
+
+  /**
+   * Updates the aptitude source details window.
+   * @param {number} previousIndex The previous index of the list.
+   */
+  updateSourceDetails(previousIndex)
+  {
+    // grab the list window.
+    const listWindow = this.aptitudeSourceListWindow();
+
+    // if the index has not changed, do nothing.
+    if (previousIndex === listWindow.index()) return;
+
+    // grab the source from the list window.
+    const source = listWindow.currentExt();
+
+    // update the details window context.
+    const details = this.aptitudeSourceDetailsWindow();
+    details.setActor(this.actor());
+    details.setSource(source);
+
+    // update our tracker.
+    this.setLastSourceIndex(listWindow.index());
+  }
+
+  /**
+   * Updates the visibility of the aptitude windows based on the current view mode.
+   * @param {string} previousViewMode The previous view mode.
+   */
+  updateVisibility(previousViewMode)
+  {
+    // grab the current view mode.
+    const currentViewMode = this.viewMode();
+
+    // if the view mode hasn't changed, do nothing.
+    if (currentViewMode === previousViewMode) return;
+
+    // pivot on the current view mode to display the appropriate windows.
+    switch (currentViewMode)
+    {
+      case Scene_Aptitude.viewMode.AGGREGATE:
+        this.hideSourceWindows();
+        this.showAggregateWindows();
+        break;
+      case Scene_Aptitude.viewMode.SOURCE:
+        this.hideAggregateWindows();
+        this.showSourceWindows();
+        break;
+    }
+  }
+
+  /**
+   * Shows the aptitude aggregate windows.
+   * Also refreshes the list and details windows with the current actor.
+   */
+  showAggregateWindows()
+  {
+    const list = this.aptitudeAggregateListWindow();
+    const details = this.aptitudeAggregateDetailsWindow();
+
+    this.rebuildAggregatesForActor();
+
+    list.show();
+    list.setActor(this.actor());
+    list.setAggregates(this.aggregates());
+    list.select(this.lastAggregateIndex());
+    list.activate();
+
+    details.show();
+    details.setActor(this.actor());
+    list.currentExt()
+      ? details.setAggregate(list.currentExt())
+      : details.setAggregate(null);
+  }
+
+  /**
+   * Hides the aptitude aggregate windows.
+   */
+  hideAggregateWindows()
+  {
+    const list = this.aptitudeAggregateListWindow();
+    const details = this.aptitudeAggregateDetailsWindow();
+
+    list.hide();
+    list.deactivate();
+    details.hide();
+  }
+
+  /**
+   * Shows the aptitude source windows.
+   * Also refreshes the list and details windows with the current actor.
+   */
+  showSourceWindows()
+  {
+    const list = this.aptitudeSourceListWindow();
+    const details = this.aptitudeSourceDetailsWindow();
+
+    list.show();
+    list.setActor(this.actor());
+    list.setSources(this.sources());
+    list.select(this.lastSourceIndex());
+    list.activate();
+
+    details.show();
+    details.setActor(this.actor());
+    list.currentExt()
+      ? details.setSource(list.currentExt())
+      : details.setSource(null);
+  }
+
+  /**
+   * Hides the aptitude source windows.
+   */
+  hideSourceWindows()
+  {
+    const list = this.aptitudeSourceListWindow();
+    const details = this.aptitudeSourceDetailsWindow();
+
+    list.hide();
+    list.deactivate();
+    details.hide();
+  }
+
+  //endregion update
+
+  //region actions
+  /**
+   * Cycles to the previous actor.
+   */
+  onCycleActorLeft()
+  {
+    // move to the previous actor.
+    this.previousActor();
+  }
+
+  /**
+   * Cycles to the next actor.
+   */
+  onCycleActorRight()
+  {
+    // move to the next actor.
+    this.nextActor();
+  }
+
+  /**
+   * Handles the "more" action- aka the shift key/square button from the either list.
+   */
+  toggleViewMode()
+  {
+    switch (this.viewMode())
+    {
+      case Scene_Aptitude.viewMode.AGGREGATE:
+        this.setViewModeToSource();
+        break;
+      case Scene_Aptitude.viewMode.SOURCE:
+        this.setViewModeToAggregate();
+        break;
+      default:
+        throw new Error(`Invalid view mode: ${this.viewMode()}`);
+    }
+  }
+
+  /**
+   * Extends {@link #onActorChange}.<br/>
+   * Also refreshes the aptitude windows when the actor changes.
+   */
+  onActorChange()
+  {
+    // perform original logic.
+    super.onActorChange();
+
+    // rebuild the cached aggregates for the new actor.
+    this.rebuildAggregatesForActor();
+
+    // rebuild the cached sources for the new actor.
+    this.rebuildSourcesForActor();
+
+    // get the updated actor reference.
+    const updatedActor = this.actor();
+
+    // rebind all windows to the new actor (ribbon, lists, details).
+    this.rebindAllWindowsToActor(updatedActor);
+
+    // refresh the list contents for the new actor (aggregates/sources).
+    this.refreshListsForActor();
+
+    // reset the per-view selection trackers back to the first index.
+    this.resetSelectionTrackers();
+
+    // choose the remembered index for the active view.
+    const startIndex = this.viewMode() === Scene_Aptitude.viewMode.AGGREGATE
+      ? this.lastAggregateIndex()
+      : this.lastSourceIndex();
+
+    // select and activate the current view, and push selection into details.
+    this.refreshSelectionForCurrentView(startIndex);
+  }
+
+  /**
+   * Rebinds all scene windows to the provided actor.
+   * @param {Game_Actor} actor - The actor to bind to all windows.
+   */
+  rebindAllWindowsToActor(actor)
+  {
+    // update the ribbon window with the new actor.
+    this.aptitudeRibbonWindow()
+      .setActor(actor);
+
+    // update both list windows with the new actor.
+    this.aptitudeAggregateListWindow()
+      .setActor(actor);
+    this.aptitudeSourceListWindow()
+      .setActor(actor);
+
+    // update both details windows with the new actor.
+    this.aptitudeAggregateDetailsWindow()
+      .setActor(actor);
+    this.aptitudeSourceDetailsWindow()
+      .setActor(actor);
+  }
+
+  /**
+   * Refreshes the list contents for the currently bound actor.
+   * This pulls from the scene’s cached aggregates and sources.
+   */
+  refreshListsForActor()
+  {
+    // refresh the aggregate list with the current aggregates cache.
+    this.aptitudeAggregateListWindow()
+      .setAggregates(this.aggregates());
+
+    // refresh the source list with the current sources cache.
+    this.aptitudeSourceListWindow()
+      .setSources(this.sources());
+  }
+
+  /**
+   * Selects and activates the current list view and updates its details.
+   * @param {number} startIndex - The index to select in the active list.
+   */
+  refreshSelectionForCurrentView(startIndex)
+  {
+    // grab the active and inactive list windows.
+    const activeList = this.currentListWindow();
+    const inactiveList = this.inactiveListWindow();
+
+    // select the desired index on the active list.
+    activeList.select(startIndex);
+
+    // activate the active list to accept input.
+    activeList.activate();
+
+    // deactivate the other list to avoid input conflicts.
+    inactiveList.deactivate();
+
+    // push the active list’s current selection into the correct details window.
+    this.setDetailsFromCurrentSelection();
+  }
+
+  /**
+   * Applies the active list selection to the corresponding details window.
+   */
+  setDetailsFromCurrentSelection()
+  {
+    // check what view we are currently in.
+    switch (this.viewMode())
+    {
+      case Scene_Aptitude.viewMode.AGGREGATE:
+      {
+        // grab the aggregate list/details windows.
+        const list = this.aptitudeAggregateListWindow();
+        const details = this.aptitudeAggregateDetailsWindow();
+
+        // update the details window with the selected aggregate or null.
+        const selected = list.currentExt();
+        if (selected)
+        {
+          details.setAggregate(selected);
+        }
+        else
+        {
+          details.setAggregate(null);
+        }
+        break;
+      }
+      case Scene_Aptitude.viewMode.SOURCE:
+      {
+        // grab the source list/details windows.
+        const list = this.aptitudeSourceListWindow();
+        const details = this.aptitudeSourceDetailsWindow();
+
+        // update the details window with the selected source or null.
+        const selected = list.currentExt();
+        if (selected)
+        {
+          details.setSource(selected);
+        }
+        else
+        {
+          details.setSource(null);
+        }
+        break;
+      }
+      default:
+      {
+        // an invalid view mode was encountered.
+        throw new Error(`Invalid view mode: ${this.viewMode()}`);
+      }
+    }
+  }
+
+  /**
+   * Handles the OK action from the aptitude list.
+   * (Reserved for future behaviors; currently a no‑op.)
+   */
+  onListOk()
+  {
+    // no special OK behavior in v1; just play a sound.
+    SoundManager.playOk();
+
+    // reselect the list to ensure it remains active.
+    this.aptitudeAggregateListWindow()
+      .activate();
+  }
+
+  //endregion actions
+
+}
+
+//endregion Scene_Aptitude
+
+//region Scene_Menu (APT)
+/**
+ * Extends {@link #createCommandWindow}.</br>
+ * Adds a handler for the Aptitude menu command.
+ */
+J.APT.Aliased.Scene_Menu.set('createCommandWindow', Scene_Menu.prototype.createCommandWindow);
+Scene_Menu.prototype.createCommandWindow = function()
+{
+  // perform original logic.
+  J.APT.Aliased.Scene_Menu.get('createCommandWindow')
+    .call(this);
+
+  // set the handler for our custom command.
+  this._commandWindow.setHandler('aptitude', this.commandAptitude.bind(this));
+};
+
+/**
+ * Opens the Aptitude scene.
+ */
+Scene_Menu.prototype.commandAptitude = function()
+{
+  // push the new scene onto the stack.
+  Scene_Aptitude.callScene();
+};
+//endregion Scene_Menu (APT)
+
+//region Window_AptitudeDetails
+/**
+ * The window containing the details of an aptitude skill aggregate.
+ */
+class Window_AptitudeAggregateDetails
+  extends Window_Base
+{
+  //region properties
+  /**
+   * The actor bound to this window.
+   * @type {Game_Actor|null}
+   */
+  _actor = null;
+
+  /**
+   * The selected entry for display.
+   * @type {AptitudeSkillAggregate|null}
+   */
+  _aggregate = null;
+
+  /**
+   * The y position of the next block to draw.
+   * @type {number}
+   */
+  _nextY = 0;
+
+  //endregion properties
+
+  // region init
+  /**
+   * Constructor.
+   * @param {Rectangle} rect The rectangle to draw the window in.
+   */
+  constructor(rect)
+  {
+    // call parent ctor.
+    super(rect);
+
+    // initialize members.
+    this.initMembers();
+
+    // draw initial contents.
+    this.refresh();
+  }
+
+  /**
+   * Initializes the members of this window.
+   */
+  initMembers()
+  {
+    // initialize the actor.
+    this._actor = null;
+
+    // initialize the aggregate.
+    this._aggregate = null;
+
+    // initialize the next y position.
+    this._nextY = 0;
+  }
+
+  //endregion init
+
+  //region accessors
+  /**
+   * The actor bound to this window.
+   * @returns {Game_Actor|null}
+   */
+  actor()
+  {
+    return this._actor;
+  }
+
+  /**
+   * Sets the actor for this window.
+   * @param {Game_Actor} actor The actor to bind.
+   */
+  setActor(actor)
+  {
+    // do nothing if the actor is unchanged.
+    if (this.actor() === actor) return;
+
+    // update the actor.
+    this._actor = actor;
+
+    // refresh the contents for the new actor.
+    this.refresh();
+  }
+
+  /**
+   * The selected aggregate for display.
+   * @returns {AptitudeSkillAggregate|null}
+   */
+  aggregate()
+  {
+    return this._aggregate;
+  }
+
+  /**
+   * Sets the selected aggregate for display.
+   * @param {AptitudeSkillAggregate|null} aggregate The selected aggregate or null to clear.
+   */
+  setAggregate(aggregate)
+  {
+    // do nothing if unchanged.
+    if (this.aggregate() === aggregate) return;
+
+    // update the entry.
+    this._aggregate = aggregate;
+
+    // refresh the contents for the new aggregate.
+    this.refresh();
+  }
+
+  /**
+   * The y position of the next block to draw.
+   * @returns {number}
+   */
+  nextY()
+  {
+    return this._nextY || 0;
+  }
+
+  /**
+   * Sets the next y position for drawing.
+   * @param {number} y The y position to set.
+   */
+  setNextY(y)
+  {
+    this._nextY = y;
+  }
+
+  //endregion accessors
+
+  //region draw
+  /**
+   * Implements {@link #drawContent}.<br/>
+   * Draws the details for the selected aggregate.
+   */
+  drawContent()
+  {
+    // if we do not have an entry or actor to work with, show a friendly hint.
+    if (!this.aggregate() || !this.actor())
+    {
+      // render a default hint.
+      this.resetTextColor();
+      this.drawText('Select a skill from the list.', 0, 0, this.contentsWidth());
+      return;
+    }
+
+    // reset the next y position.
+    this.setNextY(0);
+
+    // draw the header.
+    this.drawHeader();
+
+    // draw the per‑source breakdown table.
+    this.drawSources();
+  }
+
+  /**
+   * Draws the header containing the icon+name and learned badge.
+   */
+  drawHeader()
+  {
+    // grab the aggregate data.
+    const aggregate = this.aggregate();
+
+    // derive the skill data for icon+name.
+    const skill = this.actor()
+      .skill(aggregate.skillId());
+
+    // y anchor for the header.
+    let y = this.nextY();
+
+    // draw the icon if present.
+    if (skill.iconIndex > 0)
+    {
+      // draw the icon at the far left.
+      this.drawIcon(skill.iconIndex, 0, y);
+    }
+
+    // compute a left indent if we drew an icon.
+    const left = (skill.iconIndex > 0)
+      ? 36
+      : 0;
+
+    // draw the name.
+    this.changeTextColor(this.systemColor());
+    this.drawText(`${skill.name}`, left, y, this.contentsWidth() - left);
+
+    // if learned, render a badge at the right.
+    if (aggregate.learnedAny() === true)
+    {
+      // draw learned badge.
+      this.resetTextColor();
+      this.drawText('[LEARNED]', 0, y, this.contentsWidth(), 'right');
+    }
+
+    // advance y.
+    y += this.lineHeight();
+
+    // draw the description.
+    this.changeTextColor(ColorManager.normalColor());
+    const wrappedText = this.modFontSizeForText(-4, skill.description);
+    this.drawTextEx(wrappedText, 0, y, this.contentsWidth());
+
+    // add some spacing below the description.
+    y += this.lineHeight() * 2;
+
+    // set the next block anchor.
+    this.setNextY(y);
+  }
+
+  /**
+   * Draws the sources for the selected entry.
+   */
+  drawSources()
+  {
+    // grab the aggregate data.
+    const aggregate = this.aggregate();
+
+    // establish a y anchor somewhat below the gauges.
+    const baseY = this.nextY() + this.lineHeight();
+
+    // header label for the section.
+    this.changeTextColor(this.systemColor());
+    this.drawTextEx('\\I[86]\\C[16]Sources\\C[0]', 0, baseY, this.contentsWidth());
+
+    // compute the starting y for rows.
+    const updatedY = baseY + this.lineHeight();
+    this.setNextY(updatedY);
+
+    // iterate and draw each source row.
+    aggregate.sources()
+      .forEach(this.drawSource, this);
+  }
+
+  /**
+   * Draws a single source row.
+   * @param {AptitudeSkillSourceProgress} sourceProgress - The per-source progress to draw for this skill.
+   */
+  drawSource(sourceProgress)
+  {
+    // capture the current y position for this row.
+    const y = this.nextY();
+
+    // calculate the left column width for the icon+label.
+    const leftW = Math.floor(this.contentsWidth() * 0.60);
+
+    // resolve the database object for the display (icon/name) using the key.
+    const databaseSource = ApManager.resolveStaticSourceByKey(sourceProgress.sourceKey());
+
+    // don't render none-sourced rows.
+    if (!databaseSource) return;
+
+    // determine whether this source is currently active on the actor.
+    const isActive = ApManager.isSourceActive(this.actor(), sourceProgress.sourceKey());
+
+    // extract the icon index from the database object if available.
+    let { iconIndex } = databaseSource;
+
+    // actors don't normally have an icon index, so lets give em one.
+    if (databaseSource.isActor())
+    {
+      iconIndex = 2727;
+    }
+    // classes also don't normally have an icon index, so lets give em one.
+    else if (databaseSource.isClass())
+    {
+      iconIndex = 2694;
+    }
+
+    // extract the label from the database object if available, else fallback to the raw key.
+    let { name } = databaseSource;
+    let activityColorIndex = 0;
+
+    if (isActive === false)
+    {
+      activityColorIndex = 7;
+      name += ' (inactive)';
+    }
+
+    // draw the icon + label on the left side of the row.
+    this.drawTextEx(`\\C[${activityColorIndex}]\\I[${iconIndex}]${name}\\C[0]`, 0, y, leftW);
+
+    // determine learned state for this specific source.
+    const learned = sourceProgress.learned() === true;
+
+    // determine if the actor already knows the skill via some other source.
+    const knownElsewhere = learned === false &&
+      sourceProgress.currentAp() < sourceProgress.requiredAp() &&
+      this.actor()
+        .hasSkill(sourceProgress.skillId());
+
+    // decide the right-side text content.
+    let rightText = '';
+    if (learned === true)
+    {
+      // if learned from this source, show DONE.
+      rightText = 'DONE';
+    }
+    else if (knownElsewhere === true)
+    {
+      // if not learned from this source but the actor already knows the skill, show KNOWN.
+      rightText = 'KNOWN';
+    }
+    else
+    {
+      // otherwise, show the current/required AP counts.
+      rightText = `${sourceProgress.currentAp()}/${sourceProgress.requiredAp()}`;
+    }
+
+    // decide the right-side color index.
+    let rightColor = 7; // gray by default
+    if (learned === true)
+    {
+      // green when learned.
+      rightColor = 11;
+    }
+    else if (sourceProgress.currentAp() > 0)
+    {
+      // yellow when in-progress.
+      rightColor = isActive
+        ? 6
+        : 7;
+    }
+
+    // apply the right-side color and draw the right-aligned status text.
+    this.changeTextColor(ColorManager.textColor(rightColor));
+    const rightW = this.contentsWidth() - leftW;
+    this.drawText(rightText, 0, y, rightW, Window_Base.TextAlignments.Right);
+
+    // Only draw a gauge if the skill is neither DONE nor KNOWN.
+    const shouldDrawGauge = learned === false && knownElsewhere === false;
+    if (shouldDrawGauge === true)
+    {
+      // compute the gauge rectangle centered vertically within the row.
+      const gaugeX = Math.floor(this.contentsWidth() * 0.40);
+      const gaugeY = y + Math.round(this.lineHeight() / 2) - Math.round(this.gaugeHeight() / 2);
+      const rect = new Rectangle(gaugeX, gaugeY, this.gaugeWidth(), this.gaugeHeight());
+
+      // compute the rate between 0..1 for the gauge.
+      const progressRate = Math.max(0, Math.min(sourceProgress.currentAp() / sourceProgress.requiredAp(), 1));
+
+      // build the gauge options with a dynamic segment count and colors.
+      const leftGaugeColor = isActive
+        ? this.gaugeColor1()
+        : this.inactiveColor1();
+      const rightGaugeColor = isActive
+        ? this.gaugeColor2()
+        : this.inactiveColor2();
+      const segOpts = WindowGaugeOptions.Builder()
+        .gaugeType(Window_Base.GAUGE_TYPES.Segmented)
+        .segments(Math.max(1, Math.ceil(sourceProgress.requiredAp() / this.segmentValue())))
+        .gap(2)
+        .leftGradientColor(leftGaugeColor)
+        .rightGradientColor(rightGaugeColor)
+        .build();
+
+      // draw the segmented gauge.
+      this.drawGauge(rect, progressRate, segOpts);
+    }
+
+    // advance to the next row position.
+    this.setNextY(y + this.lineHeight());
+  }
+
+  //endregion draw
+
+  //region helpers
+  /**
+   * The width of the gauges in this window.
+   * @returns {number}
+   */
+  gaugeWidth()
+  {
+    return 256;
+  }
+
+  /**
+   * The height of the gauges in this window.
+   * @returns {number}
+   */
+  gaugeHeight()
+  {
+    return 12;
+  }
+
+  /**
+   * The back color of the gauges in this window.
+   * @returns {string}
+   */
+  gaugeBackColor()
+  {
+    return 'rgba(255, 255, 255, 0.1)';
+  }
+
+  /**
+   * The color to gradient from.
+   * Defaults to blue.
+   * @returns {string}
+   */
+  gaugeColor1()
+  {
+    return 'rgba(179, 89, 0, 1)';
+  }
+
+  /**
+   * The color to gradient into.
+   * Defaults to green.
+   * @returns {string}
+   */
+  gaugeColor2()
+  {
+    return 'rgba(255, 166, 77, 1)';
+  }
+
+  inactiveColor1()
+  {
+    return 'rgba(77, 77, 77, 1)';
+  }
+
+  inactiveColor2()
+  {
+    return 'rgba(153, 153, 153, 1)';
+  }
+
+  /**
+   * The amount that one segment represents.
+   * @returns {number}
+   */
+  segmentValue()
+  {
+    return 10;
+  }
+
+  //endregion helpers
+}
+
+//endregion Window_AptitudeDetails
+
+//region Window_AptitudeList
+/**
+ * The window containing the list of aptitude skill aggregations for an actor.
+ */
+class Window_AptitudeAggregateList
+  extends Window_Command
+{
+  //region properties
+  /**
+   * The actor bound to this window.
+   * @type {Game_Actor|null}
+   */
+  _actor = null;
+
+  /**
+   * The list of aggregates bound to this window.
+   * @type {AptitudeSkillAggregate[]}
+   */
+  _aggregates = [];
+
+  //endregion properties
+
+  //region init
+  constructor(rect)
+  {
+    // call parent ctor.
+    super(rect);
+
+    // initialize members.
+    this.initMembers();
+  }
+
+  /**
+   * Initializes the members of this window.
+   */
+  initMembers()
+  {
+    // initialize members.
+    this._actor = null;
+
+    // initialize the aggregates bucket.
+    this._aggregates = [];
+  }
+
+  //endregion init
+
+  //region accessors
+  /**
+   * Gets the actor that is bound to this window.
+   * @returns {Game_Actor|null}
+   */
+  actor()
+  {
+    return this._actor;
+  }
+
+  /**
+   * Sets the actor for this window.
+   * @param {Game_Actor} actor The actor to bind.
+   */
+  setActor(actor)
+  {
+    // do nothing if the actor is unchanged.
+    if (this._actor === actor) return;
+
+    // update the actor reference.
+    this._actor = actor;
+
+    // rebuild the command list.
+    // TODO: update this to be handled from the scene.
+    this.refresh();
+  }
+
+  /**
+   * Get the list of aggregates that are bound to this window.
+   * @returns {AptitudeSkillAggregate[]}
+   */
+  aggregates()
+  {
+    return this._aggregates || [];
+  }
+
+  /**
+   * Sets the prebuilt aggregates for rendering.
+   * @param {AptitudeSkillAggregate[]} aggregates The list of aggregates to render.
+   */
+  setAggregates(aggregates)
+  {
+    // assign and refresh.
+    this._aggregates = aggregates || [];
+
+    // rebuild command list.
+    this.refresh();
+  }
+
+  //endregion accessors
+
+  //region commands
+  /**
+   * Rebuilds the command list for the current actor.
+   */
+  makeCommandList()
+  {
+    // if we don’t have an actor, there is nothing to build.
+    if (this.actor() === null) return;
+
+    // build all commands for this window.
+    const commands = this.buildCommands();
+
+    // add all built commands to this window.
+    commands.forEach(this.addBuiltCommand, this);
+  }
+
+  /**
+   * Builds all commands for this command window.
+   * @returns {BuiltWindowCommand[]}
+   */
+  buildCommands()
+  {
+    // grab all the aggregates to build commands for.
+    const aggregates = this.aggregates();
+
+    // if no aggregates, nothing to render.
+    if (aggregates.length === 0) return [];
+
+    // build each command based on the aggregate.
+    const commands = aggregates.map(this.buildCommand, this);
+
+    // return the built command set.
+    return commands;
+  }
+
+  /**
+   * Builds a single command for the given aggregate.
+   * @param {AptitudeSkillAggregate} aggregate The aggregate to build a command for.
+   * @returns {BuiltWindowCommand}
+   */
+  buildCommand(aggregate)
+  {
+    // compute right text.
+    const learned = aggregate.learnedAny();
+    const rightText = learned === true
+      ? 'DONE'
+      : `${aggregate.currentAp()}/${aggregate.requiredAp()}`;
+
+    // compute right color index.
+    let rightColor = 7; // gray default
+    if (learned === true)
+    {
+      rightColor = 11; // green learned
+    }
+    else if (aggregate.currentAp() > 0)
+    {
+      rightColor = 6; // yellow in‑progress
+    }
+
+    // build the command for this skill.
+    const builtWindowCommand = new WindowCommandBuilder(aggregate.name())
+      .setSymbol(`skill:${aggregate.skillId()}`)
+      .setExtensionData(aggregate)
+      .setIconIndex(aggregate.iconIndex())
+      .setRightText(rightText)
+      .setRightColorIndex(rightColor)
+      .setEnabled(learned === false)
+      .build();
+
+    // add to list.
+    return builtWindowCommand;
+  }
+
+  //endregion commands
+}
+
+//endregion Window_AptitudeList
+
+//region Window_AptitudeRibbon
+/**
+ * The ribbon window for the Aptitude scene.
+ */
+class Window_AptitudeRibbon
+  extends Window_ActorRibbon
+{
+  //region properties
+  /**
+   * The target to show a hint for when the view is toggled.
+   * @type {string}
+   */
+  _toggleHintTarget = String.empty;
+
+  //endregion properties
+
+  /**
+   * Constructor.
+   * @param {Rectangle} rect The rectangle to draw the ribbon in.
+   */
+  constructor(rect)
+  {
+    super(rect);
+  }
+
+  //region accessors
+  /**
+   * Gets the target to show a hint for when the view is toggled.
+   * @returns {string}
+   */
+  toggleHintTarget()
+  {
+    return this._toggleHintTarget;
+  }
+
+  /**
+   * Sets the target to show a hint for when the view is toggled.
+   * @param {string} target The target to show a hint for.
+   */
+  setToggleHintTarget(target)
+  {
+    // store the target.
+    this._toggleHintTarget = target;
+
+    // also refresh the contents.
+    this.refresh();
+  }
+
+  //endregion accessors
+
+  /**
+   * Extends {@link #initMembers}.<br/>
+   * Adds the toggle hint target.
+   */
+  initMembers()
+  {
+    // initialize the original members.
+    super.initMembers();
+
+    // initialize our own members.
+    this._toggleHintTarget = String.empty;
+  }
+
+  //region draw
+  /**
+   * Draws the actor face in the ribbon.
+   */
+  drawActorRibbon()
+  {
+    // perform original logic.
+    super.drawActorRibbon();
+
+    // also draw the actor's name.
+    this.drawActorName();
+
+    // also draw the view-toggle hint if we have a target.
+    this.drawHint();
+  }
+
+  /**
+   * Draws the actor's name.
+   */
+  drawActorName()
+  {
+    // grab the actor.
+    const actor = this.actor();
+
+    // grab the coordinates of the face.
+    const [ x, y ] = this.faceCoordinates();
+
+    // grab the size of the face.
+    const [ w ] = this.faceSize();
+
+    // identify the name of the actor.
+    const name = actor.name();
+
+    // calculate the position.
+    const nameX = x + w + 16;
+    const nameWidth = this.contents.measureTextWidth(name);
+
+    // draw the name.
+    this.drawText(name, nameX, y, nameWidth);
+  }
+
+  /**
+   * Draws the hint for the current view.
+   */
+  drawHint()
+  {
+    // also draw the view-toggle hint if we have a target.
+    const target = this.toggleHintTarget();
+
+    // build the hint string using your icon indices.
+    const hint = `\\I[2450]/\\I[2434]: see ${target}.`;
+
+    // compute the width available to the right of the face.
+    const textW = this.contents.measureTextWidth(hint);
+
+    // grab the coordinates and size of the face to anchor our text.
+    const [ x, y ] = this.faceCoordinates();
+    const [ w, h ] = this.faceSize();
+
+    // compute the starting x for text to the right of the face.
+    const textX = x + 64;
+
+    // compute the y such that it sits beneath the name, inside the ribbon.
+    const textY = y + h;
+
+    // draw the hint using textEx so icons render correctly.
+    this.drawTextEx(hint, textX, textY, textW);
+  }
+
+  //endregion draw
+}
+
+//endregion Window_AptitudeRibbon
+
+//region Window_AptitudeSourceDetails
+/**
+ * A window displaying details about a specific aptitude source.
+ */
+class Window_AptitudeSourceDetails
+  extends Window_Base
+{
+  //region properties
+  /**
+   * The actor bound to this window.
+   * @type {Game_Actor|null}
+   */
+  _actor = null;
+
+  /**
+   * The source bound to this window.
+   * @type {RPG_Actor|RPG_Class|RPG_EquipItem|RPG_Weapon|RPG_Armor|RPG_Skill|RPG_State|null}
+   */
+  _source = null;
+
+  /**
+   * The y position of the next block to draw.
+   * @type {number}
+   */
+  _nextY = 0;
+
+  //endregion properties
+
+  //region init
+  /**
+   * Constructor.
+   * @param {Rectangle} rect The rectangle to draw the window in.
+   */
+  constructor(rect)
+  {
+    // call parent ctor.
+    super(rect);
+
+    // initialize members.
+    this.initMembers();
+
+    // draw initial contents.
+    this.refresh();
+  }
+
+  /**
+   * Initializes the members of this window.
+   */
+  initMembers()
+  {
+    // initialize the actor.
+    this._actor = null;
+
+    // initialize the source.
+    this._source = null;
+
+    // initialize the next y position.
+    this._nextY = 0;
+  }
+
+  //endregion init
+
+  //region accessors
+  /**
+   * Gets the actor that is bound to this window.
+   * @returns {Game_Actor|null}
+   */
+  actor()
+  {
+    return this._actor;
+  }
+
+  /**
+   * Sets the actor for this window.
+   * @param {Game_Actor} actor The actor to bind.
+   */
+  setActor(actor)
+  {
+    this._actor = actor;
+  }
+
+  /**
+   * Gets the source that is bound to this window.
+   * @returns {RPG_Actor|RPG_Class|RPG_EquipItem|RPG_Weapon|RPG_Armor|RPG_Skill|RPG_State|null}
+   */
+  source()
+  {
+    return this._source;
+  }
+
+  /**
+   * Sets the source for this window.
+   * @param {RPG_Actor|RPG_Class|RPG_EquipItem|RPG_Weapon|RPG_Armor|RPG_Skill|RPG_State} source The new source.
+   */
+  setSource(source)
+  {
+    // do nothing if the source is unchanged.
+    if (this.source() === source) return;
+
+    // update the source.
+    this._source = source;
+
+    // refresh the contents for the new source.
+    this.refresh();
+  }
+
+  /**
+   * The y position of the next block to draw.
+   * @returns {number}
+   */
+  nextY()
+  {
+    return this._nextY || 0;
+  }
+
+  /**
+   * Sets the next y position for drawing.
+   * @param {number} y The y position to set.
+   */
+  setNextY(y)
+  {
+    this._nextY = y;
+  }
+
+  //endregion accessors
+
+  //region draw
+  /**
+   * Implements {@link #drawContent}.<br/>
+   * Draws the details for the selected source.
+   */
+  drawContent()
+  {
+    if (!this.source() || !this.actor())
+    {
+      // render a default hint.
+      this.resetTextColor();
+      this.drawText('Select a source from the list.', 0, 0, this.contentsWidth());
+      return;
+    }
+
+    // reset the next y position.
+    this.setNextY(0);
+
+    // draw the header.
+    this.drawHeader();
+
+    // draw the learnable skills from the source.
+    this.drawDetails();
+  }
+
+  /**
+   * Draws the header containing the icon and name.
+   */
+  drawHeader()
+  {
+    // grab the source data.
+    const source = this.source();
+
+    // y anchor for the header.
+    let y = this.nextY();
+
+    if (source.iconIndex > 0)
+    {
+      this.drawIcon(source.iconIndex, 0, y);
+    }
+
+    // compute a left indent if we drew an icon.
+    const left = (source.iconIndex > 0)
+      ? 36
+      : 0;
+
+    // draw the name of the source.
+    this.changeTextColor(this.systemColor());
+    this.drawText(`${source.name}`, left, y, this.contentsWidth() - left);
+
+    // advance y.
+    y += this.lineHeight();
+
+    // default the description to an empty string.
+    let description = String.empty;
+
+    // actors use their profile as the description.
+    if (source.isActor())
+    {
+      description = source.profile;
+    }
+    // classes simply don't have a description.
+    else if (source.isClass())
+    {
+      description = 'The class applied to the current actor.';
+    }
+    // states also don't have a description.
+    else if (source.isState())
+    {
+      description = 'A state applied to the actor.';
+    }
+    // the rest of the possibilities do, though.
+    else
+    {
+      ({ description } = source);
+    }
+
+    // render the description.
+    const wrappedText = this.modFontSizeForText(-4, description);
+    this.drawTextEx(wrappedText, 0, y, this.contentsWidth());
+
+    // update the nextY coordinate.
+    y += this.lineHeight() * 3;
+    this.setNextY(y);
+  }
+
+  drawDetails()
+  {
+    // grab the source data.
+    const source = this.source();
+
+    // establish a y anchor somewhat below the gauges.
+    const baseY = this.nextY();
+
+    // header label for the section.
+    this.drawTextEx(`\\I[79]\\C[16]Skills\\C[0]`, 0, baseY, this.contentsWidth());
+
+    // compute the starting y for rows.
+    const updatedY = baseY + this.lineHeight();
+    this.setNextY(updatedY);
+
+    // extract all the teachables for this source.
+    const teachables = source.aptitudeTeachings;
+
+    // check if we are lacking in teachables.
+    if (teachables.length === 0)
+    {
+      // render a friendly hint.
+      this.resetTextColor();
+      this.drawText('No teachable skills available.', 0, this.nextY(), this.contentsWidth());
+
+      // stop processing.
+      return;
+    }
+
+    // grab the actor.
+    const actor = this.actor();
+
+    // derive the key from the source.
+    const sourceKey = ApManager.deriveKey(source);
+
+    // iterate over the teachables and draw the details for each.
+    teachables.forEach(teachable =>
+    {
+      // default with 0 for the x coordinate.
+      const x = 0;
+
+      // start with the nextY.
+      const nextY = this.nextY();
+
+      // calculate the left column width for the icon+label.
+      const leftW = Math.floor(this.contentsWidth() * 0.60);
+
+      // extract the AP required to learn this skill.
+      const { requiredAp, skillId } = teachable;
+
+      // identify the skill.
+      const skill = actor.skill(skillId);
+
+      // determine if the actor is learning this teachable.
+      const learning = actor.getAptitudeLearning(sourceKey, skillId);
+
+      // identify if the learning exists or not.
+      const hasLearning = learning !== null;
+
+      // render the learnable skill name.
+      this.drawTextEx(`\\I[${skill.iconIndex}]${skill.name}`, x, nextY, this.contentsWidth());
+
+      // determine the current AP count for this skill.
+      const currentAp = hasLearning
+        ? learning.currentAp
+        : 0;
+
+      // determine learned state for this specific source.
+      const learned = hasLearning && learning.isLearned() === true;
+
+      // determine if the actor already knows the skill via some other source.
+      const knownElsewhere = (learned === false) &&
+        this.actor()
+          .hasSkill(skillId);
+
+      // decide the right-side text content.
+      let rightText = '';
+      if (learned === true)
+      {
+        // if learned from this source, show DONE.
+        rightText = 'DONE';
+      }
+      else if (knownElsewhere === true)
+      {
+        // if not learned from this source but the actor already knows the skill, show KNOWN.
+        rightText = 'KNOWN';
+      }
+      else
+      {
+        // otherwise, show the current/required AP counts.
+        rightText = `${currentAp}/${requiredAp}`;
+      }
+
+      // decide the right-side color index.
+      let rightColor = 7; // gray by default
+      if (learned === true)
+      {
+        // green when learned.
+        rightColor = 11;
+      }
+      else if (currentAp > 0)
+      {
+        // yellow when in-progress.
+        rightColor = 6;
+      }
+
+      // apply the right-side color and draw the right-aligned status text.
+      this.changeTextColor(ColorManager.textColor(rightColor));
+      const rightW = this.contentsWidth() - leftW;
+      this.drawText(rightText, 0, nextY, rightW, Window_Base.TextAlignments.Right);
+
+      // Only draw a gauge if the skill is neither DONE nor KNOWN.
+      const shouldDrawGauge = learned === false && knownElsewhere === false;
+      if (shouldDrawGauge === true)
+      {
+        // compute the gauge rectangle centered vertically within the row.
+        const gaugeX = Math.floor(this.contentsWidth() * 0.40);
+        const gaugeY = nextY + Math.round(this.lineHeight() / 2) - Math.round(this.gaugeHeight() / 2);
+        const rect = new Rectangle(gaugeX, gaugeY, this.gaugeWidth(), this.gaugeHeight());
+
+        // compute the rate between 0..1 for the gauge.
+        const progressRate = Math.max(0, Math.min(currentAp / requiredAp, 1));
+
+        // build the gauge options with a dynamic segment count and colors.
+        const segOpts = WindowGaugeOptions.Builder()
+          .gaugeType(Window_Base.GAUGE_TYPES.Segmented)
+          .segments(Math.max(1, Math.ceil(requiredAp / this.segmentValue())))
+          .gap(2)
+          .leftGradientColor(this.gaugeColor1())
+          .rightGradientColor(this.gaugeColor2())
+          .build();
+
+        // draw the segmented gauge.
+        this.drawGauge(rect, progressRate, segOpts);
+      }
+
+      // and add a line for the next row.
+      this.setNextY(nextY + this.lineHeight());
+    });
+  }
+
+  //endregion draw
+
+  //region helpers
+  /**
+   * The width of the gauges in this window.
+   * @returns {number}
+   */
+  gaugeWidth()
+  {
+    return 256;
+  }
+
+  /**
+   * The height of the gauges in this window.
+   * @returns {number}
+   */
+  gaugeHeight()
+  {
+    return 12;
+  }
+
+  /**
+   * The back color of the gauges in this window.
+   * @returns {string}
+   */
+  gaugeBackColor()
+  {
+    return 'rgba(255, 255, 255, 0.1)';
+  }
+
+  /**
+   * The color to gradient from.
+   * Defaults to blue.
+   * @returns {string}
+   */
+  gaugeColor1()
+  {
+    return 'rgba(179, 89, 0, 1)';
+  }
+
+  /**
+   * The color to gradient into.
+   * Defaults to green.
+   * @returns {string}
+   */
+  gaugeColor2()
+  {
+    return 'rgba(255, 166, 77, 1)';
+  }
+
+  inactiveColor1()
+  {
+    return 'rgba(77, 77, 77, 1)';
+  }
+
+  inactiveColor2()
+  {
+    return 'rgba(153, 153, 153, 1)';
+  }
+
+  /**
+   * The amount that one segment represents.
+   * @returns {number}
+   */
+  segmentValue()
+  {
+    return 10;
+  }
+
+  //endregion helpers
+}
+
+//endregion Window_AptitudeSourceDetails
+
+//region Window_AptitudeSourceList
+/**
+ * A window listing all aptitude sources currently applied to the actor.
+ */
+class Window_AptitudeSourceList
+  extends Window_Command
+{
+  //region properties
+  /**
+   * The actor bound to this window.
+   * @type {Game_Actor|null}
+   */
+  _actor = null;
+
+  /**
+   * The list of sources bound to this window.
+   * @type {(RPG_Actor|RPG_Class|RPG_EquipItem|RPG_Weapon|RPG_Armor|RPG_Skill|RPG_State)[]}
+   */
+  _sources = [];
+
+  //endregion properties
+
+  //region init
+  constructor(rect)
+  {
+    // call parent ctor.
+    super(rect);
+
+    // initialize members.
+    this.initMembers();
+  }
+
+  /**
+   * Initializes the members of this window.
+   */
+  initMembers()
+  {
+    // initialize the actor.
+    this._actor = null;
+
+    // initialize the sources bucket.
+    this._sources = [];
+  }
+
+  //endregion init
+
+  //region accessors
+  /**
+   * Gets the actor that is bound to this window.
+   * @returns {Game_Actor|null}
+   */
+  actor()
+  {
+    return this._actor;
+  }
+
+  /**
+   * Sets the actor for this window.
+   * @param {Game_Actor} actor The actor to bind.
+   */
+  setActor(actor)
+  {
+    this._actor = actor;
+  }
+
+  /**
+   * The
+   * @returns {(RPG_Actor|RPG_Class|RPG_EquipItem|RPG_Weapon|RPG_Armor|RPG_Skill|RPG_State)[]}
+   */
+  sources()
+  {
+    return this._sources || [];
+  }
+
+  /**
+   * Sets the sources for this window.
+   * @param {(RPG_Actor|RPG_Class|RPG_EquipItem|RPG_Weapon|RPG_Armor|RPG_Skill|RPG_State)[]} sources The new sources.
+   */
+  setSources(sources)
+  {
+    // assign the sources.
+    this._sources = sources;
+
+    // rebuild the command list with the new data.
+    this.refresh();
+  }
+
+  //endregion accessors
+
+  /**
+   * Rebuilds the command list for the current actor.
+   */
+  makeCommandList()
+  {
+    // if we don’t have an actor, there is nothing to build.
+    if (this.actor() === null) return;
+
+    // build all commands for this window.
+    const commands = this.buildCommands();
+
+    // add all built commands to this window.
+    commands.forEach(this.addBuiltCommand, this);
+  }
+
+  /**
+   * Builds all commands for this command window.
+   * @returns {BuiltWindowCommand[]}
+   */
+  buildCommands()
+  {
+    // grab all the sources to build commands for.
+    const sources = this.sources();
+
+    // if no sources, nothing to render.
+    if (sources.length === 0) return [];
+
+    // build each command based on the source.
+    const commands = sources.map(this.buildCommand, this);
+
+    // return the built command set.
+    return commands;
+  }
+
+  /**
+   * Builds a single command for the given source.
+   * @param {RPG_Actor|RPG_Class|RPG_EquipItem|RPG_Weapon|RPG_Armor|RPG_Skill|RPG_State} source The source.
+   * @returns {BuiltWindowCommand}
+   */
+  buildCommand(source)
+  {
+    let { iconIndex } = source;
+
+    // actors don't normally have an icon index, so lets give em one.
+    if (source.isActor())
+    {
+      iconIndex = 2727;
+    }
+    // classes also don't normally have an icon index, so lets give em one.
+    else if (source.isClass())
+    {
+      iconIndex = 2694;
+    }
+
+    const builtWindowCommand = new WindowCommandBuilder(source.name)
+      .setSymbol(`source:${source.implementationType()}`)
+      .setExtensionData(source)
+      .setIconIndex(iconIndex)
+      .build();
+
+    return builtWindowCommand;
+  }
+}
+
+//endregion Window_AptitudeSourceList
+
+//region Window_MenuCommand
+/**
+ * Extends {@link #addOriginalCommands}.</br>
+ * Adds the Aptitude menu command if enabled via plugin parameter.
+ */
+J.APT.Aliased.Window_MenuCommand.set('addOriginalCommands', Window_MenuCommand.prototype.addOriginalCommands);
+Window_MenuCommand.prototype.addOriginalCommands = function()
+{
+  // perform original logic.
+  J.APT.Aliased.Window_MenuCommand.get('addOriginalCommands')
+    .call(this);
+
+  // add the APT menu command if enabled via plugin parameter.
+  const switchId = J.APT.Metadata.menuSwitchId;
+
+  // if no switch configured or the switch is ON, show the command.
+  if (switchId === 0 || $gameSwitches.value(switchId))
+  {
+    // build the command.
+    const builtCommand = new WindowCommandBuilder('Aptitude')
+      .setSymbol('aptitude')
+      .setIconIndex(186)
+      .build();
+
+    // add the command to the menu.
+    this.addBuiltCommand(builtCommand);
+  }
+};
+//endregion Window_MenuCommand

--- a/project/js/plugins/hud/ext/J-HUD-InputFrame.js
+++ b/project/js/plugins/hud/ext/J-HUD-InputFrame.js
@@ -608,7 +608,7 @@ class Sprite_CooldownGauge
    */
   gaugeColor1()
   {
-    return "rgba(0, 0, 255, 1)";
+    return 'rgba(0, 0, 255, 1)';
   }
 
   /**
@@ -618,7 +618,7 @@ class Sprite_CooldownGauge
    */
   gaugeColor2()
   {
-    return "rgba(0, 255, 0, 1)";
+    return 'rgba(0, 255, 0, 1)';
   }
 
   /**
@@ -628,7 +628,7 @@ class Sprite_CooldownGauge
    */
   gaugeBackColor()
   {
-    return "rgba(0, 0, 0, 0.5)";
+    return 'rgba(0, 0, 0, 0.5)';
   }
 
   /**
@@ -812,7 +812,8 @@ class Sprite_CooldownGauge
       fillW,                // the width to fill.
       fillH,                // the hieght to fill.
       this.gaugeColor1(),   // the color gradient to start with.
-      this.gaugeColor2());  // the color gradient to end with.
+      this.gaugeColor2()
+    );  // the color gradient to end with.
   }
 }
 

--- a/src/defs/rmmz_windows.d.ts
+++ b/src/defs/rmmz_windows.d.ts
@@ -588,12 +588,13 @@ declare class Window_Base
    * @param {number} x
    * @param {number} y
    * @param {number} width
+   * @param {number} height
    * @param {number} rate
    * @param {String} color1
    * @param {String} color2
    * @memberof Window_Base
    */
-  drawGauge(x: number, y: number, width: number, rate: number, color1: string, color2: string): void;
+  drawGauge(x: number, y: number, width: number, height: number, rate: number, color1: string, color2: string): void;
 
   /**
    * Returns the hp color as a css String.

--- a/src/plugin-template/_metadata/_annotations.js
+++ b/src/plugin-template/_metadata/_annotations.js
@@ -1,4 +1,4 @@
-//region annoations
+//region annotations
 /*:
  * @target MZ
  * @plugindesc

--- a/src/plugins/_base/_metadata/_annotations.js
+++ b/src/plugins/_base/_metadata/_annotations.js
@@ -92,6 +92,12 @@
  *
  * ============================================================================
  * CHANGELOG:
+ * - 2.3.3
+ *    Extended database object type-checking.
+ *    Provided way for any database object to provide a unique identifier.
+ *    Added gauge-drawing into the Window_Base class.
+ *    Added API on Game_Actor and Game_Party for directly setting levels.
+ *    Added Window_ActorRibbon for re-use.
  * - 2.3.2
  *    Added helper function to determine array intersections.
  *    Added prototype helper class for common prototype operations (unused).

--- a/src/plugins/_base/database/base/RPG_Base.js
+++ b/src/plugins/_base/database/base/RPG_Base.js
@@ -173,7 +173,7 @@ class RPG_Base
    */
   deleteMetadata(key)
   {
-    delete this.meta[key]
+    delete this.meta[key];
   }
 
   /**
@@ -233,12 +233,12 @@ class RPG_Base
     if (fromMeta)
     {
       // check if the value was a truthy value.
-      if (fromMeta === true || fromMeta.toLowerCase() === "true")
+      if (fromMeta === true || fromMeta.toLowerCase() === 'true')
       {
         return true;
       }
       // check if the value was a falsey value.
-      else if (fromMeta === false || fromMeta.toLowerCase() === "false")
+      else if (fromMeta === false || fromMeta.toLowerCase() === 'false')
       {
         return false;
       }
@@ -276,10 +276,10 @@ class RPG_Base
   #parseObject(obj)
   {
     // check if the object to parse is a string.
-    if (typeof obj === "string")
+    if (typeof obj === 'string')
     {
       // check if the string is an unparsed array.
-      if (obj.startsWith("[") && obj.endsWith("]"))
+      if (obj.startsWith('[') && obj.endsWith(']'))
       {
         // expose the stringified segments of the array.
         const exposedArray = obj
@@ -314,11 +314,11 @@ class RPG_Base
   #parseString(str)
   {
     // check if its actually boolean true.
-    if (str.toLowerCase() === "true")
+    if (str.toLowerCase() === 'true')
     {
       return true;
     }// check if its actually boolean false.
-    else if (str.toLowerCase() === "false") return false;
+    else if (str.toLowerCase() === 'false') return false;
 
     // check if its actually a number.
     if (!Number.isNaN(parseFloat(str))) return parseFloat(str);
@@ -880,6 +880,33 @@ class RPG_Base
   //endregion note
 
   /**
+   * Whether or not this database entry is an actor.
+   * @returns {boolean}
+   */
+  isActor()
+  {
+    return false;
+  }
+
+  /**
+   * Whether or not this database entry is a class.
+   * @returns {boolean}
+   */
+  isClass()
+  {
+    return false;
+  }
+
+  /**
+   * Whether or not this database entry is an enemy.
+   * @returns {boolean}
+   */
+  isEnemy()
+  {
+    return false;
+  }
+
+  /**
    * Whether or not this database entry is an item.
    * @returns {boolean}
    */
@@ -913,6 +940,24 @@ class RPG_Base
   isSkill()
   {
     return false;
+  }
+
+  /**
+   * Whether or not this database entry is a state.
+   * @returns {boolean}
+   */
+  isState()
+  {
+    return false;
+  }
+
+  /**
+   * Gets the type of implementation this database entry is.
+   * @returns {string}
+   */
+  implementationType()
+  {
+    return '@base';
   }
 }
 

--- a/src/plugins/_base/database/base/RPG_BaseBattler.js
+++ b/src/plugins/_base/database/base/RPG_BaseBattler.js
@@ -34,6 +34,15 @@ class RPG_BaseBattler
     this.traits = battler.traits
       .map(trait => new RPG_Trait(trait));
   }
+
+  /**
+   * Gets the type of implementation this database entry is.
+   * @returns {string}
+   */
+  implementationType()
+  {
+    return `${super.implementationType()}:battler`;
+  }
 }
 
 //endregion RPG_BaseBattler

--- a/src/plugins/_base/database/base/RPG_Traited.js
+++ b/src/plugins/_base/database/base/RPG_Traited.js
@@ -25,6 +25,15 @@ class RPG_Traited
     // map the base item's traits.
     this.traits = baseItem.traits.map(trait => new RPG_Trait(trait));
   }
+
+  /**
+   * Gets the type of implementation this database entry is.
+   * @returns {string}
+   */
+  implementationType()
+  {
+    return `${super.implementationType()}:traited`;
+  }
 }
 
 //endregion RPG_Traited

--- a/src/plugins/_base/database/core/RPG_EquipItem.js
+++ b/src/plugins/_base/database/core/RPG_EquipItem.js
@@ -64,6 +64,15 @@ class RPG_EquipItem
   {
     return this.etypeId > 1;
   }
+
+  /**
+   * Gets the type of implementation this database entry is.
+   * @returns {string}
+   */
+  implementationType()
+  {
+    return `${super.implementationType()}:equip`;
+  }
 }
 
 //endregion RPG_EquipItem

--- a/src/plugins/_base/database/core/RPG_UsableItem.js
+++ b/src/plugins/_base/database/core/RPG_UsableItem.js
@@ -91,6 +91,15 @@ class RPG_UsableItem
     this.successRate = usableItem.successRate;
     this.tpGain = usableItem.tpGain;
   }
+
+  /**
+   * Gets the type of implementation this database entry is.
+   * @returns {string}
+   */
+  implementationType()
+  {
+    return `${super.implementationType()}:usable`;
+  }
 }
 
 //endregion RPG_UsableItem

--- a/src/plugins/_base/database/implementations/RPG_Actor.js
+++ b/src/plugins/_base/database/implementations/RPG_Actor.js
@@ -84,7 +84,7 @@ class RPG_Actor
     super(actor, index);
 
     // map the data.
-    this.initMembers(actor)
+    this.initMembers(actor);
   }
 
   /**
@@ -104,6 +104,24 @@ class RPG_Actor
     this.maxLevel = actor.maxLevel;
     this.nickname = actor.nickname;
     this.profile = actor.profile;
+  }
+
+  /**
+   * Whether or not this database entry is an actor.
+   * @returns {boolean}
+   */
+  isActor()
+  {
+    return true;
+  }
+
+  /**
+   * Gets the type of implementation this database entry is.
+   * @returns {string}
+   */
+  implementationType()
+  {
+    return `${super.implementationType()}:actor`;
   }
 }
 

--- a/src/plugins/_base/database/implementations/RPG_Armor.js
+++ b/src/plugins/_base/database/implementations/RPG_Armor.js
@@ -43,6 +43,15 @@ class RPG_Armor
   {
     return true;
   }
+
+  /**
+   * Gets the type of implementation this database entry is.
+   * @returns {string}
+   */
+  implementationType()
+  {
+    return `${super.implementationType()}:armor`;
+  }
 }
 
 //endregion RPG_Armor

--- a/src/plugins/_base/database/implementations/RPG_Class.js
+++ b/src/plugins/_base/database/implementations/RPG_Class.js
@@ -52,6 +52,24 @@ class RPG_Class
     this.traits = classData.traits
       .map(trait => new RPG_Trait(trait));
   }
+
+  /**
+   * Whether or not this database entry is a class.
+   * @returns {boolean}
+   */
+  isClass()
+  {
+    return true;
+  }
+
+  /**
+   * Gets the type of implementation this database entry is.
+   * @returns {string}
+   */
+  implementationType()
+  {
+    return `${super.implementationType()}:class`;
+  }
 }
 
 //endregion RPG_Class

--- a/src/plugins/_base/database/implementations/RPG_Enemy.js
+++ b/src/plugins/_base/database/implementations/RPG_Enemy.js
@@ -76,6 +76,24 @@ class RPG_Enemy
     this.gold = enemy.gold;
     this.params = enemy.params;
   }
+
+  /**
+   * Whether or not this database entry is an enemy.
+   * @returns {boolean}
+   */
+  isEnemy()
+  {
+    return true;
+  }
+
+  /**
+   * Gets the type of implementation this database entry is.
+   * @returns {string}
+   */
+  implementationType()
+  {
+    return `${super.implementationType()}:enemy`;
+  }
 }
 
 //endregion RPG_Enemy

--- a/src/plugins/_base/database/implementations/RPG_Item.js
+++ b/src/plugins/_base/database/implementations/RPG_Item.js
@@ -57,6 +57,15 @@ class RPG_Item
   {
     return true;
   }
+
+  /**
+   * Gets the type of implementation this database entry is.
+   * @returns {string}
+   */
+  implementationType()
+  {
+    return `${super.implementationType()}:item`;
+  }
 }
 
 //endregion RPG_Item

--- a/src/plugins/_base/database/implementations/RPG_Skill.js
+++ b/src/plugins/_base/database/implementations/RPG_Skill.js
@@ -96,6 +96,15 @@ class RPG_Skill
   {
     return true;
   }
+
+  /**
+   * Gets the type of implementation this database entry is.
+   * @returns {string}
+   */
+  implementationType()
+  {
+    return `${super.implementationType()}:skill`;
+  }
 }
 
 //endregion RPG_Skill

--- a/src/plugins/_base/database/implementations/RPG_State.js
+++ b/src/plugins/_base/database/implementations/RPG_State.js
@@ -166,6 +166,24 @@ class RPG_State
     this.restriction = state.restriction;
     this.stepsToRemove = state.stepsToRemove;
   }
+
+  /**
+   * Whether or not this database entry is a state.
+   * @returns {boolean}
+   */
+  isState()
+  {
+    return true;
+  }
+
+  /**
+   * Gets the type of implementation this database entry is.
+   * @returns {string}
+   */
+  implementationType()
+  {
+    return `${super.implementationType()}:state`;
+  }
 }
 
 //endregion RPG_State

--- a/src/plugins/_base/database/implementations/RPG_Weapon.js
+++ b/src/plugins/_base/database/implementations/RPG_Weapon.js
@@ -50,6 +50,15 @@ class RPG_Weapon
   {
     return true;
   }
+
+  /**
+   * Gets the type of implementation this database entry is.
+   * @returns {string}
+   */
+  implementationType()
+  {
+    return `${super.implementationType()}:weapon`;
+  }
 }
 
 //endregion RPG_Weapon

--- a/src/plugins/_base/models/GaugeOptionsBuilder.js
+++ b/src/plugins/_base/models/GaugeOptionsBuilder.js
@@ -1,0 +1,261 @@
+//region GaugeOptionsBuilder
+/**
+ * A factory for generating {@link WindowGaugeOptions}.
+ * Comes with sensible defaults.
+ */
+class GaugeOptionsBuilder
+{
+  //region properties
+  /**
+   * The color of the gauge's background.
+   * @type {string}
+   */
+  #backColor = String.empty;
+
+  /**
+   * The color of the gauge's border.
+   * @type {string}
+   */
+  #borderColor = 'rgba(255, 255, 255, 0.85)';
+
+  /**
+   * The left color gradient for the gauge.
+   * Blends to the right color.
+   * @type {string}
+   */
+  #leftColor = 'rgba(179, 89, 0, 1)';
+
+  /**
+   * The right color gradient for the gauge.
+   * Blends from the left color.
+   * @type {string}
+   */
+  #rightColor = 'rgba(255, 166, 77, 1)';
+
+  /**
+   * The thickness of the gauge's border.
+   * @type {number}
+   */
+  #borderThickness = 2;
+
+  /**
+   * The gap between the gauge's border and the inner fill area.
+   * @type {number}
+   */
+  #borderGap = 1;
+
+  /**
+   * The color of the segment dividers.
+   * @type {string}
+   */
+  #dividerColor = 'rgba(255, 255, 255, 0.85)';
+
+  /**
+   * The number of visual segments.
+   * @type {number}
+   */
+  #segments = 8;
+
+  /**
+   * The gap between visual segments in pixels.
+   * @type {number}
+   */
+  #gap = 2;
+
+  /**
+   * The corner radius of the pill gauge in pixels.
+   * @type {number}
+   */
+  #radius = 4;
+
+  /**
+   * The thickness of the radial gauge in pixels.
+   * @type {number}
+   */
+  #thickness = 6;
+
+  /**
+   * The start angle of the radial gauge in radians.
+   * @type {number}
+   */
+  #startAngle = (-Math.PI / 2);
+
+  /**
+   * The type of gauge to render.
+   * @type {string}
+   */
+  #gaugeType = Window_Base.GAUGE_TYPES.Rectangle;
+
+  //endregion properties
+
+  /**
+   * Builds the {@link WindowGaugeOptions}.
+   * @returns {WindowGaugeOptions}
+   */
+  build()
+  {
+    return new WindowGaugeOptions(
+      this.#gaugeType,
+      this.#backColor,
+      this.#leftColor,
+      this.#rightColor,
+      this.#borderColor,
+      this.#borderThickness,
+      this.#borderGap,
+      this.#dividerColor,
+      this.#segments,
+      this.#gap,
+      this.#radius,
+      this.#thickness,
+      this.#startAngle,
+    );
+  }
+
+  //region setters
+  /**
+   * The type of gauge, from {@link Window_Base.GAUGE_TYPES}.
+   * @param {string} type The gauge type.
+   * @returns {GaugeOptionsBuilder}
+   */
+  gaugeType(type)
+  {
+    this.#gaugeType = type;
+    return this;
+  }
+
+  /**
+   * Sets the gauge's background color.
+   * @param {string} color The color to set.
+   * @returns {GaugeOptionsBuilder}
+   */
+  backColor(color)
+  {
+    this.#backColor = color;
+    return this;
+  }
+
+  /**
+   * Sets the left color gradient for the gauge.
+   * @param {string} color The color to set.
+   * @returns {GaugeOptionsBuilder}
+   */
+  leftGradientColor(color)
+  {
+    this.#leftColor = color;
+    return this;
+  }
+
+  /**
+   * Sets the right color gradient for the gauge.
+   * @param {string} color The color to set.
+   * @returns {GaugeOptionsBuilder}
+   */
+  rightGradientColor(color)
+  {
+    this.#rightColor = color;
+    return this;
+  }
+
+  /**
+   * Sets the gauge’s border color.
+   * @param {string} color The outline color.
+   * @returns {GaugeOptionsBuilder}
+   */
+  borderColor(color)
+  {
+    this.#borderColor = color;
+    return this;
+  }
+
+  /**
+   * Sets the border thickness in pixels (>=1).
+   * @param {number} thickness The outline thickness.
+   * @returns {GaugeOptionsBuilder}
+   */
+  borderThickness(thickness)
+  {
+    this.#borderThickness = thickness;
+    return this;
+  }
+
+  /**
+   * Sets the padding between outline and inner fill area (>=0).
+   * @param {number} gap The padding.
+   * @returns {GaugeOptionsBuilder}
+   */
+  borderGap(gap)
+  {
+    this.#borderGap = gap;
+    return this;
+  }
+
+  /**
+   * Sets the color for segment dividers (defaults to borderColor if omitted).
+   * @param {string} color The divider color.
+   * @returns {GaugeOptionsBuilder}
+   */
+  dividerColor(color)
+  {
+    this.#dividerColor = color;
+    return this;
+  }
+
+  /**
+   * Sets the number of visual segments (>=1).
+   * @param {number} count The segment count.
+   * @returns {GaugeOptionsBuilder}
+   */
+  segments(count)
+  {
+    this.#segments = count;
+    return this;
+  }
+
+  /**
+   * Sets the inter‑segment gap in pixels (>=0).
+   * @param {number} px The gap width.
+   * @returns {GaugeOptionsBuilder}
+   */
+  gap(px)
+  {
+    this.#gap = px;
+    return this;
+  }
+
+  /**
+   * Sets the visual corner radius for pill gauges.
+   * @param {number} r The radius in pixels.
+   * @returns {GaugeOptionsBuilder}
+   */
+  radius(r)
+  {
+    this.#radius = r;
+    return this;
+  }
+
+  /**
+   * Sets the ring thickness for radial gauges.
+   * @param {number|null} t The thickness in pixels; null to derive automatically.
+   * @returns {GaugeOptionsBuilder}
+   */
+  thickness(t)
+  {
+    this.#thickness = t;
+    return this;
+  }
+
+  /**
+   * Sets the start angle for radial gauges (radians).
+   * @param {number} radians The start angle.
+   * @returns {GaugeOptionsBuilder}
+   */
+  startAngle(radians)
+  {
+    this.#startAngle = radians;
+    return this;
+  }
+
+  //endregion setters
+}
+
+//endregion GaugeOptionsBuilder

--- a/src/plugins/_base/models/WindowGaugeOptions.js
+++ b/src/plugins/_base/models/WindowGaugeOptions.js
@@ -1,0 +1,130 @@
+//region WindowGaugeOptions
+/**
+ * The options for a gauge that shows up in the window.
+ */
+class WindowGaugeOptions
+{
+  /**
+   * A factory for generating {@link WindowGaugeOptions}.
+   * @returns {GaugeOptionsBuilder}
+   * @constructor
+   */
+  static Builder = () => new GaugeOptionsBuilder();
+
+  //region properties
+  /**
+   * The type of gauge to render.
+   * @type {string}
+   */
+  gaugeType = String.empty;
+
+  /**
+   * The color of the gauge's background.
+   * @type {string}
+   */
+  backColor = String.empty;
+
+  /**
+   * The left color gradient for the gauge.
+   * @type {string}
+   */
+  leftGradientColor = String.empty;
+
+  /**
+   * The right color gradient for the gauge.
+   * @type {string}
+   */
+  rightGradientColor = String.empty;
+
+  /**
+   * The color of the gauge's border.
+   * @type {string}
+   */
+  borderColor = String.empty;
+
+  /**
+   * The thickness of the gauge's border.
+   * @type {number}
+   */
+  borderThickness = 0;
+
+  /**
+   * The gap between the gauge's border and the inner fill area.
+   * @type {number}
+   */
+  borderGap = 0;
+
+  /**
+   * The color of the segment dividers.
+   * @type {string}
+   */
+  dividerColor = String.empty;
+
+  /**
+   * The number of visual segments.
+   * @type {number}
+   */
+  segments = 1;
+
+  /**
+   * The gap between visual segments in pixels.
+   * @type {number}
+   */
+  gap = 0;
+
+  /**
+   * The corner radius of the pill gauge in pixels.
+   * @type {number}
+   */
+  radius = 0;
+
+  /**
+   * The thickness of the radial gauge in pixels.
+   * @type {number}
+   */
+  thickness = 1;
+
+  /**
+   * The start angle of the radial gauge in radians.
+   * @type {number}
+   */
+  startAngle = 0;
+
+  //endregion properties
+
+  /**
+   * Constructor.
+   */
+  constructor(
+    gaugeType,
+    backColor,
+    leftGradientColor,
+    rightGradientColor,
+    borderColor,
+    borderThickness,
+    borderGap,
+    dividerColor,
+    segments,
+    gap,
+    radius,
+    thickness,
+    startAngle
+  )
+  {
+    this.gaugeType = gaugeType;
+    this.backColor = backColor;
+    this.leftGradientColor = leftGradientColor;
+    this.rightGradientColor = rightGradientColor;
+    this.borderColor = borderColor;
+    this.borderThickness = borderThickness;
+    this.borderGap = borderGap;
+    this.dividerColor = dividerColor;
+    this.segments = segments;
+    this.gap = gap;
+    this.radius = radius;
+    this.thickness = thickness;
+    this.startAngle = startAngle;
+  }
+}
+
+//endregion WindowGaugeOptions

--- a/src/plugins/_base/objects/Game_Actor.js
+++ b/src/plugins/_base/objects/Game_Actor.js
@@ -1,3 +1,5 @@
+/* eslint-disable no-unused-vars */
+
 //region Game_Actor
 /**
  * Gets the parameter value from the "long" parameter id.
@@ -126,7 +128,8 @@ Game_Actor.prototype.getActorNotes = function()
     actor,
 
     // add the actor's class to the source list.
-    this.class(actor.classId) ];
+    this.class(actor.classId)
+  ];
 };
 
 /**
@@ -144,7 +147,8 @@ Game_Actor.prototype.getNotesSources = function()
     this.currentClass(),
 
     // add all of the actor's valid equips to the source list.
-    ...this.equippedEquips(), ];
+    ...this.equippedEquips(),
+  ];
 
   // combine the two source lists.
   const combinedNoteSources = baseNoteSources.concat(actorUniqueNoteSources);
@@ -295,6 +299,10 @@ Game_Actor.prototype.onEquipChange = function()
   this.onBattlerDataChange();
 };
 
+/**
+ * Extends {@link #changeClass}.<br/>
+ * Adds a hook for performing actions when the actor changes class.
+ */
 J.BASE.Aliased.Game_Actor.set('changeClass', Game_Actor.prototype.changeClass);
 Game_Actor.prototype.changeClass = function(classId, keepExp)
 {
@@ -463,6 +471,19 @@ Game_Actor.prototype.equippedEquips = function()
 };
 
 /**
+ * Sets the level of this actor to the given level.
+ * @param {number} level The level to set this actor to.
+ */
+Game_Actor.prototype.setLevel = function(level)
+{
+  // Identify the minimum threshold of experience for the target level.
+  const newExperience = this.expForLevel(level);
+
+  // change the experience for this actor to the new level's amount.
+  this.changeExp(newExperience, false);
+};
+
+/**
  * An event hook fired when this actor levels up.
  */
 Game_Actor.prototype.onLevelUp = function()
@@ -471,7 +492,7 @@ Game_Actor.prototype.onLevelUp = function()
 };
 
 /**
- * Extends {@link #levelUp}.<br>
+ * Extends {@link #levelUp}.<br/>
  * Adds a hook for performing actions when an the actor levels up.
  */
 J.BASE.Aliased.Game_Actor.set('levelUp', Game_Actor.prototype.levelUp);

--- a/src/plugins/_base/objects/Game_Party.js
+++ b/src/plugins/_base/objects/Game_Party.js
@@ -183,8 +183,31 @@ Game_Party.prototype.recoverAllMembers = function()
     .forEach(member => member.recoverAll());
 };
 
+/**
+ * Overrides {@link #maxBattleMembers}.<br/>
+ * Sets the maximum number of battle members to 8.
+ * @returns {number}
+ */
 Game_Party.prototype.maxBattleMembers = function()
 {
   return 8;
+};
+
+/**
+ * Sets the level of all party members to the given level.
+ * @param {number} level The level to set all party members to.
+ */
+Game_Party.prototype.setLevel = function(level)
+{
+  // iterate over each member and set their level to the designated level.
+  this.members()
+    .forEach(member =>
+    {
+      // ensure the level is within the valid range.
+      const normalizedLevel = level.clamp(1, member.maxLevel());
+
+      // set the level.
+      member.setLevel(normalizedLevel);
+    });
 };
 //endregion Game_Party

--- a/src/plugins/_base/windows/Window_ActorRibbon.js
+++ b/src/plugins/_base/windows/Window_ActorRibbon.js
@@ -1,0 +1,224 @@
+//region Window_ActorRibbon
+/**
+ * A window for rendering a ribbon of an actor's face.
+ * If the window is made longer or taller, additional info could be rendered around it.
+ */
+class Window_ActorRibbon
+  extends Window_Base
+{
+  //region init
+  /**
+   * @constructor
+   * @param {Rectangle} rect The rectangle that defines this window's shape.
+   */
+  constructor(rect)
+  {
+    // perform original logic.
+    super(rect);
+
+    // initialize our custom members.
+    this.initMembers();
+  }
+
+  /**
+   * Initializes all custom members of this window.
+   */
+  initMembers()
+  {
+    /**
+     * The actor in this window.
+     * @type {Game_Actor|null}
+     */
+    this._actor = null;
+
+    /**
+     * The width of the actor face in the ribbon.
+     * @type {number}
+     */
+    this._faceWidth = 128;
+
+    /**
+     * The height of the actor face in the ribbon.
+     * @type {number}
+     */
+    this._faceHeight = 40;
+
+    /**
+     * The x of the actor's face in the ribbon.
+     * @type {number}
+     */
+    this._faceX = 0;
+
+    /**
+     * The y of the actor's face in the ribbon.
+     * @type {number}
+     */
+    this._faceY = 0;
+  }
+
+  //endregion init
+
+  //region properties
+  //region actor
+  /**
+   * Gets the actor focus for the window.
+   * @returns {Game_Actor|null}
+   */
+  actor()
+  {
+    return this._actor;
+  }
+
+  /**
+   * Sets the actor focus for the window and optionally refreshes.
+   * @param {Game_Actor} actor The actor to display.
+   * @param {boolean} [andRefresh=true] Whether or not to refresh the window; defaults to true.
+   */
+  setActor(actor, andRefresh = true)
+  {
+    // set the actor.
+    this._actor = actor;
+
+    // check if a refresh is desired.
+    if (andRefresh)
+    {
+      // refresh the window.
+      this.refresh();
+    }
+  }
+
+  //endregion actor
+
+  // region face size
+  /**
+   * The width of the actor face in the ribbon.
+   * @returns {number}
+   */
+  faceWidth()
+  {
+    return this._faceWidth;
+  }
+
+  /**
+   * The width of the actor face in the ribbon.
+   * @returns {number}
+   */
+  setFaceWidth(width)
+  {
+    this._faceWidth = width;
+  }
+
+  /**
+   * The height of the actor face in the ribbon.
+   * @returns {number}
+   */
+  faceHeight()
+  {
+    return this._faceHeight;
+  }
+
+  /**
+   * The height of the actor face in the ribbon.
+   * @returns {number}
+   */
+  setFaceHeight(height)
+  {
+    this._faceHeight = height;
+  }
+
+  /**
+   * Gets the size of the actor face in the ribbon.
+   * @returns {[number, number]}
+   */
+  faceSize()
+  {
+    return [ this.faceWidth(), this.faceHeight() ];
+  }
+
+  //endregion face size
+
+  //region face coordinates
+  /**
+   * Gets the x coordinate of the actor face in the ribbon.
+   * @returns {number}
+   */
+  faceX()
+  {
+    return this._faceX;
+  }
+
+  /**
+   * Sets the x coordinate of the actor face in the ribbon.
+   * @param {number} x The x coordinate.
+   */
+  setFaceX(x)
+  {
+    this._faceX = x;
+  }
+
+  /**
+   * Gets the y coordinate of the actor face in the ribbon.
+   * @returns {number}
+   */
+  faceY()
+  {
+    return this._faceY;
+  }
+
+  /**
+   * Sets the y coordinate of the actor face in the ribbon.
+   * @param {number} y The y coordinate.
+   */
+  setFaceY(y)
+  {
+    this._faceY = y;
+  }
+
+  /**
+   * Gets the coordinates of the actor face in the ribbon.
+   * @returns {[number, number]}
+   */
+  faceCoordinates()
+  {
+    return [ this.faceX(), this.faceY() ];
+  }
+
+  //endregion face coordinates
+  //endregion properties
+
+  //region draw
+  /**
+   * Implements {@link #drawContent}.<br/>
+   * Draws the actor face in the ribbon.
+   */
+  drawContent()
+  {
+    // don't draw if the actor is unavailable.
+    if (!this._actor) return;
+
+    // draw the actor face.
+    this.drawActorRibbon();
+  }
+
+  /**
+   * Draws the actor face in the ribbon.
+   */
+  drawActorRibbon()
+  {
+    // grab the actor.
+    const actor = this.actor();
+
+    // grab the coordinates of the face.
+    const [ x, y ] = this.faceCoordinates();
+
+    // grab the size of the face.
+    const [ w, h ] = this.faceSize();
+
+    // draw the face.
+    this.drawFace(actor.faceName(), actor.faceIndex(), x, y, w, h);
+  }
+
+  //endregion draw
+}
+
+//endregion Window_ActorRibbon

--- a/src/plugins/_base/windows/Window_Base.js
+++ b/src/plugins/_base/windows/Window_Base.js
@@ -25,6 +25,25 @@ Window_Base.TextAlignments = {
 };
 
 /**
+ * Enumerates built-in gauge types for {@link Window_Base#drawGauge}.
+ */
+Window_Base.GAUGE_TYPES = {
+  // a bordered rectangular gauge with gradient fill.
+  Rectangle: 'rect',
+
+  // a segmented gauge.
+  Segmented: 'segmented',
+
+  // a rounded-corner style.
+  Pill: 'pill',
+
+  // a circular ring gauge.
+  Radial: 'radial',
+};
+
+//region draw text
+
+/**
  * Draws a horizontal "line" with the given parameters.
  *
  * The origin coordinate is always the upper left corner.
@@ -188,6 +207,8 @@ Window_Base.prototype.setFontSize = function(fontSize)
   this.contents.fontSize = normalizedFontSize;
 };
 
+//endregion draw text
+
 /**
  * Renders a "background" of a given rectangle.
  * This is centralized for all windows to leverage if necessary.
@@ -211,4 +232,420 @@ Window_Base.prototype.drawBackgroundRect = function(rect)
   this.contentsBack.gradientFillRect(x, y, width, height, color1, color2, true);
   this.contentsBack.strokeRect(x, y, width, height, color1);
 };
+
+// region draw gauge
+
+/**
+ * The height of this gauge.
+ */
+Window_Base.prototype.gaugeHeight = function()
+{
+  return 10;
+};
+
+/**
+ * The backdrop color.
+ * Defaults to black with 50% opacity.
+ * @returns {string}
+ */
+Window_Base.prototype.gaugeBackColor = function()
+{
+  return 'rgba(0, 0, 0, 0.5)';
+};
+
+/**
+ * Draws a gauge using a {@link Rectangle} and a {@link WindowGaugeOptions}.
+ * @param {Rectangle} rect The rectangle area to draw within.
+ * @param {number} rate The 0..1 fill amount.
+ * @param {WindowGaugeOptions} options The gauge options.
+ */
+Window_Base.prototype.drawGauge = function(
+  rect,
+  rate,
+  options,
+)
+{
+  // delegate to the Rectangle-based switch.
+  this.drawGaugeRect(rect, rate, options);
+};
+
+/**
+ * Dispatches to the specific gauge renderer based on the options.
+ * Provides an inner-rect (padding) and delegates shape/back/border to the style.
+ * @param {Rectangle} rect The rectangle area.
+ * @param {number} rate The 0..1 fill amount.
+ * @param {WindowGaugeOptions} options The strongly-typed gauge options.
+ */
+Window_Base.prototype.drawGaugeRect = function(rect, rate, options)
+{
+  // clamp the rate to the 0..1 range.
+  const clampedRate = Math.max(0, Math.min(1, rate));
+
+  // compute the inner rectangle to avoid the border padding.
+  const inner = this._computeGaugeInnerRect(rect, options);
+
+  // extract the inner rectangle coordinates.
+  const {
+    x,
+    y,
+    width,
+    height
+  } = inner;
+
+  // route to the appropriate style.
+  switch (options.gaugeType)
+  {
+    case Window_Base.GAUGE_TYPES.Segmented:
+    {
+      this.drawGaugeSegmented(x, y, width, height, clampedRate, options);
+      break;
+    }
+    case Window_Base.GAUGE_TYPES.Pill:
+    {
+      this.drawGaugePill(x, y, width, height, clampedRate, options);
+      break;
+    }
+    case Window_Base.GAUGE_TYPES.Radial:
+    {
+      this.drawGaugeRadial(x, y, width, height, clampedRate, options);
+      break;
+    }
+    case Window_Base.GAUGE_TYPES.Rectangle:
+    default:
+    {
+      this.drawGaugeBorderedRect(x, y, width, height, clampedRate, options);
+      break;
+    }
+  }
+};
+
+/**
+ * Draws a rectangular gauge with a gradient fill and a rectangle border that
+ * hugs the fill area. Back color is rendered first.
+ * @param {number} x The x coordinate inside the inner rect.
+ * @param {number} y The y coordinate inside the inner rect.
+ * @param {number} w The inner width.
+ * @param {number} h The inner height.
+ * @param {number} rate The 0..1 fill amount.
+ * @param {WindowGaugeOptions} options The strongly-typed gauge options.
+ */
+Window_Base.prototype.drawGaugeBorderedRect = function(x, y, w, h, rate, options)
+{
+  // styling.
+  const { backColor } = options;
+  const { borderColor } = options;
+  const { borderThickness } = options;
+
+  // fill back area.
+  this.contents.fillRect(x, y, w, h, backColor);
+
+  // fill gradient portion.
+  const fw = Math.max(0, Math.floor(w * Math.max(0, Math.min(1, rate))));
+  if (fw > 0 && h > 0)
+  {
+    this.contents.gradientFillRect(x, y, fw, h, options.leftGradientColor, options.rightGradientColor);
+  }
+
+  // stroke rectangular border.
+  const ctx = this.contents._context;
+  ctx.save();
+  ctx.beginPath();
+  ctx.rect(x + 0.5, y + 0.5, w - 1, h - 1);
+  ctx.lineWidth = borderThickness;
+  ctx.strokeStyle = borderColor;
+  ctx.stroke();
+  ctx.restore();
+};
+
+/**
+ * Draws a segmented gauge with a single continuous gradient across the filled length.
+ * Then carves gap bars so color transitions don’t reset per segment.
+ * Border is a simple rectangle following the gauge.
+ * @param {number} x The x coordinate.
+ * @param {number} y The y coordinate.
+ * @param {number} w The inner width.
+ * @param {number} h The inner height.
+ * @param {number} rate The 0..1 fill amount.
+ * @param {WindowGaugeOptions} options The strongly-typed gauge options.
+ */
+Window_Base.prototype.drawGaugeSegmented = function(x, y, w, h, rate, options)
+{
+  // pull styling.
+  const { backColor } = options;
+  const { borderColor } = options;
+  const { borderThickness } = options;
+
+  // divider styling (defaults to border color so it remains visible on any fill).
+  const dividerColor = options.dividerColor || borderColor;
+
+  // coerce parameters.
+  const count = Math.max(1, Number(options.segments));
+  const spacing = Math.max(0, Number(options.gap));
+
+  // compute the filled width and early outs.
+  const clamped = Math.max(0, Math.min(1, rate));
+  const fw = Math.max(0, Math.floor(w * clamped));
+  if (h <= 0) return;
+
+  // BACK: whole rect.
+  this.contents.fillRect(x, y, w, h, backColor);
+
+  // FILL: one continuous gradient across fw.
+  if (fw > 0)
+  {
+    this.contents.gradientFillRect(x, y, fw, h, options.leftGradientColor, options.rightGradientColor);
+
+    // carve gaps without breaking the gradient.
+    if (count > 1 && spacing > 0)
+    {
+      const totalGap = spacing * (count - 1);
+      const segW = Math.max(1, Math.floor((w - totalGap) / count));
+      for (let i = 1; i < count; i++)
+      {
+        // location of the i-th divider (left edge of the gap)
+        const gx = x + i * segW + (i - 1) * spacing;
+
+        // only carve within the filled area.
+        if (gx < x + fw)
+        {
+          // width to carve for this divider (may be truncated if near the fill edge).
+          const carve = Math.min(spacing, (x + fw) - gx);
+
+          // draw the divider using its own color for strong contrast.
+          if (carve > 0)
+          {
+            this.contents.fillRect(gx, y, carve, h, dividerColor);
+          }
+        }
+      }
+    }
+  }
+
+  // BORDER: rectangular stroke around the shape.
+  const ctx = this.contents._context;
+  ctx.save();
+  ctx.beginPath();
+  ctx.rect(x + 0.5, y + 0.5, w - 1, h - 1);
+  ctx.lineWidth = borderThickness;
+  ctx.strokeStyle = borderColor;
+  ctx.stroke();
+  ctx.restore();
+};
+
+/**
+ * Draws a pill gauge with a true rounded-rectangle path (no scanlines),
+ * then outlines it so the border follows the pill shape.
+ * @param {number} x The x coordinate.
+ * @param {number} y The y coordinate.
+ * @param {number} w The inner width.
+ * @param {number} h The inner height.
+ * @param {number} rate The 0..1 fill amount.
+ * @param {WindowGaugeOptions} options The strongly-typed gauge options.
+ */
+Window_Base.prototype.drawGaugePill = function(x, y, w, h, rate, options)
+{
+  // clamp the radius to avoid pointy ends.
+  const maxR = Math.max(0, Math.floor(h / 2) - 1);
+  const r = Math.max(0, Math.min(Number(options.radius), maxR));
+
+  // derive styling.
+  const { backColor } = options;
+  const { borderColor } = options;
+  const { borderThickness } = options;
+
+  // compute the filled width.
+  const fw = Math.max(0, Math.floor(w * Math.max(0, Math.min(1, rate))));
+  if (h <= 0) return;
+
+  // get 2D context and gradient.
+  const ctx = this.contents._context;
+  const grad = ctx.createLinearGradient(x, y, x + w, y);
+  grad.addColorStop(0, options.leftGradientColor);
+  grad.addColorStop(1, options.rightGradientColor);
+
+  // helper to draw a rounded-rect path.
+  const roundedRectPath = () =>
+  {
+    const x2 = x + w;
+    const y2 = y + h;
+    ctx.beginPath();
+    ctx.moveTo(x + r, y);
+    ctx.lineTo(x2 - r, y);
+    ctx.arcTo(x2, y, x2, y + r, r);
+    ctx.lineTo(x2, y2 - r);
+    ctx.arcTo(x2, y2, x2 - r, y2, r);
+    ctx.lineTo(x + r, y2);
+    ctx.arcTo(x, y2, x, y2 - r, r);
+    ctx.lineTo(x, y + r);
+    ctx.arcTo(x, y, x + r, y, r);
+    ctx.closePath();
+  };
+
+  // BACK: pill outline filled with back color.
+  ctx.save();
+  roundedRectPath();
+  ctx.fillStyle = backColor;
+  ctx.fill();
+  ctx.restore();
+
+  // FILL: draw only the left fw portion — clip to the pill shape for clean ends.
+  if (fw > 0)
+  {
+    ctx.save();
+    roundedRectPath();
+    ctx.clip();
+    ctx.fillStyle = grad;
+    ctx.fillRect(x, y, fw, h);
+    ctx.restore();
+  }
+
+  // BORDER: stroke the pill outline.
+  ctx.save();
+  roundedRectPath();
+  ctx.lineWidth = borderThickness;
+  ctx.strokeStyle = borderColor;
+  ctx.stroke();
+  ctx.restore();
+};
+
+/**
+ * Draws an elliptical (oval-capable) radial gauge inside the given rect.
+ * Renders: back ring → filled wedge → border strokes that follow outer+inner ellipses.
+ * @param {number} x The inner-rect x.
+ * @param {number} y The inner-rect y.
+ * @param {number} w The inner-rect width.
+ * @param {number} h The inner-rect height.
+ * @param {number} rate The 0..1 fill amount.
+ * @param {WindowGaugeOptions} options The strongly-typed gauge options.
+ */
+Window_Base.prototype.drawGaugeRadial = function(x, y, w, h, rate, options)
+{
+  // compute outer radii and center.
+  const rx = Math.max(2, Math.floor(w / 2) - 1);
+  const ry = Math.max(2, Math.floor(h / 2) - 1);
+  const cx = x + Math.floor(w / 2);
+  const cy = y + Math.floor(h / 2);
+
+  // clamp rate and angles.
+  const r = Math.max(0, Math.min(1, rate));
+  const a0 = options.startAngle;
+  const a1 = a0 + (Math.PI * 2 * r);
+
+  // inner radii from thickness.
+  const t = Math.max(1, Math.floor(options.thickness));
+  const irx = Math.max(1, rx - t);
+  const iry = Math.max(1, ry - t);
+
+  // styling.
+  const { backColor } = options;
+  const { borderColor } = options;
+  const { borderThickness } = options;
+
+  // acquire 2D context and gradient.
+  const ctx = this.contents._context;
+  const midAngle = a0 + (a1 - a0) / 2;
+  const gx0 = cx + Math.cos(a0) * irx;
+  const gy0 = cy + Math.sin(a0) * iry;
+  const gx1 = cx + Math.cos(midAngle) * rx;
+  const gy1 = cy + Math.sin(midAngle) * ry;
+  const grad = ctx.createLinearGradient(gx0, gy0, gx1, gy1);
+  grad.addColorStop(0, options.leftGradientColor);
+  grad.addColorStop(1, options.rightGradientColor);
+
+  // BACK: full ring.
+  ctx.save();
+  ctx.beginPath();
+  ctx.ellipse(cx, cy, rx, ry, 0, 0, Math.PI * 2, false);
+  ctx.ellipse(cx, cy, irx, iry, 0, Math.PI * 2, 0, true);
+  ctx.closePath();
+  ctx.fillStyle = backColor;
+  ctx.fill();
+  ctx.restore();
+
+  // FILL: wedge slice (donut section) if any progress.
+  if (r > 0)
+  {
+    ctx.save();
+    ctx.beginPath();
+    ctx.ellipse(cx, cy, rx, ry, 0, a0, a1, false);
+    ctx.ellipse(cx, cy, irx, iry, 0, a1, a0, true);
+    ctx.closePath();
+    ctx.fillStyle = grad;
+    ctx.fill();
+    ctx.restore();
+  }
+
+  // BORDER: outer + inner ellipses stroked to match the ring’s shape.
+  ctx.save();
+  ctx.lineWidth = borderThickness;
+  ctx.strokeStyle = borderColor;
+
+  // outer ring border.
+  ctx.beginPath();
+  ctx.ellipse(
+    cx,
+    cy,
+    rx - (borderThickness % 2
+      ? 0.5
+      : 0),
+    ry - (borderThickness % 2
+      ? 0.5
+      : 0),
+    0,
+    0,
+    Math.PI * 2,
+    false
+  );
+  ctx.stroke();
+
+  // inner ring border.
+  ctx.beginPath();
+  ctx.ellipse(
+    cx,
+    cy,
+    irx + (borderThickness % 2
+      ? 0.5
+      : 0),
+    iry + (borderThickness % 2
+      ? 0.5
+      : 0),
+    0,
+    0,
+    Math.PI * 2,
+    false
+  );
+  ctx.stroke();
+  ctx.restore();
+};
+
+/**
+ * Computes the inner rectangle to draw into by applying border/padding options.
+ * This prevents the fill from touching the border while letting each style
+ * render its own border/backdrop shape.
+ * @param {Rectangle} rect The outer rectangle passed to drawGauge.
+ * @param {WindowGaugeOptions} options The gauge options (includes border settings).
+ * @returns {Rectangle} The inner rect.
+ */
+Window_Base.prototype._computeGaugeInnerRect = function(rect, options)
+{
+  // pull padding factors.
+  const borderThickness = Math.max(1, options.borderThickness);
+  const borderGap = Math.max(0, options.borderGap);
+
+  // compute inner rect inside the padding.
+  const ix = rect.x + borderThickness + borderGap;
+  const iy = rect.y + borderThickness + borderGap;
+  const iw = Math.max(0, rect.width - ((borderThickness + borderGap) * 2));
+  const ih = Math.max(0, rect.height - ((borderThickness + borderGap) * 2));
+
+  // return the inner rect.
+  return {
+    x: ix,
+    y: iy,
+    width: iw,
+    height: ih
+  };
+};
+
+//endregion draw gauge
 //endregion Window_Base

--- a/src/plugins/_base/windows/Window_Command.js
+++ b/src/plugins/_base/windows/Window_Command.js
@@ -64,7 +64,7 @@ Window_Command.prototype.drawItem = function(index)
   const rightText = this.commandRightText(index);
 
   // grab the subtext for this command.
-  const isSubtext = this.isCommandSubtext(index)
+  const isSubtext = this.isCommandSubtext(index);
   const subtexts = this.commandSubtext(index);
 
   // grab the extra lines for this command.
@@ -112,7 +112,8 @@ Window_Command.prototype.drawItem = function(index)
       commandNameX - 36,
       faceY - 12,
       ImageManager.faceWidth,
-      ImageManager.faceHeight);
+      ImageManager.faceHeight
+    );
     commandNameX += 36;
   }
 
@@ -156,7 +157,7 @@ Window_Command.prototype.drawItem = function(index)
     this.processColorChange(this.commandRightColorIndex(index));
 
     // render the right-aligned text.
-    this.drawText(rightText, rightTextX, rightTextY, textWidth, "right");
+    this.drawText(rightText, rightTextX, rightTextY, textWidth, 'right');
 
     // bolden the text if we have subtext to make it stand out.
     this.toggleBold(false);

--- a/src/plugins/apt/core/_metadata/_annotations.js
+++ b/src/plugins/apt/core/_metadata/_annotations.js
@@ -1,0 +1,141 @@
+//region annotations
+/*:
+ * @target MZ
+ * @plugindesc
+ * [v1.0.0 APT] A plugin that grants the ability to learn by gaining points.
+ * @author JE
+ * @url https://github.com/je-can-code/rmmz-plugins
+ * @base J-Base
+ * @orderAfter J-Base
+ * @orderAfter J-ABS
+ * @orderAfter J-LevelMaster
+ * @orderAfter J-Log
+ * @orderAfter J-TextPops
+ * @help
+ * ============================================================================
+ * OVERVIEW
+ * This plugin grants the ability to learn skills by gaining points.
+ *
+ * Integrates with others of mine plugins:
+ * - J-Base; to be honest this is just required for all my plugins.
+ * - J-ABS; acquire points from enemy kills and skill executions.
+ * - J-LevelMaster; considers level difference for an AP multiplier.
+ * - J-Log; log all AP gained.
+ * - J-TextPops; display popups for AP gained.
+ *
+ * ----------------------------------------------------------------------------
+ * DETAILS
+ * This plugin lets actors learn skills by gaining AP (Aptitude Points).
+ * As actors earn AP, it flows into the currently-active sources
+ * (like Class/Weapons/Armor/States/Actor), and when a requirement is met:
+ * the skill is learned.
+ * - Only active sources on the actor receive AP. Change gear/class/state?
+ *   Active sources change too.
+ * - Multiple sources can point at the same skill; progress is tracked per
+ *   source and the moment any teaching crosses its requirement, the skill
+ *   becomes learned for the actor.
+ *
+ * ============================================================================
+ * TEACHABLES
+ * Ever want to have skills “teach themselves” while you play? Well now you
+ * can! By applying the appropriate tags across the various database locations,
+ * your actors will soak up AP from adventures and unlock those skills.
+ *
+ * TAG USAGE:
+ * - Actors
+ * - Classes
+ * - Weapons
+ * - Armor
+ * - States
+ *
+ * TAG FORMAT:
+ *  <aptitude:[SKILL_ID, REQUIRED_AP]>
+ *    Where SKILL_ID is the database id of the skill to learn,
+ *    Where REQUIRED_AP is how much AP that source needs to teach it.
+ *
+ * TAG EXAMPLES:
+ *  <aptitude:[12, 150]>
+ * This source enables learning skill of id 12 once the owner gains 150 AP.
+ * ============================================================================
+ * AP
+ * Ever want to gain AP so that you could learn all those skills that various
+ * sources teach. Well now you can! By applying the appropriate tags onto
+ * enemies, you too can gain AP when chopping up enemies.
+ *
+ * NOTE ABOUT LEVEL DIFFERENCE
+ * There is a limit by default that prevents AP from being gained when the
+ * actor level is too far above the enemy level. This is a plugin parameter
+ * for your convenience. If you set the plugin parameter to -1, the
+ * functionality will be disabled.
+ *
+ * TAG USAGE:
+ * - Enemies only.
+ *
+ * TAG FORMAT:
+ *  <ap:[AMOUNT]>
+ *    Where AMOUNT is the amount of AP to be gained.
+ *
+ * TAG EXAMPLES:
+ *  <ap:6>
+ * This enemy will yield 6 AP upon defeat.
+ *
+ * ============================================================================
+ * TIPS
+ * ----------------------------------------------------------------------------
+ * - Stack learnings: You can define the same skill on multiple sources. The UI
+ *   will aggregate per‑source progress for that skill so you can see total vs.
+ *   source contributions.
+ * - Source lifetime: Only currently active sources on the actor receive AP
+ *   (ex: changing class/equipment/states changes the active set of sources).
+ * - J-ABS synergy: Pair enemy <ap:...> rewards with your encounter balance to
+ *   tune progression alongside EXP.
+ *
+ * ============================================================================
+ * CHANGELOG:
+ * - 1.0.0
+ *    The initial release.
+ * ============================================================================
+ *
+ * @param parentConfig
+ * @text SETUP
+ *
+ * @param menu-switch
+ * @parent parentConfig
+ * @type switch
+ * @text Menu Switch ID
+ * @desc When this switch is ON, then this command is visible in the menu.
+ * @default 107
+ *
+ * @param levelConfig
+ * @text LEVEL-RELATED SETUP
+ *
+ * @param max-level-threshold
+ * @parent levelConfig
+ * @type number
+ * @text Max Level Threshold
+ * @desc The max allowed difference in level between actor and enemy to gain AP from.
+ * @min -1
+ * @default 10
+ *
+ * @command mod-ap-all
+ * @text Add/Remove AP (Party)
+ * @desc Adds or removes a designated amount of AP from all members of the current party.
+ * @arg points
+ * @type number
+ * @min -99999999
+ * @max 99999999
+ * @desc The amount of AP to modify by. Negative removes AP. Per-source never goes below 0.
+ *
+ * @command mod-ap
+ * @text Add/Remove AP
+ * @desc Adds or removes a designated amount of AP from an actor by its id.
+ * @arg actorId
+ * @type actor
+ * @desc The id of the actor to modify AP for.
+ * @arg points
+ * @type number
+ * @min -99999999
+ * @max 99999999
+ * @desc The amount of AP to modify by. Negative removes AP. Per-source never goes below 0.
+ */
+//endregion annotations

--- a/src/plugins/apt/core/_metadata/_pluginMetadata.js
+++ b/src/plugins/apt/core/_metadata/_pluginMetadata.js
@@ -1,0 +1,51 @@
+//region plugin metadata
+class JAptitude_PluginMetadata
+  extends PluginMetadata
+{
+  /**
+   * Constructor.
+   */
+  constructor(name, version)
+  {
+    super(name, version);
+  }
+
+  /**
+   *  Extends {@link #postInitialize}.<br>
+   *  Includes translation of plugin parameters.
+   */
+  postInitialize()
+  {
+    // execute original logic.
+    super.postInitialize();
+
+    // initialize this plugin from configuration.
+    this.initializeMetadata();
+  }
+
+  /**
+   * Initializes the metadata associated with this plugin.
+   */
+  initializeMetadata()
+  {
+    /**
+     * The id of a switch that represents whether or not this system is accessible in the menu.
+     * @type {number}
+     */
+    this.menuSwitchId = parseInt(this.parsedPluginParameters['menu-switch']);
+
+    /**
+     * The maximum level difference between actor and enemy that allows AP gain.
+     * @type {number}
+     */
+    this.maxLevelThreshold = parseInt(this.parsedPluginParameters['max-level-threshold']);
+
+    /**
+     * Whether or not the level threshold limit is being used.
+     * @type {boolean}
+     */
+    this.usingLevelThresholdLimit = this.maxLevelThreshold > -1;
+  }
+}
+
+//endregion plugin metadata

--- a/src/plugins/apt/core/_metadata/initialization.js
+++ b/src/plugins/apt/core/_metadata/initialization.js
@@ -1,0 +1,74 @@
+//region initialization
+/**
+ * The core where all of my extensions live: in the `J` object.
+ */
+var J = J || {};
+
+/**
+ * The plugin umbrella that governs all things related to this plugin.
+ */
+J.APT = {};
+
+/**
+ * The plugin umbrella that governs all extensions related to the parent.
+ */
+J.APT.EXT ||= {};
+
+/**
+ * The metadata associated with this plugin.
+ */
+J.APT.Metadata = new JAptitude_PluginMetadata('J-Aptitude', '1.0.0');
+
+/**
+ * A collection of all aliased methods for this plugin.
+ */
+J.APT.Aliased = {};
+J.APT.Aliased.BattleManager = new Map();
+J.APT.Aliased.Game_Action = new Map();
+J.APT.Aliased.Game_Actor = new Map();
+J.APT.Aliased.JABS_Battler = new Map();
+J.APT.Aliased.JABS_Engine = new Map();
+J.APT.Aliased.Scene_Menu = new Map();
+J.APT.Aliased.Window_MenuCommand = new Map();
+
+/**
+ * All regular expressions used by this plugin.
+ */
+J.APT.RegExp = {};
+
+/**
+ * The structure of a learnable aptitude skill.
+ *
+ * <pre>
+ * Structure:
+ *  <aptitude:[SKILL_ID, REQUIRED_AP]>
+ *
+ * Example:
+ *  <aptitude:[12, 150]>
+ *
+ * Translation:
+ *  Skill Learned: 12
+ *  Required AP  : 150
+ * </pre>
+ * @type {RegExp}
+ */
+J.APT.RegExp.AptitudeTeachable = /<aptitude:[ ]?(\[\d+,[ ]?\d+])>/gi;
+
+/**
+ * The AP reward an enemy yields on defeat.
+ *
+ * <pre>
+ * Structure:
+ *  <ap:AMOUNT>
+ *
+ * Example:
+ *  <ap:12>
+ *
+ * Translation:
+ *  AP gained: 12
+ * </pre>
+ * @type {RegExp}
+ */
+J.APT.RegExp.ApReward = /<ap: ?(\d+)>/i;
+
+//endregion initialization

--- a/src/plugins/apt/core/_metadata/pluginCommands.js
+++ b/src/plugins/apt/core/_metadata/pluginCommands.js
@@ -1,0 +1,34 @@
+//region plugin commands
+/**
+ * Plugin command for modifying AP for all actors.
+ */
+PluginManager.registerCommand(
+  J.APT.Metadata.name,
+  'mod-ap-all',
+  ({ points }) =>
+  {
+    // iterate over all members and gain the AP.
+    $gameParty.members()
+      .forEach(actor => ApManager.gainAp(actor, parseInt(points), 'plugin-command'));
+  }
+);
+
+/**
+ * Plugin command for modifying AP for a specific actor.
+ */
+PluginManager.registerCommand(
+  J.APT.Metadata.name,
+  'mod-ap',
+  ({
+    actorId,
+    points
+  }) =>
+  {
+    // grab the chosen actor.
+    const actor = $gameActors.actor(parseInt(actorId));
+
+    // gain the AP.
+    ApManager.gainAp(actor, parseInt(points), 'plugin-command');
+  }
+);
+//endregion plugin commands

--- a/src/plugins/apt/core/_models/AptitudeLearning.js
+++ b/src/plugins/apt/core/_models/AptitudeLearning.js
@@ -1,0 +1,70 @@
+//region AptitudeLearning
+/**
+ * The current state of a skill being learned.
+ * @param {number} skillId The skill id to learn.
+ * @param {number} requiredAp The required AP to achieve this learning.
+ * @param {number} currentAp The current AP towards achieving this learning.
+ * @constructor
+ */
+function AptitudeLearning(skillId, requiredAp, currentAp)
+{
+  this.initialize(skillId, requiredAp, currentAp);
+}
+
+AptitudeLearning.prototype = {};
+AptitudeLearning.prototype.constructor = AptitudeLearning;
+
+/**
+ * Initializes the learning.
+ * @param {number} skillId The skill id to learn.
+ * @param {number} requiredAp The required AP to achieve this learning.
+ * @param {number} currentAp The current AP towards achieving this learning.
+ */
+AptitudeLearning.prototype.initialize = function(skillId, requiredAp, currentAp)
+{
+  /**
+   * The id of the skill learned when achieving this learning.
+   * @type {number}
+   */
+  this.skillId = skillId;
+
+  /**
+   * The current AP towards achieving this learning.
+   * @type {number}
+   */
+  this.currentAp = currentAp;
+
+  /**
+   * The required amount of AP to achieve this learning.
+   * @type {number}
+   */
+  this.requiredAp = requiredAp;
+};
+
+/**
+ * Gains AP towards achieving this learning.
+ * @param {number} ap The amount of AP to gain.
+ */
+AptitudeLearning.prototype.gainAp = function(ap)
+{
+  this.currentAp += ap;
+};
+
+/**
+ * Sets the current AP towards achieving this learning.
+ * @param {number} ap The amount of AP to set.
+ */
+AptitudeLearning.prototype.setAp = function(ap)
+{
+  this.currentAp = ap;
+}
+
+/**
+ * Whether or not this learning is achieved.
+ * @returns {boolean} True if the learning is achieved, false otherwise.
+ */
+AptitudeLearning.prototype.isLearned = function()
+{
+  return this.currentAp >= this.requiredAp;
+};
+//endregion AptitudeLearning

--- a/src/plugins/apt/core/_models/AptitudeProgress.js
+++ b/src/plugins/apt/core/_models/AptitudeProgress.js
@@ -1,0 +1,94 @@
+//region AptitudeProgress
+/**
+ * The structure of an object and its potential {@link AptitudeLearning}s.
+ * @param {string} key "type:id" unique key of the aptitude being learned.
+ * @param {Record<number, AptitudeLearning>} aptitudeLearnings The current state of learnings.
+ * @constructor
+ */
+function AptitudeProgress(key, aptitudeLearnings)
+{
+  this.initialize(key, aptitudeLearnings);
+}
+
+AptitudeProgress.prototype = {};
+AptitudeProgress.prototype.constructor = AptitudeProgress;
+
+/**
+ * Initializes the learning.
+ * @param {string} key "type:id" unique key of the aptitude being learned.
+ * @param {Record<number, AptitudeLearning>} [aptitudeLearnings] The current state of learnings; defaults to nothing.
+ */
+AptitudeProgress.prototype.initialize = function(key, aptitudeLearnings = {})
+{
+  /**
+   * The "type:id" unique key of the aptitude being learned.
+   * @type {string}
+   */
+  this.key = key;
+
+  /**
+   * The current state of learnings.
+   * @type {Record<number, AptitudeLearning>}
+   */
+  this._learnings = aptitudeLearnings;
+};
+
+/**
+ * Gets the current progress for a skill.
+ * @param {number} skillId The skill id to learn.
+ * @returns {AptitudeLearning|null} The current learning for the skill, or null if it doesn't exist.
+ */
+AptitudeProgress.prototype.learningBySkillId = function(skillId)
+{
+  // get the current progress for the skill, or politely coalesce to null if it doesn't exist.
+  return this._learnings[skillId] ?? null;
+};
+
+/**
+ * Determines whether or not this aptitude progress has a learning for the given skill.
+ * @param {number} skillId The skill id to check for.
+ * @returns {boolean} True if the skill exists on this progress, false otherwise.
+ */
+AptitudeProgress.prototype.hasLearning = function(skillId)
+{
+  return this._learnings[skillId] !== undefined;
+};
+
+/**
+ * Adds or updates a learning for this aptitude progress.
+ * @param {number} skillId The skill id to learn.
+ * @param {number} [amount] The current amount of AP for the learning; defaults to 0.
+ */
+AptitudeProgress.prototype.setLearning = function(skillId, amount = 0)
+{
+  // check if we have the learning already.
+  if (this.hasLearning(skillId) === false) return;
+
+  // we do, so just grab what exists.
+  const learning = this.learningBySkillId(skillId);
+
+  // update the AP for it.
+  learning.setAp(amount);
+};
+
+/**
+ * Creates a new learning for this aptitude progress.
+ * @param {number} skillId The id of the skill for the learning.
+ * @param {number} requiredAp The amount of AP required for the learning.
+ * @param {number} [amount] The current amount of AP for the learning; defaults to 0.
+ */
+AptitudeProgress.prototype.initializeLearning = function(skillId, requiredAp, amount = 0)
+{
+  // we don't have it, so create a new one with this amount.
+  this._learnings[skillId] = new AptitudeLearning(skillId, requiredAp, amount);
+};
+
+/**
+ * Gets the current state of learnings for this aptitude progress tracker.
+ * @returns {Record<number, AptitudeLearning>}
+ */
+AptitudeProgress.prototype.learnings = function()
+{
+  return this._learnings;
+};
+//endregion AptitudeProgress

--- a/src/plugins/apt/core/_models/AptitudeSkill.js
+++ b/src/plugins/apt/core/_models/AptitudeSkill.js
@@ -1,0 +1,76 @@
+//region AptitudeSkill
+/**
+ * The structure of an object and the skill that was learned.
+ * @param {skillId} skillId The skill id that was learned.
+ * @param {boolean} [learned] Whether or not the skill was learned; defaults to false.
+ * @constructor
+ */
+function AptitudeSkill(skillId, learned = false)
+{
+  this.initialize(skillId, learned);
+}
+
+AptitudeSkill.prototype = {};
+AptitudeSkill.prototype.constructor = AptitudeSkill;
+
+/**
+ * Initializes the learning.
+ * @param {skillId} skillId The skill id that was learned.
+ * @param {boolean} [learned] Whether or not the skill was learned; defaults to false.
+ */
+AptitudeSkill.prototype.initialize = function(skillId, learned = false)
+{
+  /**
+   * The skill id that was learned.
+   * @type {number}
+   */
+  this.skillId = skillId;
+
+  /**
+   * Whether or not this aptitude skill is learned.
+   * @type {boolean}
+   */
+  this.learned = learned;
+
+  /**
+   * The "type:id" key of the aptitude that this skill was learned from.
+   * @type {string}
+   */
+  this._learnedFrom = String.empty;
+};
+
+/**
+ * Learns the skill.
+ * @param {AptitudeProgress} learnedFrom The aptitude from which this skill was learned.
+ */
+AptitudeSkill.prototype.learnSkill = function(learnedFrom)
+{
+  // flag the aptitude as learned.
+  this.learned = true;
+
+  // identify what aptitude it was learned from.
+  this._learnedFrom = learnedFrom.key;
+};
+
+/**
+ * Forgets the skill.
+ */
+AptitudeSkill.prototype.forgetSkill = function()
+{
+  // flag the aptitude as not learned.
+  this.learned = false;
+
+  // clear the aptitude that it was learned from.
+  this._learnedFrom = String.empty;
+};
+
+/**
+ * Gets the key of the aptitude that this skill was learned from.
+ * @returns {string}
+ */
+AptitudeSkill.prototype.learnedFrom = function()
+{
+  // TODO: map this to something meaningful for output.
+  return this._learnedFrom;
+};
+//endregion AptitudeSkill

--- a/src/plugins/apt/core/_models/AptitudeSkillAggregate.js
+++ b/src/plugins/apt/core/_models/AptitudeSkillAggregate.js
@@ -1,0 +1,181 @@
+// #region AptitudeSkillAggregate
+
+/**
+ * Represents one skill learned via aptitudes across all sources on an actor.
+ * Holds per‑source progress and exposes convenience accessors for list/details UIs.
+ */
+class AptitudeSkillAggregate
+{
+  /**
+   * The skill id.
+   * @type {number}
+   */
+  #skillId = 0;
+
+  /**
+   * The database skill.
+   * @type {RPG_Skill}
+   */
+  #skill = null;
+
+  /**
+   * The sources that this skill reside in.
+   * @type {AptitudeSkillSourceProgress[]}
+   */
+  #sources = [];
+
+  /**
+   * @param {number} skillId The skill id.
+   * @param {RPG_Skill} skillData The database skill for name/icon/desc.
+   */
+  constructor(skillId, skillData)
+  {
+    // store the skill id.
+    this.#skillId = skillId;
+
+    // store the database skill reference.
+    this.#skill = skillData;
+
+    // initialize the per‑source rows.
+    this.#sources = [];
+  }
+
+  /**
+   * Adds one per‑source progress row to this aggregate.
+   * @param {AptitudeSkillSourceProgress} src The per‑source row.
+   */
+  addSource(src)
+  {
+    // push the source row into this aggregate.
+    this.sources()
+      .push(src);
+  }
+
+  /**
+   * The skill id for this aggregate.
+   * @returns {number}
+   */
+  skillId()
+  {
+    return this.#skillId;
+  }
+
+  /**
+   * The database object for the skill.
+   * @returns {RPG_Skill}
+   */
+  skill()
+  {
+    return this.#skill;
+  }
+
+  /**
+   * The name of the skill.
+   * @returns {string}
+   */
+  name()
+  {
+    return this.#skill.name;
+  }
+
+  /**
+   * The icon index of the skill.
+   * @returns {number}
+   */
+  iconIndex()
+  {
+    return this.#skill.iconIndex;
+  }
+
+  /**
+   * The sources that this skill resides in.
+   * @returns {AptitudeSkillSourceProgress[]}
+   */
+  sources()
+  {
+    return this.#sources;
+  }
+
+  /**
+   * Whether or not this skill has been learned in any source.
+   * @returns {boolean}
+   */
+  learnedAny()
+  {
+    return this.sources()
+      .some(source => source.learned() === true);
+  }
+
+  /**
+   * Finds the source with the minimum remaining AP among not‑yet‑learned sources.
+   * If all sources are learned, returns the first source for display context.
+   * @returns {AptitudeSkillSourceProgress|null}
+   */
+  cheapestSource()
+  {
+    // start with no cheapest found.
+    let cheapest = null;
+
+    const sources = this.sources();
+
+    // iterate all sources.
+    sources.forEach(s =>
+    {
+      // skip learned sources when searching cheapest remaining.
+      if (s.learned() === true)
+      {
+        return;
+      }
+
+      // compute the remaining AP for this source.
+      const remaining = s.remainingAp();
+
+      // select if first or cheaper than previous.
+      if (cheapest === null || remaining < cheapest.remainingAp())
+      {
+        cheapest = s;
+      }
+    });
+
+    // if all sources were learned but we have sources, return the first.
+    if (cheapest === null && sources.length > 0)
+    {
+      return sources[0];
+    }
+
+    // return the cheapest or null.
+    return cheapest;
+  }
+
+  /**
+   * Convenience: current AP of the cheapest path for list UI.
+   * @returns {number}
+   */
+  currentAp()
+  {
+    // find the cheapest source.
+    const cheapest = this.cheapestSource();
+
+    // return its current AP, or 0 if none.
+    return cheapest
+      ? cheapest.currentAp()
+      : 0;
+  }
+
+  /**
+   * Convenience: required AP of the cheapest path for list UI.
+   * @returns {number}
+   */
+  requiredAp()
+  {
+    // find the cheapest source.
+    const cheapest = this.cheapestSource();
+
+    // return its required AP, or 1 if none to prevent div‑by‑zero gauges.
+    return cheapest
+      ? cheapest.requiredAp()
+      : 1;
+  }
+}
+
+// #endregion AptitudeSkillAggregate

--- a/src/plugins/apt/core/_models/AptitudeSkillSourceProgress.js
+++ b/src/plugins/apt/core/_models/AptitudeSkillSourceProgress.js
@@ -1,0 +1,118 @@
+//region AptitudeSkillSourceProgress
+/**
+ * Represents per‑source progress for learning a skill via aptitudes.
+ */
+class AptitudeSkillSourceProgress
+{
+  /**
+   * The source key (e.g., equipment/state/skill source id string).
+   * @type {string}
+   */
+  #sourceKey = String.empty;
+
+  /**
+   * The skill id this source contributes AP toward.
+   * @type {number}
+   */
+  #skillId = 0;
+
+  /**
+   * The current AP accumulated toward the skill.
+   * @type {number}
+   */
+  #currentAp = 0;
+
+  /**
+   * The total AP required to learn the skill.
+   * @type {number}
+   */
+  #requiredAp = 0;
+
+  /**
+   * Whether or not the skill has been learned from this source.
+   * @type {boolean}
+   */
+  #learned = false;
+
+  /**
+   * Constructor.
+   * @param {string} sourceKey - The source key (e.g., equipment/state/skill source id string).
+   * @param {number} skillId - The skill id this source contributes AP toward.
+   * @param {number} currentAp - The current AP accumulated for this source toward the skill.
+   * @param {number} requiredAp - The total AP required to learn from this source.
+   * @param {boolean} learned - Whether this source already granted the skill (complete).
+   */
+  constructor(sourceKey, skillId, currentAp, requiredAp, learned)
+  {
+    // store the source key.
+    this.#sourceKey = sourceKey;
+
+    this.#skillId = skillId;
+
+    // store current AP.
+    this.#currentAp = currentAp;
+
+    // store required AP.
+    this.#requiredAp = requiredAp;
+
+    // store learned flag.
+    this.#learned = learned === true;
+  }
+
+  /**
+   * The key of the source.
+   * @returns {string}
+   */
+  sourceKey()
+  {
+    return this.#sourceKey;
+  }
+
+  /**
+   * The skill id this source contributes AP toward.
+   * @returns {number}
+   */
+  skillId()
+  {
+    return this.#skillId;
+  }
+
+  /**
+   * The current AP accumulated toward the skill.
+   * @returns {number}
+   */
+  currentAp()
+  {
+    return this.#currentAp;
+  }
+
+  /**
+   * The total AP required to learn the skill.
+   * @returns {number}
+   */
+  requiredAp()
+  {
+    return this.#requiredAp;
+  }
+
+  /**
+   * Whether or not the skill has been learned from this source.
+   * @returns {boolean}
+   */
+  learned()
+  {
+    return this.#learned;
+  }
+
+  /**
+   * The remaining AP needed to learn the skill.
+   * @returns {number}
+   */
+  remainingAp()
+  {
+    // compute how much is left to reach required AP.
+    return Math.max(0, this.requiredAp() - this.currentAp());
+  }
+}
+
+//endregion AptitudeSkillSourceProgress

--- a/src/plugins/apt/core/_models/AptitudeTeachable.js
+++ b/src/plugins/apt/core/_models/AptitudeTeachable.js
@@ -1,0 +1,35 @@
+//region AptitudeTeachable
+/**
+ * The runtime shape of a learnable skill and its requirements.
+ * @param {number} skillId The skill id to learn.
+ * @param {number} requiredAp The required AP to learn the skill.
+ * @constructor
+ */
+function AptitudeTeachable(skillId, requiredAp)
+{
+  this.initialize(skillId, requiredAp);
+}
+
+AptitudeTeachable.prototype = {};
+AptitudeTeachable.prototype.constructor = AptitudeTeachable;
+
+/**
+ * Initializes the learning.
+ * @param {number} skillId The skill id to learn.
+ * @param {number} requiredAp The required AP to learn the skill.
+ */
+AptitudeTeachable.prototype.initialize = function(skillId, requiredAp)
+{
+  /**
+   * The id of the skill to learn.
+   * @type {number}
+   */
+  this.skillId = skillId;
+
+  /**
+   * The required AP to learn the skill.
+   * @type {number}
+   */
+  this.requiredAp = requiredAp;
+};
+//endregion AptitudeTeachable

--- a/src/plugins/apt/core/_models/JABS_Battler.js
+++ b/src/plugins/apt/core/_models/JABS_Battler.js
@@ -1,0 +1,127 @@
+//region JABS_Battler
+if (J.ABS)
+{
+  /**
+   * Extends {@link #gainBasicRewards}.<br/>
+   * Also includes AP when defeating an enemy.
+   * @param {Game_Battler} enemy The target battler that was defeated.
+   * @param {JABS_Battler} actor The map battler that defeated the target.
+   */
+  J.APT.Aliased.JABS_Engine.set('gainBasicRewards', JABS_Engine.prototype.gainBasicRewards);
+  JABS_Engine.prototype.gainBasicRewards = function(enemy, actor)
+  {
+    // perform original logic.
+    J.APT.Aliased.JABS_Engine.get('gainBasicRewards')
+      .call(this, enemy, actor);
+
+    // grab the AP amount from the enemy.
+    const ap = enemy.apPoints();
+
+    // if there is no AP, do nothing.
+    if (ap === 0) return;
+
+    // gain the AP.
+    this.gainAptitudeReward(ap, actor, enemy);
+  };
+
+  /**
+   * Gains AP from battle rewards.
+   * @param {number} ap The AP to gain.
+   * @param {JABS_Battler} actor The map battler that defeated the target.
+   * @param {JABS_Battler} enemy The map battler that was defeated.
+   */
+  JABS_Engine.prototype.gainAptitudeReward = function(ap, actor, enemy)
+  {
+    // don't do anything if the enemy didn't grant any sdp points.
+    if (ap === 0) return;
+
+    // Award AP to the full party; per-actor distribution happens in ApManager.
+    $gameParty.members()
+      .filter(member => this.canGainAptitudeReward(member, enemy))
+      .forEach(member =>
+      {
+        // identify the JABS battler that owns this member.
+        const jabsBattler = JABS_AiManager.getBattlerByUuid(member.getUuid());
+
+        // if somehow we have no battler here, then do nothing.
+        if (!jabsBattler) return;
+
+        // apply level scaling multiplier if applicable.
+        const levelMultiplier = this.getRewardScalingMultiplier(enemy, jabsBattler);
+
+        // round in favor of the player.
+        const actualAp = Math.ceil(ap * levelMultiplier);
+
+        // gain the applicable points.
+        ApManager.gainAp(member, actualAp, 'on-kill');
+
+        // generate the popup.
+        this.generatePopAp(actualAp, jabsBattler.getCharacter());
+
+        // create the log entry.
+        this.createLogAp(actualAp, jabsBattler);
+      });
+  };
+
+  /**
+   * Determines whether or not the actor can gain AP from the enemy.
+   * @param {Game_Actor} actor The map battler that defeated the target.
+   * @param {Game_Enemy} enemy The map battler that was defeated.
+   * @returns {boolean} True if the actor can gain AP, false otherwise.
+   */
+  JABS_Engine.prototype.canGainAptitudeReward = function(actor, enemy)
+  {
+    // check if we are using the level plugin.
+    if (J.LEVEL && J.LEVEL.Metadata.enabled && J.APT.Metadata.usingLevelThresholdLimit === true)
+    {
+      // identify the level difference between the battlers.
+      const levelDifference = actor.level - enemy.level;
+
+      // if the level difference was too great, then no AP is gained.
+      if (levelDifference > J.APT.Metadata.maxLevelThreshold) return false;
+    }
+
+    // gain that AP!
+    return true;
+  };
+
+  /**
+   * Generates a popup.
+   * @param {number} apPoints The amount to display.
+   * @param {Game_Character} character The character to show the popup on.
+   */
+  JABS_Engine.prototype.generatePopAp = function(apPoints, character)
+  {
+    // if we are not using popups, then don't do this.
+    if (!J.POPUPS) return;
+
+    // generate the textpop.
+    const apPop = new TextPopBuilder(apPoints)
+      .isAptitude()
+      .build();
+
+    // add the pop to the caster's tracking.
+    character.addTextPop(apPop);
+    character.requestTextPop();
+  };
+
+  /**
+   * Creates the log entry.
+   * @param {number} apPoints The AP gained.
+   * @param {JABS_Battler} battler The battler gaining the AP.
+   */
+  JABS_Engine.prototype.createLogAp = function(apPoints, battler)
+  {
+    // if we are not logging, then don't do this.
+    if (!J.LOG) return;
+
+    // build the log entry.
+    const apLog = new ActionLogBuilder()
+      .setMessage(`\\C[16]${battler.battlerName()}\\C[0] gained \\C[29]\\*${apPoints}\\*\\C[0] AP.`)
+      .build();
+
+    // add the log to the action log manager.
+    $actionLogManager.addLog(apLog);
+  };
+}
+//endregion JABS_Battler

--- a/src/plugins/apt/core/_models/Map_TextPop.js
+++ b/src/plugins/apt/core/_models/Map_TextPop.js
@@ -1,0 +1,7 @@
+if (J.POPUPS)
+{
+  /**
+   * The popup type of "ap", for displaying AP gain pops.
+   */
+  Map_TextPop.Types.Ap = 'ap';
+}

--- a/src/plugins/apt/core/_models/TextPopBuilder.js
+++ b/src/plugins/apt/core/_models/TextPopBuilder.js
@@ -1,0 +1,27 @@
+if (J.POPUPS)
+{
+  /**
+   * Add some convenient defaults for configuring AP points popups.
+   * @returns {TextPopBuilder} The builder, for fluent chaining.
+   */
+  TextPopBuilder.prototype.isAptitude = function()
+  {
+    // set the popup type to be an AP point acquisition.
+    this.setPopupType(Map_TextPop.Types.Ap);
+
+    // set the text color to be lovely pink.
+    this.setTextColorIndex(17);
+
+    // set the icon index to the learned skill's icon.
+    this.setIconIndex(86);
+
+    // add no x variance when working with AP points.
+    this.setXVariance(48);
+
+    // add some y variance when working with AP points.
+    this.setYVariance(96);
+
+    // return the builder for fluent chaining.
+    return this;
+  };
+}

--- a/src/plugins/apt/core/database/RPG_Base.js
+++ b/src/plugins/apt/core/database/RPG_Base.js
@@ -1,0 +1,17 @@
+//region RPG_Base
+/**
+ * Gets all {@link AptitudeTeachable}s associated with this database object.
+ * @type {AptitudeTeachable[]}
+ */
+Object.defineProperty(RPG_Base.prototype, 'aptitudeTeachings', {
+  get()
+  {
+    // extract the data from the notes- should be [skillId, requiredAp].
+    const raw = RPGManager.getArraysFromNotesByRegex(this, J.APT.RegExp.AptitudeTeachable, true) ?? [];
+
+    // map all the raw data to DTOs.
+    return raw.map(([ skillId, requiredAp ]) => new AptitudeTeachable(skillId, requiredAp));
+  },
+});
+
+//endregion RPG_Base

--- a/src/plugins/apt/core/database/RPG_Enemy.js
+++ b/src/plugins/apt/core/database/RPG_Enemy.js
@@ -1,0 +1,13 @@
+//region RPG_Enemy
+/**
+ * The number of AP this enemy will yield upon defeat.
+ * @type {number}
+ */
+Object.defineProperty(RPG_Enemy.prototype, 'apPoints', {
+  get()
+  {
+    // get the AP amount from this enemy's notes.
+    return RPGManager.getNumberFromNoteByRegex(this, J.APT.RegExp.ApReward);
+  },
+});
+//endregion RPG_Enemy

--- a/src/plugins/apt/core/managers/ApManager.js
+++ b/src/plugins/apt/core/managers/ApManager.js
@@ -1,0 +1,364 @@
+//region ApManager
+class ApManager
+{
+  /**
+   * Awards AP to the given actor, distributing to all active APT sources
+   * and resolving any skill learns that cross their thresholds.
+   * @param {Game_Actor} actor The actor gaining AP.
+   * @param {number} amount The amount of AP awarded.
+   * @param {string} cause A short label describing the cause (ex: 'victory').
+   */
+  static gainAp(actor, amount, cause = 'victory')
+  {
+    // don't bother if the AP gained is zero.
+    if (this.canGainAp(actor, amount) === false) return;
+
+    // build the list of active sources for this actor.
+    const teachableSources = this.#activeTeachables(actor);
+
+    // iterate each active source to apply AP.
+    teachableSources.forEach(source =>
+    {
+      // deconstruct the source for readability.
+      const {
+        key,
+        teachables
+      } = source;
+
+      // apply the AP to this source's taught skills.
+      this.#applyApToSource(actor, key, teachables, amount, cause);
+    });
+  }
+
+  /**
+   * Determines whether the actor can gain AP.
+   * @param {Game_Actor} actor The actor to evaluate.
+   * @param {number} amount The amount of AP to check.
+   * @returns {boolean} True if the actor can gain AP, false otherwise.
+   */
+  static canGainAp(actor, amount)
+  {
+    // dead actors cannot gain AP.
+    if (actor.isDead()) return false;
+
+    // zero AP cannot be gained.
+    if (amount === 0) return false;
+
+    // gain the AP!
+    return true;
+  }
+
+  /**
+   * Derives a stable key for a source.
+   * @param {RPG_Base} source The source to derive a key for.
+   * @returns {string} The stable key.
+   */
+  static deriveKey(source)
+  {
+    return `${source.implementationType()}:${source.id}`;
+  }
+
+  /**
+   * Resolves a `sourceKey` (as produced by {@link ApManager.deriveKey}) back to the
+   * concrete RPG object currently contributing aptitude teachables for the actor.
+   *
+   * Notes:
+   * - This searches the actor’s current aptitude sources and matches by the same
+   *   `deriveKey(source)` used during AP distribution, guaranteeing a stable pair.
+   * - If the matched source is a skill, this returns the actor’s live skill entry
+   *   (`actor.skill(id)`) to mirror the behavior in `#activeTeachables`.
+   *
+   * @param {Game_Actor} actor - The actor whose sources are searched.
+   * @param {string} sourceKey - The stable key (e.g., "@base:usable:skill:17").
+   * @returns {RPG_Actor|RPG_Class|RPG_Skill|RPG_Weapon|RPG_Armor|RPG_State|null} - The found source object.
+   */
+  static resolveSourceByKey(actor, sourceKey)
+  {
+    // guard against missing inputs.
+    if (!actor) return null;
+
+    // gather all current aptitude sources from the actor.
+    const sources = actor.getAptitudeSources();
+
+    // iterate the sources to find a matching key.
+    for (let i = 0; i < sources.length; i++)
+    {
+      // grab the candidate source.
+      const candidate = sources[i];
+
+      // re-derive the stable key from this source.
+      const key = this.deriveKey(candidate);
+
+      // if the key matches, we have our source.
+      if (key === sourceKey)
+      {
+        // if this is a skill, resolve to the actor's live skill entry.
+        if (candidate.isSkill() === true)
+        {
+          // return the actor's known version of the database skill.
+          return actor.skill(candidate.id);
+        }
+
+        // otherwise, return the source as-is.
+        return candidate;
+      }
+    }
+
+    // no matching source was found.
+    return null;
+  }
+
+  /**
+   * Resolves a `sourceKey` into a database object (ignores actor state).
+   * @param {string} sourceKey
+   * @returns {RPG_Actor|RPG_Class|RPG_Skill|RPG_Weapon|RPG_Armor|RPG_State|RPG_Item|null}
+   */
+  static resolveStaticSourceByKey(sourceKey)
+  {
+    const parsed = this.parseKey(sourceKey);
+    if (!parsed || Number.isFinite(parsed.id) === false) return null;
+    const {
+      types,
+      id
+    } = parsed;
+    const terminal = types[types.length - 1];
+    switch (terminal)
+    {
+      case 'skill':
+        return $dataSkills[id] || null;
+      case 'weapon':
+        return $dataWeapons[id] || null;
+      case 'armor':
+        return $dataArmors[id] || null;
+      case 'state':
+        return $dataStates[id] || null;
+      case 'class':
+        return $dataClasses[id] || null;
+      case 'actor':
+        return $dataActors[id] || null;
+      case 'item':
+        return $dataItems[id] || null;
+      default:
+        return null;
+    }
+  }
+
+  static isSourceActive(actor, sourceKey)
+  {
+    if (!actor) return false;
+    // Build a set of current keys once per call; S is usually small.
+    const sources = actor.getAptitudeSources();
+    for (let i = 0; i < sources.length; i++)
+    {
+      const key = this.deriveKey(sources[i]);
+      if (key === sourceKey) return true;
+    }
+    return false;
+  }
+
+  /**
+   * Resolves a list of `sourceKey`s into their concrete source objects.
+   *
+   * @param {Game_Actor} actor - The actor whose sources are searched.
+   * @param {string[]} sourceKeys - The list of stable keys to resolve.
+   * @returns {(RPG_Base|null)[]} - Array of resolved sources (null where missing).
+   */
+  static resolveAllSourcesByKeys(actor, sourceKeys)
+  {
+    // coalesce an empty list if none provided.
+    const keys = Array.isArray(sourceKeys)
+      ? sourceKeys
+      : [];
+
+    // map each key through the single-key resolver.
+    const resolved = keys.map(key => this.resolveSourceByKey(actor, key));
+
+    // return the resolved list.
+    return resolved;
+  }
+
+  /**
+   * Parses a `sourceKey` produced by {@link ApManager.deriveKey}.
+   *
+   * A key looks like: "@base:traited:equip:weapon:12" or "@base:usable:skill:17".
+   * The final segment is always the numeric id; all preceding segments are the
+   * type chain assembled via `implementationType()` across the inheritance stack.
+   *
+   * @param {string} sourceKey - The stable key to parse.
+   * @returns {{ types: string[], id: number }} - The parsed components.
+   */
+  static parseKey(sourceKey)
+  {
+    // split on ':' to separate type chain and id.
+    const parts = String(sourceKey)
+      .split(':');
+
+    // if we don't have at least type+id, return a minimal shape.
+    if (parts.length < 2)
+    {
+      // provide a safe fallback.
+      return {
+        types: [],
+        id: NaN
+      };
+    }
+
+    // extract the id (final segment).
+    const idText = parts[parts.length - 1];
+
+    // parse into a number.
+    const id = Number(idText);
+
+    // everything before the id is the type chain.
+    const types = parts.slice(0, parts.length - 1);
+
+    // return the parsed structure.
+    return {
+      types,
+      id
+    };
+  }
+
+  /**
+   * Builds the list of currently active APT sources for the actor.
+   * Each source contains a stringy `key` and a {@link AptitudeTeachable[]} `teachables`.
+   * @param {Game_Actor} actor The actor to evaluate.
+   * @returns {{ key: string, teachables: AptitudeTeachable[] }[]} The active teachable sources.
+   */
+  static #activeTeachables(actor)
+  {
+    // acquire all potential sources.
+    const sources = actor.getAptitudeSources();
+
+    // draw up a set for keys to prevent dupes.
+    const foundKeys = new Set();
+
+    // all the results with teachables.
+    const results = [];
+
+    // iterate once; conditionally add entries that matter.
+    sources.forEach(source =>
+    {
+      // derive stable key like 'equip:weapon:5'.
+      const key = this.deriveKey(source);
+
+      // skip duplicate sources.
+      if (foundKeys.has(key)) return;
+
+      // this might be a skill requiring extension.
+      let trueSource = source;
+
+      // check if the source is a skill.
+      if (source.isSkill())
+      {
+        // get the full skill.
+        trueSource = actor.skill(source.id);
+      }
+
+      // grab all the teachables.
+      const teachables = trueSource.aptitudeTeachings;
+
+      // only include if there is at least one teachable.
+      if (teachables.length === 0) return;
+
+      // flag this key as found to prevent dupes.
+      foundKeys.add(key);
+
+      // record this source for downstream AP application.
+      results.push({
+        key,
+        teachables
+      });
+    });
+
+    // Return only meaningful sources.
+    return results;
+  }
+
+  /**
+   * Applies AP to all relevant skill tracks for a single source, then resolves learns.
+   * @param {Game_Actor} actor The actor gaining AP.
+   * @param {string} sourceKey The stable key for this source.
+   * @param {AptitudeTeachable[]} teachables The skills this source teaches.
+   * @param {number} amount The AP awarded for this tick.
+   * @param {string} cause The cause string for debugging/toasts.
+   */
+  static #applyApToSource(actor, sourceKey, teachables, amount, cause)
+  {
+    // iterate each teachable to add progress and check thresholds.
+    teachables.forEach(teachable =>
+    {
+      // destructure the teachable for readability.
+      const {
+        skillId,
+        requiredAp
+      } = teachable;
+
+      // skip if already learned permanently.
+      if (actor.hasLearnedAptitudeSkill(skillId)) return;
+
+      // validate the progress exists on the actor.
+      if (actor.hasAptitudeProgress(sourceKey) === false)
+      {
+        // initialize the progress for this source.
+        actor.initializeAptitudeProgress(sourceKey, skillId, requiredAp, 0);
+      }
+
+      // Get current progress for this skill from this source.
+      const aptitudeProgress = actor.getAptitudeProgress(sourceKey);
+
+      // validate the learning exists on the progress.
+      if (aptitudeProgress.hasLearning(skillId) === false)
+      {
+        // initialize the learning.
+        aptitudeProgress.initializeLearning(skillId, requiredAp, 0);
+      }
+
+      // grab the learning from the progress.
+      const aptitudeLearning = aptitudeProgress.learningBySkillId(skillId);
+
+      // the previous amount of AP acquired.
+      const before = aptitudeLearning.currentAp;
+
+      // Calculate updated progress.
+      const unclamped = before + amount;
+      const after = Math.max(0, Math.min(unclamped, requiredAp));
+
+      // Persist the updated progress.
+      actor.setAptitudeProgress(sourceKey, skillId, after);
+
+      // Check if the threshold was crossed this tick.
+      if (aptitudeLearning.isLearned())
+      {
+        // Resolve the learn and emit feedback.
+        this.#resolveLearn(actor, sourceKey, skillId, cause);
+      }
+    });
+  }
+
+  /**
+   * Resolves learning the skill permanently and emits any feedback.
+   * @param {Game_Actor} actor The actor learning a skill.
+   * @param {string} sourceKey The source that triggered the learn.
+   * @param {number} skillId The id of the learned skill.
+   * @param {string} cause A short label describing why this occurred.
+   */
+  // eslint-disable-next-line no-unused-vars
+  static #resolveLearn(actor, sourceKey, skillId, cause)
+  {
+    // Mark the skill as learned in the actor's APT data.
+    actor.learnAptitudeSkill(skillId, sourceKey);
+
+    // Learn it in the engine if not already known.
+    if (actor.isLearnedSkill(skillId) === false)
+    {
+      // Add the skill to the actor's known skills.
+      actor.learnSkill(skillId);
+    }
+
+    // Emit a toast or other UI feedback via your popups integration (hook later).
+    // Example idea (pseudo): J.POPUPS.pushLearnedSkill(actor, skillId, sourceKey, cause);
+  }
+}
+
+//endregion ApManager

--- a/src/plugins/apt/core/managers/BattleManager.js
+++ b/src/plugins/apt/core/managers/BattleManager.js
@@ -1,0 +1,83 @@
+//region BattleManager
+/**
+ * Extends {@link #makeRewards}.<br/>
+ * Also includes the aptitude AP earned.
+ */
+J.APT.Aliased.BattleManager.set('makeRewards', BattleManager.makeRewards);
+BattleManager.makeRewards = function()
+{
+  // Perform original logic.
+  J.APT.Aliased.BattleManager.get('makeRewards')
+    .call(this);
+
+  // Extend the rewards to include AP.
+  this._rewards = {
+    ...this._rewards,
+    aptitudeAp: $gameTroop.aptitudeApTotal(),
+  };
+};
+
+/**
+ * Extends {@link #gainRewards}.<br/>
+ * Also awards the aptitude AP to party members via ApManager.
+ */
+J.APT.Aliased.BattleManager.set('gainRewards', BattleManager.gainRewards);
+BattleManager.gainRewards = function()
+{
+  // Perform original logic.
+  J.APT.Aliased.BattleManager.get('gainRewards')
+    .call(this);
+
+  // Also gain the APT AP rewards.
+  this.gainAptitudeApRewards();
+};
+
+/**
+ * Performs the AP award for all members of the party after battle.
+ */
+BattleManager.gainAptitudeApRewards = function()
+{
+  // Extract the AP that was earned.
+  const { aptitudeAp } = this._rewards;
+
+  // If there was no AP, then there is nothing to do.
+  if (!aptitudeAp) return;
+
+  // Iterate over each current party member and award AP.
+  $gameParty.members()
+    .forEach(actor => ApManager.gainAp(actor, aptitudeAp, 'victory'));
+};
+
+/**
+ * Extends {@link #displayRewards}.<br/>
+ * Also displays the AP victory text.
+ */
+J.APT.Aliased.BattleManager.set('displayRewards', BattleManager.displayRewards);
+BattleManager.displayRewards = function()
+{
+  // Also display AP rewards first.
+  this.displayAptitudeAp();
+
+  // Perform original logic.
+  J.APT.Aliased.BattleManager.get('displayRewards')
+    .call(this);
+};
+
+/**
+ * Displays the AP victory text in the victory log.
+ */
+BattleManager.displayAptitudeAp = function()
+{
+  // Extract the AP that was earned.
+  const { aptitudeAp } = this._rewards;
+
+  // If no AP was earned, do not display anything.
+  if (!aptitudeAp) return;
+
+  // Define the message to add (tune to taste or i18n).
+  const text = `\\. ${aptitudeAp} AP gained`;
+
+  // Add it to the victory log.
+  $gameMessage.add(text);
+};
+//endregion BattleManager

--- a/src/plugins/apt/core/objects/Game_Actor.js
+++ b/src/plugins/apt/core/objects/Game_Actor.js
@@ -1,0 +1,312 @@
+//region Game_Actor
+/**
+ * Extends {@link #initMembers}.<br/>
+ * Also initializes aptitude members.
+ */
+J.APT.Aliased.Game_Actor.set('initMembers', Game_Actor.prototype.initMembers);
+Game_Actor.prototype.initMembers = function()
+{
+  // perform original logic.
+  J.APT.Aliased.Game_Actor.get('initMembers')
+    .call(this);
+
+  // also initialize aptitude members.
+  this.initAptitudeMembers();
+};
+
+/**
+ * Initializes the aptitude members.
+ */
+Game_Actor.prototype.initAptitudeMembers = function()
+{
+  /**
+   * The shared root namespace for all of J's plugin data.
+   */
+  this._j ||= {};
+
+  /**
+   * A grouping of all properties associated with this plugin.
+   */
+  this._j._aptitude ||= {};
+
+  /**
+   * A collection of all aptitudes that are presently being learned.
+   * @type {Record<string, AptitudeProgress>}
+   */
+  this._j._aptitude._progress = {};
+
+  /**
+   * The aptitude skills for this actor.
+   * @type {Record<number, AptitudeSkill>}
+   */
+  this._j._aptitude._learned = {};
+};
+
+/**
+ * Gets all aptitude progress for this actor.
+ * @returns {Record<string, AptitudeProgress>}
+ */
+Game_Actor.prototype.getAllAptitudeProgresses = function()
+{
+  return this._j._aptitude._progress;
+};
+
+/**
+ * Gets all learned aptitude skills for this actor.
+ * @returns {Record<number, AptitudeSkill>}
+ */
+Game_Actor.prototype.getAllAptitudeSkillsLearned = function()
+{
+  return this._j._aptitude._learned;
+};
+
+/**
+ * Builds per‑skill aptitude aggregates across all current sources on this actor.
+ * Each aggregate contains the database skill and all per‑source progress rows.
+ * @returns {AptitudeSkillAggregate[]} The list of aggregates, one per skill id.
+ */
+Game_Actor.prototype.getAptitudeSkillAggregates = function()
+{
+  // acquire all aptitude progresses keyed by source.
+  const progresses = this.getAllAptitudeProgresses();
+
+  // build index keyed by skillId.
+  /** @type {{ [skillId: string]: AptitudeSkillAggregate }} */
+  const perSkill = {};
+
+  // iterate each source → progress.
+  Object.entries(progresses)
+    .forEach(([ sourceKey, progress ]) =>
+    {
+      // iterate each learning under this progress.
+      Object.entries(progress.learnings())
+        .forEach(([ skillId, learning ]) =>
+        {
+          // create the aggregate if not present.
+          if (!perSkill[skillId])
+          {
+            // retrieve the database skill for name/icon/desc.
+            const skillData = this.skill(skillId);
+
+            // initialize the aggregate bucket.
+            perSkill[skillId] = new AptitudeSkillAggregate(skillId, skillData);
+          }
+
+          // build the per‑source row for this skill (now includes skillId).
+          const row = new AptitudeSkillSourceProgress(
+            sourceKey,
+            skillId,
+            learning.currentAp,
+            learning.requiredAp,
+            learning.isLearned()
+          );
+
+          // add this source row into the aggregate.
+          perSkill[skillId].addSource(row);
+        });
+    });
+
+  // return the aggregates as an array in numeric skillId order by default.
+  return Object.values(perSkill)
+    .sort((a, b) => a.skillId() - b.skillId());
+};
+
+/**
+ * Gets the aptitude progress for the given key.
+ * @param {string} key The key to get the progress for.
+ * @returns {AptitudeProgress|null} The aptitude progress for the given key.
+ */
+Game_Actor.prototype.getAptitudeProgress = function(key)
+{
+  // get the progress, or coalesce politely to null if it doesn't exist.
+  return this._j._aptitude._progress[key] ?? null;
+};
+
+/**
+ * Determines whether or not the actor has a progress for the given key.
+ * @param {string} key The key to check for progress.
+ * @returns {boolean} True if the actor has progress for the key, false otherwise.
+ */
+Game_Actor.prototype.hasAptitudeProgress = function(key)
+{
+  return this._j._aptitude._progress[key] !== undefined;
+};
+
+/**
+ * Sets the aptitude progress for the given key, skill id, and current AP.
+ * @param {string} key The key to set the progress for.
+ * @param {number} skillId The skill id to learn.
+ * @param {number} [currentAp] The current AP for the learning; defaults to 0.
+ */
+Game_Actor.prototype.setAptitudeProgress = function(key, skillId, currentAp = 0)
+{
+  // check if the progress exists.
+  if (this.hasAptitudeProgress(key) === false) return;
+
+  // grab the progress of the key.
+  const progress = this.getAptitudeProgress(key);
+
+  // update the progress with the new learning.
+  progress.setLearning(skillId, currentAp);
+};
+
+/**
+ * Initializes the aptitude progress for the given key, skill id, and current AP.
+ * @param {string} key The key to create the progress for.
+ * @param {number} skillId The skill id to learn.
+ * @param {number} requiredAp The amount of AP required for the learning.
+ * @param {number} currentAp The current AP for the learning.
+ */
+Game_Actor.prototype.initializeAptitudeProgress = function(key, skillId, requiredAp, currentAp = 0)
+{
+  // we don't have one, so create a new progress.
+  const newProgress = this.createAptitudeProgress(key, skillId, requiredAp, currentAp);
+
+  // update the mapping with the new progress.
+  this._j._aptitude._progress[key] = newProgress;
+};
+
+/**
+ * Creates a new aptitude progress for the given key and skill id.
+ * @param {string} key The key to create the progress for.
+ * @param {number} skillId The skill id to learn.
+ * @param {number} requiredAp The amount of AP required for the learning.
+ * @param {number} initialAp The initial AP to set for the learning.
+ * @returns {AptitudeProgress} The created aptitude progress.
+ */
+Game_Actor.prototype.createAptitudeProgress = function(key, skillId, requiredAp, initialAp)
+{
+  // we don't have one, so create a new progress.
+  const newProgress = new AptitudeProgress(key);
+
+  // add the new learning to this progress with the initial AP.
+  newProgress.setLearning(skillId, requiredAp, initialAp);
+
+  // return the built aptitude progress.
+  return newProgress;
+};
+
+/**
+ * Gets the aptitude learning for the given key and skill id.
+ * @param {string} key The key to get the learning for.
+ * @param {number} skillId The skill id to learn.
+ * @returns {AptitudeLearning|null} The aptitude learning for the given key and skill id, or null if it doesn't exist.
+ */
+Game_Actor.prototype.getAptitudeLearning = function(key, skillId)
+{
+  // check if we have an aptitude progress for the key.
+  if (this.hasAptitudeProgress(key) === false) return null;
+
+  // grab the progress of the key.
+  const progress = this.getAptitudeProgress(key);
+
+  // if its null, then the key didn't map to anything.
+  if (progress.hasLearning(skillId) === false) return null;
+
+  // return the learning.
+  return progress.learningBySkillId(skillId);
+};
+
+/**
+ * Gets all aptitude sources for this actor.
+ * This is typed as {@link RPG_Base}, but can yield many of its subclasses.
+ * @returns {(RPG_Actor|RPG_Class|RPG_EquipItem|RPG_Weapon|RPG_Armor|RPG_Skill|RPG_State)[]}
+ */
+Game_Actor.prototype.getAptitudeSources = function()
+{
+  // get literally everything.
+  return this.getAllNotes()
+    // exclude skills since we are learning skills.
+    .filter(obj => obj.isSkill() === false);
+};
+
+/**
+ * Gets whether or not this actor has the aptitude skill registered.
+ * @param {number} skillId The skill id to check.
+ * @returns {boolean} True if the actor has the aptitude skill registered, false otherwise.
+ */
+Game_Actor.prototype.hasAptitudeSkill = function(skillId)
+{
+  return this._j._aptitude._learned[skillId] !== undefined;
+};
+
+/**
+ * Gets the aptitude skill for the given skill id.
+ * @param {number} skillId The skill id to check.
+ * @returns {AptitudeSkill|null} The aptitude skill for the given skill id, or null if it doesn't exist.
+ */
+Game_Actor.prototype.getAptitudeSkill = function(skillId)
+{
+  return this._j._aptitude._learned[skillId];
+};
+
+/**
+ * Sets the aptitude skill for the given skill id.
+ * @param {number} skillId The skill id to set.
+ * @param {AptitudeSkill} aptitudeSkill The aptitude skill to set.
+ */
+Game_Actor.prototype.setAptitudeSkill = function(skillId, aptitudeSkill)
+{
+  // set the aptitude.
+  this._j._aptitude._learned[skillId] = aptitudeSkill;
+};
+
+/**
+ * Gets whether or not this actor has learned the given skill from an aptitude.
+ * @param {number} skillId The skill id to check.
+ * @returns {boolean} True if the actor has learned the skill, false otherwise.
+ */
+Game_Actor.prototype.hasLearnedAptitudeSkill = function(skillId)
+{
+  // if we don't have the aptitude skill, then we can't possibly have learned it.
+  if (this.hasAptitudeSkill(skillId) === false) return false;
+
+  // grab the aptitude skill.
+  const aptitudeSkill = this.getAptitudeSkill(skillId);
+
+  // return whether or not the skill is learned.
+  return aptitudeSkill.learned === true;
+};
+
+/**
+ * Marks the given skill as learned from an aptitude.
+ * @param {number} skillId The skill id to mark as learned.
+ * @param {string} sourceKey The source key for the aptitude.
+ */
+Game_Actor.prototype.learnAptitudeSkill = function(skillId, sourceKey)
+{
+  // don't process the learning if we already learned it.
+  if (this.hasLearnedAptitudeSkill(skillId)) return;
+
+  // check if we're missing the aptitude skill.
+  if (this.hasAptitudeSkill(skillId) === false)
+  {
+    // create a new aptitude skill.
+    const newAptitudeSkill = this.createAptitudeSkill(skillId);
+
+    // set the aptitude skill.
+    this.setAptitudeSkill(skillId, newAptitudeSkill);
+  }
+
+  // grab the aptitude skill.
+  const aptitudeSkill = this.getAptitudeSkill(skillId);
+
+  // grab the progress of the source key.
+  const aptitudeProgress = this.getAptitudeProgress(sourceKey);
+
+  // stamp the skill as learned with the given progress.
+  aptitudeSkill.learnSkill(aptitudeProgress);
+};
+
+/**
+ * Creates a new aptitude skill for the given skill id.
+ * @param {number} skillId The skill id to create the skill for.
+ * @param {boolean} [isLearned] Whether or not the skill is already learned; defaults to false.
+ * @returns {AptitudeSkill} The created aptitude skill.
+ */
+Game_Actor.prototype.createAptitudeSkill = function(skillId, isLearned = false)
+{
+  // generate the new aptitude skill.
+  return new AptitudeSkill(skillId, isLearned);
+};
+//endregion Game_Actor

--- a/src/plugins/apt/core/objects/Game_Battler.js
+++ b/src/plugins/apt/core/objects/Game_Battler.js
@@ -1,0 +1,11 @@
+//region Game_Battler
+/**
+ * Gets the AP points this battler yields upon defeat..
+ * @returns {number}
+ */
+Game_Battler.prototype.apPoints = function()
+{
+  return this.databaseData().apPoints;
+};
+
+//endregion Game_Battler

--- a/src/plugins/apt/core/objects/Game_Troop.js
+++ b/src/plugins/apt/core/objects/Game_Troop.js
@@ -1,0 +1,18 @@
+//region Game_Troop (APT)
+/**
+ * Gets the amount of AP earned from all defeated enemies in the troop.
+ * @returns {number}
+ */
+Game_Troop.prototype.aptitudeApTotal = function()
+{
+  // Initialize the total to zero.
+  let ap = 0;
+
+  // Sum the AP from all dead enemies in this troop.
+  this.deadMembers()
+    .forEach(enemy => ap += enemy.apPoints);
+
+  // Return the summed AP.
+  return ap;
+};
+//endregion Game_Troop (APT)

--- a/src/plugins/apt/core/scenes/Scene_Aptitude.js
+++ b/src/plugins/apt/core/scenes/Scene_Aptitude.js
@@ -1,0 +1,1132 @@
+//region Scene_Aptitude
+/**
+ * The scene for viewing aptitude progress.
+ */
+class Scene_Aptitude
+  extends Scene_MenuBase
+{
+  /**
+   * Pushes this current scene onto the stack, forcing it into action.
+   */
+  static callScene()
+  {
+    SceneManager.push(this);
+  }
+
+  /**
+   * The available view modes for the aptitude windows.
+   */
+  static viewMode = {
+    /**
+     * The view mode for viewing aggregates of aptitudes.
+     */
+    AGGREGATE: 'aggregate',
+
+    /**
+     * The view mode for viewing aptitude sources.
+     */
+    SOURCE: 'source'
+  };
+
+  //region init
+  /**
+   * Extends {@link #initMembers}.<br/>
+   * Also initializes the aptitude members.
+   */
+  initMembers()
+  {
+    // perform original logic.
+    super.initMembers();
+
+    // initialize the core aptitude namespace.
+    this.initCoreMembers();
+
+    // initialize the primary members for the scene.
+    this.initPrimaryMembers();
+  }
+
+  /**
+   * Initializes the core aptitude members.
+   */
+  initCoreMembers()
+  {
+    /**
+     * The shared root namespace for all of J's plugin data.
+     */
+    this._j ||= {};
+
+    /**
+     * A grouping of all properties associated with the aptitude system.
+     */
+    this._j._aptitude = {};
+  }
+
+  /**
+   * Initializes the primary members for the scene.
+   */
+  initPrimaryMembers()
+  {
+    /**
+     * The last index tracked in the aggregate list window, per-actor.
+     * Keyed by actorId → number.
+     * @type {{[actorId:number]: number}}
+     */
+    this._j._aptitude._lastAggregateIndexByActor = {};
+
+    /**
+     * The last index tracked in the source list window, per-actor.
+     * Keyed by actorId → number.
+     * @type {{[actorId:number]: number}}
+     */
+    this._j._aptitude._lastSourceIndexByActor = {};
+
+    /**
+     * The current view mode for the aptitude windows.
+     * Toggle between "aggregate" and "source" views.
+     * @type {string}
+     */
+    this._j._aptitude._viewMode = Scene_Aptitude.viewMode.AGGREGATE;
+
+    /**
+     * The aptitude aggregates for the current actor.
+     * @type {AptitudeSkillAggregate[]}
+     */
+    this._j._aptitude._aggregates = [];
+
+    /**
+     * The aptitude sources for the current actor.
+     * @type {(RPG_Actor|RPG_Class|RPG_EquipItem|RPG_Weapon|RPG_Armor|RPG_Skill|RPG_State)[]}
+     */
+    this._j._aptitude._sources = [];
+
+    /**
+     * A grouping of all windows for this scene.
+     */
+    this._j._aptitude._windows = {};
+
+    /**
+     * The ribbon window to display the actor and their name.
+     * @type {Window_AptitudeRibbon|null}
+     */
+    this._j._aptitude._windows._ribbon = null;
+
+    /**
+     * The list window that displays the per-skill aggregates.
+     * @type {Window_AptitudeAggregateList|null}
+     */
+    this._j._aptitude._windows._aggregateList = null;
+
+    /**
+     * The list window that displays the actor's sources.
+     * @type {Window_AptitudeSourceList|null}
+     */
+    this._j._aptitude._windows._sourceList = null;
+
+    /**
+     * The details window that displays all sources and respective progress towards learning the skill.
+     * @type {Window_AptitudeAggregateDetails|null}
+     */
+    this._j._aptitude._windows._aggregateDetails = null;
+
+    /**
+     * The details window that displays what this aptitude source is teaching.
+     * @type {Window_AptitudeSourceDetails|null}
+     */
+    this._j._aptitude._windows._sourceDetails = null;
+  }
+
+  //endregion init
+
+  //region accessors
+  /**
+   * Gets the last index tracked in the aggregate list window for the current actor.
+   * @returns {number}
+   */
+  lastAggregateIndex()
+  {
+    // get the current actor id.
+    const actorId = this.actor().actorId();
+
+    // pull from the map; default to 0 if not yet set.
+    const map = this._j._aptitude._lastAggregateIndexByActor;
+    if (map[actorId] === undefined)
+    {
+      map[actorId] = 0;
+    }
+
+    // return the remembered index.
+    return map[actorId];
+  }
+
+  /**
+   * Sets the last index tracked in the aggregate list window for the current actor.
+   * @param {number} index - The new index to track.
+   */
+  setLastAggregateIndex(index)
+  {
+    // get the current actor id.
+    const actorId = this.actor().actorId();
+
+    // update the remembered index for this actor.
+    this._j._aptitude._lastAggregateIndexByActor[actorId] = index;
+  }
+
+  /**
+   * Gets the last index tracked in the source list window for the current actor.
+   * @returns {number}
+   */
+  lastSourceIndex()
+  {
+    // get the current actor id.
+    const actorId = this.actor().actorId();
+
+    // pull from the map; default to 0 if not yet set.
+    const map = this._j._aptitude._lastSourceIndexByActor;
+    if (map[actorId] === undefined)
+    {
+      map[actorId] = 0;
+    }
+
+    // return the remembered index.
+    return map[actorId];
+  }
+
+  /**
+   * Sets the last index tracked in the source list window for the current actor.
+   * @param {number} index - The new index to track.
+   */
+  setLastSourceIndex(index)
+  {
+    // get the current actor id.
+    const actorId = this.actor().actorId();
+
+    // update the remembered index for this actor.
+    this._j._aptitude._lastSourceIndexByActor[actorId] = index;
+  }
+
+  /**
+   * Ensures selection tracker indices exist for the current actor without overwriting them.
+   * This initializes to 0 only if the current actor does not yet have entries.
+   */
+  resetSelectionTrackers()
+  {
+    // get the current actor id.
+    const actorId = this.actor().actorId();
+
+    // ensure aggregate index exists.
+    const aggMap = this._j._aptitude._lastAggregateIndexByActor;
+    if (aggMap[actorId] === undefined)
+    {
+      aggMap[actorId] = 0;
+    }
+
+    // ensure source index exists.
+    const srcMap = this._j._aptitude._lastSourceIndexByActor;
+    if (srcMap[actorId] === undefined)
+    {
+      srcMap[actorId] = 0;
+    }
+  }
+
+  /**
+   * Gets the cached list of per‑skill aggregates for the current actor.
+   * @returns {AptitudeSkillAggregate[]}
+   */
+  aggregates()
+  {
+    // return the cached aggregates.
+    return this._j._aptitude._aggregates;
+  }
+
+  /**
+   * Rebuilds the aggregates cache for the current actor.
+   */
+  rebuildAggregatesForActor()
+  {
+    // compute new aggregates from the actor.
+    const next = this.actor()
+      .getAptitudeSkillAggregates();
+
+    // replace the cache.
+    this._j._aptitude._aggregates = next;
+  }
+
+  /**
+   * Gets the aptitude sources for the current actor.
+   * @returns {(RPG_Actor|RPG_Class|RPG_EquipItem|RPG_Weapon|RPG_Armor|RPG_Skill|RPG_State)[]}
+   */
+  sources()
+  {
+    return this._j._aptitude._sources;
+  }
+
+  /**
+   * Sets the aptitude sources for the current actor.
+   * @param {(RPG_Actor|RPG_Class|RPG_EquipItem|RPG_Weapon|RPG_Armor|RPG_Skill|RPG_State)[]} sources The new sources.
+   */
+  setSources(sources)
+  {
+    this._j._aptitude._sources = sources;
+  }
+
+  /**
+   * Rebuilds the sources cache for the current actor.
+   */
+  rebuildSourcesForActor()
+  {
+    // compute new sources from the actor.
+    const next = this.actor()
+      .getAptitudeSources();
+
+    // replace the cache.
+    this._j._aptitude._sources = next;
+  }
+
+  /**
+   * Gets the current view mode for the aptitude windows.
+   * Should be one of {@link Scene_Aptitude.viewMode}.
+   * @returns {string}
+   */
+  viewMode()
+  {
+    return this._j._aptitude._viewMode;
+  }
+
+  /**
+   * Sets the current view mode to the aggregate view.
+   */
+  setViewModeToAggregate()
+  {
+    this._j._aptitude._viewMode = Scene_Aptitude.viewMode.AGGREGATE;
+
+    this.aptitudeRibbonWindow()
+      .setToggleHintTarget('the sources');
+  }
+
+  /**
+   * Sets the current view mode to the source view.
+   */
+  setViewModeToSource()
+  {
+    this._j._aptitude._viewMode = Scene_Aptitude.viewMode.SOURCE;
+
+    this.aptitudeRibbonWindow()
+      .setToggleHintTarget('your skills');
+  }
+
+  /**
+   * Gets the current active list window for the view mode.
+   * @returns {Window_AptitudeAggregateList|Window_AptitudeSourceList|null} - The active list window.
+   */
+  currentListWindow()
+  {
+    // return the list window based on the current view mode.
+    if (this.viewMode() === Scene_Aptitude.viewMode.AGGREGATE)
+    {
+      return this.aptitudeAggregateListWindow();
+    }
+    else if (this.viewMode() === Scene_Aptitude.viewMode.SOURCE)
+    {
+      return this.aptitudeSourceListWindow();
+    }
+
+    return null;
+  }
+
+  /**
+   * Gets the currently inactive list window for the view mode.
+   * @returns {Window_AptitudeAggregateList|Window_AptitudeSourceList|null} - The inactive list window.
+   */
+  inactiveListWindow()
+  {
+    // return the opposite list window based on the current view mode.
+    if (this.viewMode() === Scene_Aptitude.viewMode.AGGREGATE)
+    {
+      return this.aptitudeSourceListWindow();
+    }
+    else if (this.viewMode() === Scene_Aptitude.viewMode.SOURCE)
+    {
+      return this.aptitudeAggregateListWindow();
+    }
+
+    return null;
+  }
+
+  /**
+   * Gets the current active details window for the view mode.
+   * @returns {Window_AptitudeAggregateDetails|Window_AptitudeSourceDetails|null} - The active details window.
+   */
+  currentDetailsWindow()
+  {
+    // return the details window based on the current view mode.
+    if (this.viewMode() === Scene_Aptitude.viewMode.AGGREGATE)
+    {
+      return this.aptitudeAggregateDetailsWindow();
+    }
+    else if (this.viewMode() === Scene_Aptitude.viewMode.SOURCE)
+    {
+      return this.aptitudeSourceDetailsWindow();
+    }
+
+    return null;
+  }
+
+  //endregion accessors
+
+  //region create
+  /**
+   * Initialize all resources required for this scene.
+   */
+  create()
+  {
+    // perform original logic.
+    super.create();
+
+    // create the various display objects on the screen.
+    this.createDisplayObjects();
+  }
+
+  /**
+   * Creates the display objects for this scene.
+   */
+  createDisplayObjects()
+  {
+    // create all our windows.
+    this.createAllWindows();
+  }
+
+  /**
+   * Creates all windows for this scene.
+   */
+  createAllWindows()
+  {
+    // rebuild aggregates once for the initial actor.
+    this.rebuildAggregatesForActor();
+
+    // rebuild sources once for the initial actor.
+    this.rebuildSourcesForActor();
+
+    // create the ribbon window.
+    this.createAptitudeRibbonWindow();
+
+    // create the list window for aptitudes aggregations.
+    this.createAptitudeAggregateListWindow();
+
+    // create the list window for aptitudes sources.
+    this.createAptitudeSourceListWindow();
+
+    // create the details window that responds to aggregate selection.
+    this.createAptitudeAggregateDetailsWindow();
+
+    // create the details window that responds to source selection.
+    this.createAptitudeSourceDetailsWindow();
+  }
+
+  //region ribbon
+  /**
+   * Creates the aptitude ribbon window.
+   */
+  createAptitudeRibbonWindow()
+  {
+    // define the rectangle.
+    const rect = this.aptitudeRibbonRect();
+
+    // build the window.
+    const win = new Window_AptitudeRibbon(rect);
+
+    // initialize the actor.
+    win.setActor(this.actor());
+
+    // assign the view mode for the toggle hint.
+    win.setToggleHintTarget('the sources');
+
+    // assign the window.
+    this._j._aptitude._windows._ribbon = win;
+
+    // add the window to the scene.
+    this.addWindow(win);
+  }
+
+  /**
+   * Gets the rectangle for the aptitude ribbon window.
+   * @returns {Rectangle}
+   */
+  aptitudeRibbonRect()
+  {
+    // compute the centered container width (~66% of the screen width).
+    const containerW = Math.floor(Graphics.boxWidth * this.containerWidthPercent());
+
+    // compute the x offset to center the container.
+    const containerX = Math.floor((Graphics.boxWidth - containerW) / 2);
+
+    // place the ribbon at the top of the container.
+    const x = containerX;
+    const y = 0;
+
+    // keep ribbon width proportional to list column (25% of container width).
+    const w = Math.floor(containerW * 0.25);
+
+    // keep the same visual height used previously for ribbon rows.
+    const height = (36 * 3);
+
+    // return the rectangle for the ribbon window.
+    return new Rectangle(x, y, w, height);
+  }
+
+  /**
+   * Gets the aptitude ribbon window.
+   * @returns {Window_AptitudeRibbon|null}
+   */
+  aptitudeRibbonWindow()
+  {
+    return this._j._aptitude._windows._ribbon;
+  }
+
+  //endregion ribbon
+
+  //region aggregate list
+  /**
+   * Creates the aptitude aggregate list window.
+   */
+  createAptitudeAggregateListWindow()
+  {
+    // build the rectangle for the list window.
+    const rect = this.aptitudeAggregateListWindowRect();
+
+    // create the list window instance.
+    const win = new Window_AptitudeAggregateList(rect);
+
+    // set the actor for the list.
+    win.setActor(this.actor());
+
+    // provide the prebuilt aggregates.
+    win.setAggregates(this.aggregates());
+
+    // wire basic handlers.
+    win.setHandler('ok', this.onListOk.bind(this));
+    win.setHandler('cancel', this.popScene.bind(this));
+    win.setHandler('more', this.toggleViewMode.bind(this));
+
+    // also wire page navigation keys (Q/W or shoulder buttons).
+    win.setHandler('pageup', this.onCycleActorLeft.bind(this));
+    win.setHandler('pagedown', this.onCycleActorRight.bind(this));
+
+    // store and add to the scene.
+    this._j._aptitude._windows._aggregateList = win;
+    this.addWindow(win);
+  }
+
+  /**
+   * Builds the rectangle for the aptitude aggregate list window.
+   * @returns {Rectangle}
+   */
+  aptitudeAggregateListWindowRect()
+  {
+    // compute the centered container width (~66% of the screen width).
+    const containerW = Math.floor(Graphics.boxWidth * this.containerWidthPercent());
+
+    // compute the x offset to center the container.
+    const containerX = Math.floor((Graphics.boxWidth - containerW) / 2);
+
+    // grab some data from the ribbon window.
+    const {
+      y: ribbonY,
+      height: ribbonHeight
+    } = this.aptitudeRibbonRect();
+
+    // compute the top of the list to sit directly under the ribbon.
+    const wy = ribbonY + ribbonHeight;
+
+    // use the main area height for window height.
+    const wh = Graphics.boxHeight - ribbonHeight;
+
+    // keep the list width at 25% of the container width.
+    const listW = Math.floor(containerW * 0.25);
+
+    // return the rectangle for the list on the left of the container.
+    return new Rectangle(containerX, wy, listW, wh);
+  }
+
+  /**
+   * Gets the aptitude aggregate list window.
+   * @returns {Window_AptitudeAggregateList|null}
+   */
+  aptitudeAggregateListWindow()
+  {
+    // return the list window or null.
+    return this._j._aptitude._windows._aggregateList;
+  }
+
+  //endregion aggregate list
+
+  //region source list
+  /**
+   * Creates the aptitude source list window.
+   */
+  createAptitudeSourceListWindow()
+  {
+    // build the rectangle for the list window.
+    const rect = this.aptitudeSourceListWindowRect();
+
+    // create the list window instance.
+    const win = new Window_AptitudeSourceList(rect);
+
+    // set the actor for the list.
+    win.setActor(this.actor());
+
+    // provide the prebuilt sources.
+    win.setSources(this.sources());
+
+    // wire basic handlers.
+    win.setHandler('ok', this.onListOk.bind(this));
+    win.setHandler('cancel', this.popScene.bind(this));
+    win.setHandler('more', this.toggleViewMode.bind(this));
+
+    // also wire page navigation keys (Q/W or shoulder buttons).
+    win.setHandler('pageup', this.onCycleActorLeft.bind(this));
+    win.setHandler('pagedown', this.onCycleActorRight.bind(this));
+
+    // hide this window initially.
+    win.hide();
+    win.deactivate();
+
+    // store and add to the scene.
+    this._j._aptitude._windows._sourceList = win;
+    this.addWindow(win);
+  }
+
+  /**
+   * Builds the rectangle for the aptitude source list window.
+   * @returns {Rectangle}
+   */
+  aptitudeSourceListWindowRect()
+  {
+    return this.aptitudeAggregateListWindowRect();
+  }
+
+  /**
+   * Gets the aptitude source list window.
+   * @returns {Window_AptitudeSourceList|null}
+   */
+  aptitudeSourceListWindow()
+  {
+    return this._j._aptitude._windows._sourceList;
+  }
+
+  //endregion source list
+
+  //region aggregate details
+  /**
+   * Creates the aptitude aggregate details window.
+   */
+  createAptitudeAggregateDetailsWindow()
+  {
+    // build the rectangle for the details window.
+    const rect = this.aptitudeAggregateDetailsWindowRect();
+
+    // create the details window instance.
+    const win = new Window_AptitudeAggregateDetails(rect);
+
+    // set the actor for the details window.
+    win.setActor(this.actor());
+
+    // store and add to the scene.
+    this._j._aptitude._windows._aggregateDetails = win;
+    this.addWindow(win);
+  }
+
+  /**
+   * Builds the rectangle for the aptitude aggregate details window.
+   * @returns {Rectangle}
+   */
+  aptitudeAggregateDetailsWindowRect()
+  {
+    // compute the centered container width (~66% of the screen width).
+    const containerW = Math.floor(Graphics.boxWidth * this.containerWidthPercent());
+
+    // compute the x offset to center the container.
+    const containerX = Math.floor((Graphics.boxWidth - containerW) / 2);
+
+    // use the same main area vertical bounds.
+    const wy = this.mainAreaTop();
+    const wh = Graphics.boxHeight;
+
+    // split container 25/75 between list and details (same proportions as before).
+    const listW = Math.floor(containerW * 0.25);
+    const detailsW = containerW - listW;
+
+    // place details immediately to the right of the list.
+    const dx = containerX + listW;
+
+    // return the rectangle for the details window.
+    return new Rectangle(dx, wy, detailsW, wh);
+  }
+
+  /**
+   * Gets the aptitude aggregate details window.
+   * @returns {Window_AptitudeAggregateDetails|null}
+   */
+  aptitudeAggregateDetailsWindow()
+  {
+    // return the details window or null.
+    return this._j._aptitude._windows._aggregateDetails;
+  }
+
+  //endregion aggregate details
+
+  //region source details
+  /**
+   * Creates the aptitude source details window.
+   */
+  createAptitudeSourceDetailsWindow()
+  {
+    // build the rectangle for the details window.
+    const rect = this.aptitudeSourceDetailsWindowRect();
+
+    // create the details window instance.
+    const win = new Window_AptitudeSourceDetails(rect);
+
+    // set the actor for the details window.
+    win.setActor(this.actor());
+
+    // hide this window initially.
+    win.hide();
+
+    // store and add to the scene.
+    this._j._aptitude._windows._sourceDetails = win;
+    this.addWindow(win);
+  }
+
+  /**
+   * Builds the rectangle for the aptitude source details window.
+   * @returns {Rectangle}
+   */
+  aptitudeSourceDetailsWindowRect()
+  {
+    return this.aptitudeAggregateDetailsWindowRect();
+  }
+
+  /**
+   * Gets the aptitude source details window.
+   * @returns {Window_AptitudeSourceDetails|null}
+   */
+  aptitudeSourceDetailsWindow()
+  {
+    return this._j._aptitude._windows._sourceDetails;
+  }
+
+  //endregion source details
+
+  containerWidthPercent()
+  {
+    return 0.90;
+  }
+
+  containerHeightPercent()
+  {
+    return 0.80;
+  }
+
+  //endregion create
+
+  //region update
+  /**
+   * Extends {@link #update}.<br/>
+   * Also updates the details window when the list selection changes.
+   */
+  update()
+  {
+    // grab the previous view mode.
+    const previousViewMode = this.viewMode();
+
+    // perform original logic.
+    super.update();
+
+    // if the list is not present, do nothing.
+    const list = this.aptitudeAggregateListWindow();
+    if (!list) return;
+
+    // manage the details content based on whether or not the list index changed.
+    this.updateDetails();
+
+    // manage visibility based on view mode.
+    this.updateVisibility(previousViewMode);
+  }
+
+  /**
+   * Updates the aptitude details window based on the current list selection.
+   */
+  updateDetails()
+  {
+    switch (this.viewMode())
+    {
+      case Scene_Aptitude.viewMode.AGGREGATE:
+      {
+        const previousIndex = this.lastAggregateIndex();
+        this.updateAggregateDetails(previousIndex);
+        break;
+      }
+      case Scene_Aptitude.viewMode.SOURCE:
+      {
+        const previousIndex = this.lastSourceIndex();
+        this.updateSourceDetails(previousIndex);
+        break;
+      }
+    }
+  }
+
+  /**
+   * Updates the aptitude aggregate details window.
+   * @param {number} previousIndex The previous index of the list.
+   */
+  updateAggregateDetails(previousIndex)
+  {
+    // grab the list window.
+    const listWindow = this.aptitudeAggregateListWindow();
+
+    // if the index has not changed, do nothing.
+    if (previousIndex === listWindow.index()) return;
+
+    // acquire the selected entry if available.
+    const aggregate = listWindow.currentExt();
+
+    // update the details window context.
+    const details = this.aptitudeAggregateDetailsWindow();
+
+    // update both actor and entry for completeness.
+    details.setActor(this.actor());
+    details.setAggregate(aggregate);
+
+    // update our tracker.
+    this.setLastAggregateIndex(listWindow.index());
+  }
+
+  /**
+   * Updates the aptitude source details window.
+   * @param {number} previousIndex The previous index of the list.
+   */
+  updateSourceDetails(previousIndex)
+  {
+    // grab the list window.
+    const listWindow = this.aptitudeSourceListWindow();
+
+    // if the index has not changed, do nothing.
+    if (previousIndex === listWindow.index()) return;
+
+    // grab the source from the list window.
+    const source = listWindow.currentExt();
+
+    // update the details window context.
+    const details = this.aptitudeSourceDetailsWindow();
+    details.setActor(this.actor());
+    details.setSource(source);
+
+    // update our tracker.
+    this.setLastSourceIndex(listWindow.index());
+  }
+
+  /**
+   * Updates the visibility of the aptitude windows based on the current view mode.
+   * @param {string} previousViewMode The previous view mode.
+   */
+  updateVisibility(previousViewMode)
+  {
+    // grab the current view mode.
+    const currentViewMode = this.viewMode();
+
+    // if the view mode hasn't changed, do nothing.
+    if (currentViewMode === previousViewMode) return;
+
+    // pivot on the current view mode to display the appropriate windows.
+    switch (currentViewMode)
+    {
+      case Scene_Aptitude.viewMode.AGGREGATE:
+        this.hideSourceWindows();
+        this.showAggregateWindows();
+        break;
+      case Scene_Aptitude.viewMode.SOURCE:
+        this.hideAggregateWindows();
+        this.showSourceWindows();
+        break;
+    }
+  }
+
+  /**
+   * Shows the aptitude aggregate windows.
+   * Also refreshes the list and details windows with the current actor.
+   */
+  showAggregateWindows()
+  {
+    const list = this.aptitudeAggregateListWindow();
+    const details = this.aptitudeAggregateDetailsWindow();
+
+    this.rebuildAggregatesForActor();
+
+    list.show();
+    list.setActor(this.actor());
+    list.setAggregates(this.aggregates());
+    list.select(this.lastAggregateIndex());
+    list.activate();
+
+    details.show();
+    details.setActor(this.actor());
+    list.currentExt()
+      ? details.setAggregate(list.currentExt())
+      : details.setAggregate(null);
+  }
+
+  /**
+   * Hides the aptitude aggregate windows.
+   */
+  hideAggregateWindows()
+  {
+    const list = this.aptitudeAggregateListWindow();
+    const details = this.aptitudeAggregateDetailsWindow();
+
+    list.hide();
+    list.deactivate();
+    details.hide();
+  }
+
+  /**
+   * Shows the aptitude source windows.
+   * Also refreshes the list and details windows with the current actor.
+   */
+  showSourceWindows()
+  {
+    const list = this.aptitudeSourceListWindow();
+    const details = this.aptitudeSourceDetailsWindow();
+
+    list.show();
+    list.setActor(this.actor());
+    list.setSources(this.sources());
+    list.select(this.lastSourceIndex());
+    list.activate();
+
+    details.show();
+    details.setActor(this.actor());
+    list.currentExt()
+      ? details.setSource(list.currentExt())
+      : details.setSource(null);
+  }
+
+  /**
+   * Hides the aptitude source windows.
+   */
+  hideSourceWindows()
+  {
+    const list = this.aptitudeSourceListWindow();
+    const details = this.aptitudeSourceDetailsWindow();
+
+    list.hide();
+    list.deactivate();
+    details.hide();
+  }
+
+  //endregion update
+
+  //region actions
+  /**
+   * Cycles to the previous actor.
+   */
+  onCycleActorLeft()
+  {
+    // move to the previous actor.
+    this.previousActor();
+  }
+
+  /**
+   * Cycles to the next actor.
+   */
+  onCycleActorRight()
+  {
+    // move to the next actor.
+    this.nextActor();
+  }
+
+  /**
+   * Handles the "more" action- aka the shift key/square button from the either list.
+   */
+  toggleViewMode()
+  {
+    switch (this.viewMode())
+    {
+      case Scene_Aptitude.viewMode.AGGREGATE:
+        this.setViewModeToSource();
+        break;
+      case Scene_Aptitude.viewMode.SOURCE:
+        this.setViewModeToAggregate();
+        break;
+      default:
+        throw new Error(`Invalid view mode: ${this.viewMode()}`);
+    }
+  }
+
+  /**
+   * Extends {@link #onActorChange}.<br/>
+   * Also refreshes the aptitude windows when the actor changes.
+   */
+  onActorChange()
+  {
+    // perform original logic.
+    super.onActorChange();
+
+    // rebuild the cached aggregates for the new actor.
+    this.rebuildAggregatesForActor();
+
+    // rebuild the cached sources for the new actor.
+    this.rebuildSourcesForActor();
+
+    // get the updated actor reference.
+    const updatedActor = this.actor();
+
+    // rebind all windows to the new actor (ribbon, lists, details).
+    this.rebindAllWindowsToActor(updatedActor);
+
+    // refresh the list contents for the new actor (aggregates/sources).
+    this.refreshListsForActor();
+
+    // reset the per-view selection trackers back to the first index.
+    this.resetSelectionTrackers();
+
+    // choose the remembered index for the active view.
+    const startIndex = this.viewMode() === Scene_Aptitude.viewMode.AGGREGATE
+      ? this.lastAggregateIndex()
+      : this.lastSourceIndex();
+
+    // select and activate the current view, and push selection into details.
+    this.refreshSelectionForCurrentView(startIndex);
+  }
+
+  /**
+   * Rebinds all scene windows to the provided actor.
+   * @param {Game_Actor} actor - The actor to bind to all windows.
+   */
+  rebindAllWindowsToActor(actor)
+  {
+    // update the ribbon window with the new actor.
+    this.aptitudeRibbonWindow()
+      .setActor(actor);
+
+    // update both list windows with the new actor.
+    this.aptitudeAggregateListWindow()
+      .setActor(actor);
+    this.aptitudeSourceListWindow()
+      .setActor(actor);
+
+    // update both details windows with the new actor.
+    this.aptitudeAggregateDetailsWindow()
+      .setActor(actor);
+    this.aptitudeSourceDetailsWindow()
+      .setActor(actor);
+  }
+
+  /**
+   * Refreshes the list contents for the currently bound actor.
+   * This pulls from the scene’s cached aggregates and sources.
+   */
+  refreshListsForActor()
+  {
+    // refresh the aggregate list with the current aggregates cache.
+    this.aptitudeAggregateListWindow()
+      .setAggregates(this.aggregates());
+
+    // refresh the source list with the current sources cache.
+    this.aptitudeSourceListWindow()
+      .setSources(this.sources());
+  }
+
+  /**
+   * Selects and activates the current list view and updates its details.
+   * @param {number} startIndex - The index to select in the active list.
+   */
+  refreshSelectionForCurrentView(startIndex)
+  {
+    // grab the active and inactive list windows.
+    const activeList = this.currentListWindow();
+    const inactiveList = this.inactiveListWindow();
+
+    // select the desired index on the active list.
+    activeList.select(startIndex);
+
+    // activate the active list to accept input.
+    activeList.activate();
+
+    // deactivate the other list to avoid input conflicts.
+    inactiveList.deactivate();
+
+    // push the active list’s current selection into the correct details window.
+    this.setDetailsFromCurrentSelection();
+  }
+
+  /**
+   * Applies the active list selection to the corresponding details window.
+   */
+  setDetailsFromCurrentSelection()
+  {
+    // check what view we are currently in.
+    switch (this.viewMode())
+    {
+      case Scene_Aptitude.viewMode.AGGREGATE:
+      {
+        // grab the aggregate list/details windows.
+        const list = this.aptitudeAggregateListWindow();
+        const details = this.aptitudeAggregateDetailsWindow();
+
+        // update the details window with the selected aggregate or null.
+        const selected = list.currentExt();
+        if (selected)
+        {
+          details.setAggregate(selected);
+        }
+        else
+        {
+          details.setAggregate(null);
+        }
+        break;
+      }
+      case Scene_Aptitude.viewMode.SOURCE:
+      {
+        // grab the source list/details windows.
+        const list = this.aptitudeSourceListWindow();
+        const details = this.aptitudeSourceDetailsWindow();
+
+        // update the details window with the selected source or null.
+        const selected = list.currentExt();
+        if (selected)
+        {
+          details.setSource(selected);
+        }
+        else
+        {
+          details.setSource(null);
+        }
+        break;
+      }
+      default:
+      {
+        // an invalid view mode was encountered.
+        throw new Error(`Invalid view mode: ${this.viewMode()}`);
+      }
+    }
+  }
+
+  /**
+   * Handles the OK action from the aptitude list.
+   * (Reserved for future behaviors; currently a no‑op.)
+   */
+  onListOk()
+  {
+    // no special OK behavior in v1; just play a sound.
+    SoundManager.playOk();
+
+    // reselect the list to ensure it remains active.
+    this.aptitudeAggregateListWindow()
+      .activate();
+  }
+
+  //endregion actions
+
+}
+
+//endregion Scene_Aptitude

--- a/src/plugins/apt/core/scenes/Scene_Menu.js
+++ b/src/plugins/apt/core/scenes/Scene_Menu.js
@@ -1,0 +1,25 @@
+//region Scene_Menu (APT)
+/**
+ * Extends {@link #createCommandWindow}.</br>
+ * Adds a handler for the Aptitude menu command.
+ */
+J.APT.Aliased.Scene_Menu.set('createCommandWindow', Scene_Menu.prototype.createCommandWindow);
+Scene_Menu.prototype.createCommandWindow = function()
+{
+  // perform original logic.
+  J.APT.Aliased.Scene_Menu.get('createCommandWindow')
+    .call(this);
+
+  // set the handler for our custom command.
+  this._commandWindow.setHandler('aptitude', this.commandAptitude.bind(this));
+};
+
+/**
+ * Opens the Aptitude scene.
+ */
+Scene_Menu.prototype.commandAptitude = function()
+{
+  // push the new scene onto the stack.
+  Scene_Aptitude.callScene();
+};
+//endregion Scene_Menu (APT)

--- a/src/plugins/apt/core/windows/Window_AptitudeAggregateDetails.js
+++ b/src/plugins/apt/core/windows/Window_AptitudeAggregateDetails.js
@@ -1,0 +1,440 @@
+//region Window_AptitudeDetails
+/**
+ * The window containing the details of an aptitude skill aggregate.
+ */
+class Window_AptitudeAggregateDetails
+  extends Window_Base
+{
+  //region properties
+  /**
+   * The actor bound to this window.
+   * @type {Game_Actor|null}
+   */
+  _actor = null;
+
+  /**
+   * The selected entry for display.
+   * @type {AptitudeSkillAggregate|null}
+   */
+  _aggregate = null;
+
+  /**
+   * The y position of the next block to draw.
+   * @type {number}
+   */
+  _nextY = 0;
+
+  //endregion properties
+
+  // region init
+  /**
+   * Constructor.
+   * @param {Rectangle} rect The rectangle to draw the window in.
+   */
+  constructor(rect)
+  {
+    // call parent ctor.
+    super(rect);
+
+    // initialize members.
+    this.initMembers();
+
+    // draw initial contents.
+    this.refresh();
+  }
+
+  /**
+   * Initializes the members of this window.
+   */
+  initMembers()
+  {
+    // initialize the actor.
+    this._actor = null;
+
+    // initialize the aggregate.
+    this._aggregate = null;
+
+    // initialize the next y position.
+    this._nextY = 0;
+  }
+
+  //endregion init
+
+  //region accessors
+  /**
+   * The actor bound to this window.
+   * @returns {Game_Actor|null}
+   */
+  actor()
+  {
+    return this._actor;
+  }
+
+  /**
+   * Sets the actor for this window.
+   * @param {Game_Actor} actor The actor to bind.
+   */
+  setActor(actor)
+  {
+    // do nothing if the actor is unchanged.
+    if (this.actor() === actor) return;
+
+    // update the actor.
+    this._actor = actor;
+
+    // refresh the contents for the new actor.
+    this.refresh();
+  }
+
+  /**
+   * The selected aggregate for display.
+   * @returns {AptitudeSkillAggregate|null}
+   */
+  aggregate()
+  {
+    return this._aggregate;
+  }
+
+  /**
+   * Sets the selected aggregate for display.
+   * @param {AptitudeSkillAggregate|null} aggregate The selected aggregate or null to clear.
+   */
+  setAggregate(aggregate)
+  {
+    // do nothing if unchanged.
+    if (this.aggregate() === aggregate) return;
+
+    // update the entry.
+    this._aggregate = aggregate;
+
+    // refresh the contents for the new aggregate.
+    this.refresh();
+  }
+
+  /**
+   * The y position of the next block to draw.
+   * @returns {number}
+   */
+  nextY()
+  {
+    return this._nextY || 0;
+  }
+
+  /**
+   * Sets the next y position for drawing.
+   * @param {number} y The y position to set.
+   */
+  setNextY(y)
+  {
+    this._nextY = y;
+  }
+
+  //endregion accessors
+
+  //region draw
+  /**
+   * Implements {@link #drawContent}.<br/>
+   * Draws the details for the selected aggregate.
+   */
+  drawContent()
+  {
+    // if we do not have an entry or actor to work with, show a friendly hint.
+    if (!this.aggregate() || !this.actor())
+    {
+      // render a default hint.
+      this.resetTextColor();
+      this.drawText('Select a skill from the list.', 0, 0, this.contentsWidth());
+      return;
+    }
+
+    // reset the next y position.
+    this.setNextY(0);
+
+    // draw the header.
+    this.drawHeader();
+
+    // draw the per‑source breakdown table.
+    this.drawSources();
+  }
+
+  /**
+   * Draws the header containing the icon+name and learned badge.
+   */
+  drawHeader()
+  {
+    // grab the aggregate data.
+    const aggregate = this.aggregate();
+
+    // derive the skill data for icon+name.
+    const skill = this.actor()
+      .skill(aggregate.skillId());
+
+    // y anchor for the header.
+    let y = this.nextY();
+
+    // draw the icon if present.
+    if (skill.iconIndex > 0)
+    {
+      // draw the icon at the far left.
+      this.drawIcon(skill.iconIndex, 0, y);
+    }
+
+    // compute a left indent if we drew an icon.
+    const left = (skill.iconIndex > 0)
+      ? 36
+      : 0;
+
+    // draw the name.
+    this.changeTextColor(this.systemColor());
+    this.drawText(`${skill.name}`, left, y, this.contentsWidth() - left);
+
+    // if learned, render a badge at the right.
+    if (aggregate.learnedAny() === true)
+    {
+      // draw learned badge.
+      this.resetTextColor();
+      this.drawText('[LEARNED]', 0, y, this.contentsWidth(), 'right');
+    }
+
+    // advance y.
+    y += this.lineHeight();
+
+    // draw the description.
+    this.changeTextColor(ColorManager.normalColor());
+    const wrappedText = this.modFontSizeForText(-4, skill.description);
+    this.drawTextEx(wrappedText, 0, y, this.contentsWidth());
+
+    // add some spacing below the description.
+    y += this.lineHeight() * 2;
+
+    // set the next block anchor.
+    this.setNextY(y);
+  }
+
+  /**
+   * Draws the sources for the selected entry.
+   */
+  drawSources()
+  {
+    // grab the aggregate data.
+    const aggregate = this.aggregate();
+
+    // establish a y anchor somewhat below the gauges.
+    const baseY = this.nextY() + this.lineHeight();
+
+    // header label for the section.
+    this.changeTextColor(this.systemColor());
+    this.drawTextEx('\\I[86]\\C[16]Sources\\C[0]', 0, baseY, this.contentsWidth());
+
+    // compute the starting y for rows.
+    const updatedY = baseY + this.lineHeight();
+    this.setNextY(updatedY);
+
+    // iterate and draw each source row.
+    aggregate.sources()
+      .forEach(this.drawSource, this);
+  }
+
+  /**
+   * Draws a single source row.
+   * @param {AptitudeSkillSourceProgress} sourceProgress - The per-source progress to draw for this skill.
+   */
+  drawSource(sourceProgress)
+  {
+    // capture the current y position for this row.
+    const y = this.nextY();
+
+    // calculate the left column width for the icon+label.
+    const leftW = Math.floor(this.contentsWidth() * 0.60);
+
+    // resolve the database object for the display (icon/name) using the key.
+    const databaseSource = ApManager.resolveStaticSourceByKey(sourceProgress.sourceKey());
+
+    // don't render none-sourced rows.
+    if (!databaseSource) return;
+
+    // determine whether this source is currently active on the actor.
+    const isActive = ApManager.isSourceActive(this.actor(), sourceProgress.sourceKey());
+
+    // extract the icon index from the database object if available.
+    let { iconIndex } = databaseSource;
+
+    // actors don't normally have an icon index, so lets give em one.
+    if (databaseSource.isActor())
+    {
+      iconIndex = 2727;
+    }
+    // classes also don't normally have an icon index, so lets give em one.
+    else if (databaseSource.isClass())
+    {
+      iconIndex = 2694;
+    }
+
+    // extract the label from the database object if available, else fallback to the raw key.
+    let { name } = databaseSource;
+    let activityColorIndex = 0;
+
+    if (isActive === false)
+    {
+      activityColorIndex = 7;
+      name += ' (inactive)';
+    }
+
+    // draw the icon + label on the left side of the row.
+    this.drawTextEx(`\\C[${activityColorIndex}]\\I[${iconIndex}]${name}\\C[0]`, 0, y, leftW);
+
+    // determine learned state for this specific source.
+    const learned = sourceProgress.learned() === true;
+
+    // determine if the actor already knows the skill via some other source.
+    const knownElsewhere = learned === false &&
+      sourceProgress.currentAp() < sourceProgress.requiredAp() &&
+      this.actor()
+        .hasSkill(sourceProgress.skillId());
+
+    // decide the right-side text content.
+    let rightText = '';
+    if (learned === true)
+    {
+      // if learned from this source, show DONE.
+      rightText = 'DONE';
+    }
+    else if (knownElsewhere === true)
+    {
+      // if not learned from this source but the actor already knows the skill, show KNOWN.
+      rightText = 'KNOWN';
+    }
+    else
+    {
+      // otherwise, show the current/required AP counts.
+      rightText = `${sourceProgress.currentAp()}/${sourceProgress.requiredAp()}`;
+    }
+
+    // decide the right-side color index.
+    let rightColor = 7; // gray by default
+    if (learned === true)
+    {
+      // green when learned.
+      rightColor = 11;
+    }
+    else if (sourceProgress.currentAp() > 0)
+    {
+      // yellow when in-progress.
+      rightColor = isActive
+        ? 6
+        : 7;
+    }
+
+    // apply the right-side color and draw the right-aligned status text.
+    this.changeTextColor(ColorManager.textColor(rightColor));
+    const rightW = this.contentsWidth() - leftW;
+    this.drawText(rightText, 0, y, rightW, Window_Base.TextAlignments.Right);
+
+    // Only draw a gauge if the skill is neither DONE nor KNOWN.
+    const shouldDrawGauge = learned === false && knownElsewhere === false;
+    if (shouldDrawGauge === true)
+    {
+      // compute the gauge rectangle centered vertically within the row.
+      const gaugeX = Math.floor(this.contentsWidth() * 0.40);
+      const gaugeY = y + Math.round(this.lineHeight() / 2) - Math.round(this.gaugeHeight() / 2);
+      const rect = new Rectangle(gaugeX, gaugeY, this.gaugeWidth(), this.gaugeHeight());
+
+      // compute the rate between 0..1 for the gauge.
+      const progressRate = Math.max(0, Math.min(sourceProgress.currentAp() / sourceProgress.requiredAp(), 1));
+
+      // build the gauge options with a dynamic segment count and colors.
+      const leftGaugeColor = isActive
+        ? this.gaugeColor1()
+        : this.inactiveColor1();
+      const rightGaugeColor = isActive
+        ? this.gaugeColor2()
+        : this.inactiveColor2();
+      const segOpts = WindowGaugeOptions.Builder()
+        .gaugeType(Window_Base.GAUGE_TYPES.Segmented)
+        .segments(Math.max(1, Math.ceil(sourceProgress.requiredAp() / this.segmentValue())))
+        .gap(2)
+        .leftGradientColor(leftGaugeColor)
+        .rightGradientColor(rightGaugeColor)
+        .build();
+
+      // draw the segmented gauge.
+      this.drawGauge(rect, progressRate, segOpts);
+    }
+
+    // advance to the next row position.
+    this.setNextY(y + this.lineHeight());
+  }
+
+  //endregion draw
+
+  //region helpers
+  /**
+   * The width of the gauges in this window.
+   * @returns {number}
+   */
+  gaugeWidth()
+  {
+    return 256;
+  }
+
+  /**
+   * The height of the gauges in this window.
+   * @returns {number}
+   */
+  gaugeHeight()
+  {
+    return 12;
+  }
+
+  /**
+   * The back color of the gauges in this window.
+   * @returns {string}
+   */
+  gaugeBackColor()
+  {
+    return 'rgba(255, 255, 255, 0.1)';
+  }
+
+  /**
+   * The color to gradient from.
+   * Defaults to blue.
+   * @returns {string}
+   */
+  gaugeColor1()
+  {
+    return 'rgba(179, 89, 0, 1)';
+  }
+
+  /**
+   * The color to gradient into.
+   * Defaults to green.
+   * @returns {string}
+   */
+  gaugeColor2()
+  {
+    return 'rgba(255, 166, 77, 1)';
+  }
+
+  inactiveColor1()
+  {
+    return 'rgba(77, 77, 77, 1)';
+  }
+
+  inactiveColor2()
+  {
+    return 'rgba(153, 153, 153, 1)';
+  }
+
+  /**
+   * The amount that one segment represents.
+   * @returns {number}
+   */
+  segmentValue()
+  {
+    return 10;
+  }
+
+  //endregion helpers
+}
+
+//endregion Window_AptitudeDetails

--- a/src/plugins/apt/core/windows/Window_AptitudeAggregateList.js
+++ b/src/plugins/apt/core/windows/Window_AptitudeAggregateList.js
@@ -1,0 +1,174 @@
+//region Window_AptitudeList
+/**
+ * The window containing the list of aptitude skill aggregations for an actor.
+ */
+class Window_AptitudeAggregateList
+  extends Window_Command
+{
+  //region properties
+  /**
+   * The actor bound to this window.
+   * @type {Game_Actor|null}
+   */
+  _actor = null;
+
+  /**
+   * The list of aggregates bound to this window.
+   * @type {AptitudeSkillAggregate[]}
+   */
+  _aggregates = [];
+
+  //endregion properties
+
+  //region init
+  constructor(rect)
+  {
+    // call parent ctor.
+    super(rect);
+
+    // initialize members.
+    this.initMembers();
+  }
+
+  /**
+   * Initializes the members of this window.
+   */
+  initMembers()
+  {
+    // initialize members.
+    this._actor = null;
+
+    // initialize the aggregates bucket.
+    this._aggregates = [];
+  }
+
+  //endregion init
+
+  //region accessors
+  /**
+   * Gets the actor that is bound to this window.
+   * @returns {Game_Actor|null}
+   */
+  actor()
+  {
+    return this._actor;
+  }
+
+  /**
+   * Sets the actor for this window.
+   * @param {Game_Actor} actor The actor to bind.
+   */
+  setActor(actor)
+  {
+    // do nothing if the actor is unchanged.
+    if (this._actor === actor) return;
+
+    // update the actor reference.
+    this._actor = actor;
+
+    // rebuild the command list.
+    // TODO: update this to be handled from the scene.
+    this.refresh();
+  }
+
+  /**
+   * Get the list of aggregates that are bound to this window.
+   * @returns {AptitudeSkillAggregate[]}
+   */
+  aggregates()
+  {
+    return this._aggregates || [];
+  }
+
+  /**
+   * Sets the prebuilt aggregates for rendering.
+   * @param {AptitudeSkillAggregate[]} aggregates The list of aggregates to render.
+   */
+  setAggregates(aggregates)
+  {
+    // assign and refresh.
+    this._aggregates = aggregates || [];
+
+    // rebuild command list.
+    this.refresh();
+  }
+
+  //endregion accessors
+
+  //region commands
+  /**
+   * Rebuilds the command list for the current actor.
+   */
+  makeCommandList()
+  {
+    // if we don’t have an actor, there is nothing to build.
+    if (this.actor() === null) return;
+
+    // build all commands for this window.
+    const commands = this.buildCommands();
+
+    // add all built commands to this window.
+    commands.forEach(this.addBuiltCommand, this);
+  }
+
+  /**
+   * Builds all commands for this command window.
+   * @returns {BuiltWindowCommand[]}
+   */
+  buildCommands()
+  {
+    // grab all the aggregates to build commands for.
+    const aggregates = this.aggregates();
+
+    // if no aggregates, nothing to render.
+    if (aggregates.length === 0) return [];
+
+    // build each command based on the aggregate.
+    const commands = aggregates.map(this.buildCommand, this);
+
+    // return the built command set.
+    return commands;
+  }
+
+  /**
+   * Builds a single command for the given aggregate.
+   * @param {AptitudeSkillAggregate} aggregate The aggregate to build a command for.
+   * @returns {BuiltWindowCommand}
+   */
+  buildCommand(aggregate)
+  {
+    // compute right text.
+    const learned = aggregate.learnedAny();
+    const rightText = learned === true
+      ? 'DONE'
+      : `${aggregate.currentAp()}/${aggregate.requiredAp()}`;
+
+    // compute right color index.
+    let rightColor = 7; // gray default
+    if (learned === true)
+    {
+      rightColor = 11; // green learned
+    }
+    else if (aggregate.currentAp() > 0)
+    {
+      rightColor = 6; // yellow in‑progress
+    }
+
+    // build the command for this skill.
+    const builtWindowCommand = new WindowCommandBuilder(aggregate.name())
+      .setSymbol(`skill:${aggregate.skillId()}`)
+      .setExtensionData(aggregate)
+      .setIconIndex(aggregate.iconIndex())
+      .setRightText(rightText)
+      .setRightColorIndex(rightColor)
+      .setEnabled(learned === false)
+      .build();
+
+    // add to list.
+    return builtWindowCommand;
+  }
+
+  //endregion commands
+}
+
+//endregion Window_AptitudeList

--- a/src/plugins/apt/core/windows/Window_AptitudeRibbon.js
+++ b/src/plugins/apt/core/windows/Window_AptitudeRibbon.js
@@ -1,0 +1,136 @@
+//region Window_AptitudeRibbon
+/**
+ * The ribbon window for the Aptitude scene.
+ */
+class Window_AptitudeRibbon
+  extends Window_ActorRibbon
+{
+  //region properties
+  /**
+   * The target to show a hint for when the view is toggled.
+   * @type {string}
+   */
+  _toggleHintTarget = String.empty;
+
+  //endregion properties
+
+  /**
+   * Constructor.
+   * @param {Rectangle} rect The rectangle to draw the ribbon in.
+   */
+  constructor(rect)
+  {
+    super(rect);
+  }
+
+  //region accessors
+  /**
+   * Gets the target to show a hint for when the view is toggled.
+   * @returns {string}
+   */
+  toggleHintTarget()
+  {
+    return this._toggleHintTarget;
+  }
+
+  /**
+   * Sets the target to show a hint for when the view is toggled.
+   * @param {string} target The target to show a hint for.
+   */
+  setToggleHintTarget(target)
+  {
+    // store the target.
+    this._toggleHintTarget = target;
+
+    // also refresh the contents.
+    this.refresh();
+  }
+
+  //endregion accessors
+
+  /**
+   * Extends {@link #initMembers}.<br/>
+   * Adds the toggle hint target.
+   */
+  initMembers()
+  {
+    // initialize the original members.
+    super.initMembers();
+
+    // initialize our own members.
+    this._toggleHintTarget = String.empty;
+  }
+
+  //region draw
+  /**
+   * Draws the actor face in the ribbon.
+   */
+  drawActorRibbon()
+  {
+    // perform original logic.
+    super.drawActorRibbon();
+
+    // also draw the actor's name.
+    this.drawActorName();
+
+    // also draw the view-toggle hint if we have a target.
+    this.drawHint();
+  }
+
+  /**
+   * Draws the actor's name.
+   */
+  drawActorName()
+  {
+    // grab the actor.
+    const actor = this.actor();
+
+    // grab the coordinates of the face.
+    const [ x, y ] = this.faceCoordinates();
+
+    // grab the size of the face.
+    const [ w ] = this.faceSize();
+
+    // identify the name of the actor.
+    const name = actor.name();
+
+    // calculate the position.
+    const nameX = x + w + 16;
+    const nameWidth = this.contents.measureTextWidth(name);
+
+    // draw the name.
+    this.drawText(name, nameX, y, nameWidth);
+  }
+
+  /**
+   * Draws the hint for the current view.
+   */
+  drawHint()
+  {
+    // also draw the view-toggle hint if we have a target.
+    const target = this.toggleHintTarget();
+
+    // build the hint string using your icon indices.
+    const hint = `\\I[2450]/\\I[2434]: see ${target}.`;
+
+    // compute the width available to the right of the face.
+    const textW = this.contents.measureTextWidth(hint);
+
+    // grab the coordinates and size of the face to anchor our text.
+    const [ x, y ] = this.faceCoordinates();
+    const [ w, h ] = this.faceSize();
+
+    // compute the starting x for text to the right of the face.
+    const textX = x + 64;
+
+    // compute the y such that it sits beneath the name, inside the ribbon.
+    const textY = y + h;
+
+    // draw the hint using textEx so icons render correctly.
+    this.drawTextEx(hint, textX, textY, textW);
+  }
+
+  //endregion draw
+}
+
+//endregion Window_AptitudeRibbon

--- a/src/plugins/apt/core/windows/Window_AptitudeSourceDetails.js
+++ b/src/plugins/apt/core/windows/Window_AptitudeSourceDetails.js
@@ -1,0 +1,426 @@
+//region Window_AptitudeSourceDetails
+/**
+ * A window displaying details about a specific aptitude source.
+ */
+class Window_AptitudeSourceDetails
+  extends Window_Base
+{
+  //region properties
+  /**
+   * The actor bound to this window.
+   * @type {Game_Actor|null}
+   */
+  _actor = null;
+
+  /**
+   * The source bound to this window.
+   * @type {RPG_Actor|RPG_Class|RPG_EquipItem|RPG_Weapon|RPG_Armor|RPG_Skill|RPG_State|null}
+   */
+  _source = null;
+
+  /**
+   * The y position of the next block to draw.
+   * @type {number}
+   */
+  _nextY = 0;
+
+  //endregion properties
+
+  //region init
+  /**
+   * Constructor.
+   * @param {Rectangle} rect The rectangle to draw the window in.
+   */
+  constructor(rect)
+  {
+    // call parent ctor.
+    super(rect);
+
+    // initialize members.
+    this.initMembers();
+
+    // draw initial contents.
+    this.refresh();
+  }
+
+  /**
+   * Initializes the members of this window.
+   */
+  initMembers()
+  {
+    // initialize the actor.
+    this._actor = null;
+
+    // initialize the source.
+    this._source = null;
+
+    // initialize the next y position.
+    this._nextY = 0;
+  }
+
+  //endregion init
+
+  //region accessors
+  /**
+   * Gets the actor that is bound to this window.
+   * @returns {Game_Actor|null}
+   */
+  actor()
+  {
+    return this._actor;
+  }
+
+  /**
+   * Sets the actor for this window.
+   * @param {Game_Actor} actor The actor to bind.
+   */
+  setActor(actor)
+  {
+    this._actor = actor;
+  }
+
+  /**
+   * Gets the source that is bound to this window.
+   * @returns {RPG_Actor|RPG_Class|RPG_EquipItem|RPG_Weapon|RPG_Armor|RPG_Skill|RPG_State|null}
+   */
+  source()
+  {
+    return this._source;
+  }
+
+  /**
+   * Sets the source for this window.
+   * @param {RPG_Actor|RPG_Class|RPG_EquipItem|RPG_Weapon|RPG_Armor|RPG_Skill|RPG_State} source The new source.
+   */
+  setSource(source)
+  {
+    // do nothing if the source is unchanged.
+    if (this.source() === source) return;
+
+    // update the source.
+    this._source = source;
+
+    // refresh the contents for the new source.
+    this.refresh();
+  }
+
+  /**
+   * The y position of the next block to draw.
+   * @returns {number}
+   */
+  nextY()
+  {
+    return this._nextY || 0;
+  }
+
+  /**
+   * Sets the next y position for drawing.
+   * @param {number} y The y position to set.
+   */
+  setNextY(y)
+  {
+    this._nextY = y;
+  }
+
+  //endregion accessors
+
+  //region draw
+  /**
+   * Implements {@link #drawContent}.<br/>
+   * Draws the details for the selected source.
+   */
+  drawContent()
+  {
+    if (!this.source() || !this.actor())
+    {
+      // render a default hint.
+      this.resetTextColor();
+      this.drawText('Select a source from the list.', 0, 0, this.contentsWidth());
+      return;
+    }
+
+    // reset the next y position.
+    this.setNextY(0);
+
+    // draw the header.
+    this.drawHeader();
+
+    // draw the learnable skills from the source.
+    this.drawDetails();
+  }
+
+  /**
+   * Draws the header containing the icon and name.
+   */
+  drawHeader()
+  {
+    // grab the source data.
+    const source = this.source();
+
+    // y anchor for the header.
+    let y = this.nextY();
+
+    if (source.iconIndex > 0)
+    {
+      this.drawIcon(source.iconIndex, 0, y);
+    }
+
+    // compute a left indent if we drew an icon.
+    const left = (source.iconIndex > 0)
+      ? 36
+      : 0;
+
+    // draw the name of the source.
+    this.changeTextColor(this.systemColor());
+    this.drawText(`${source.name}`, left, y, this.contentsWidth() - left);
+
+    // advance y.
+    y += this.lineHeight();
+
+    // default the description to an empty string.
+    let description = String.empty;
+
+    // actors use their profile as the description.
+    if (source.isActor())
+    {
+      description = source.profile;
+    }
+    // classes simply don't have a description.
+    else if (source.isClass())
+    {
+      description = 'The class applied to the current actor.';
+    }
+    // states also don't have a description.
+    else if (source.isState())
+    {
+      description = 'A state applied to the actor.';
+    }
+    // the rest of the possibilities do, though.
+    else
+    {
+      ({ description } = source);
+    }
+
+    // render the description.
+    const wrappedText = this.modFontSizeForText(-4, description);
+    this.drawTextEx(wrappedText, 0, y, this.contentsWidth());
+
+    // update the nextY coordinate.
+    y += this.lineHeight() * 3;
+    this.setNextY(y);
+  }
+
+  drawDetails()
+  {
+    // grab the source data.
+    const source = this.source();
+
+    // establish a y anchor somewhat below the gauges.
+    const baseY = this.nextY();
+
+    // header label for the section.
+    this.drawTextEx(`\\I[79]\\C[16]Skills\\C[0]`, 0, baseY, this.contentsWidth());
+
+    // compute the starting y for rows.
+    const updatedY = baseY + this.lineHeight();
+    this.setNextY(updatedY);
+
+    // extract all the teachables for this source.
+    const teachables = source.aptitudeTeachings;
+
+    // check if we are lacking in teachables.
+    if (teachables.length === 0)
+    {
+      // render a friendly hint.
+      this.resetTextColor();
+      this.drawText('No teachable skills available.', 0, this.nextY(), this.contentsWidth());
+
+      // stop processing.
+      return;
+    }
+
+    // grab the actor.
+    const actor = this.actor();
+
+    // derive the key from the source.
+    const sourceKey = ApManager.deriveKey(source);
+
+    // iterate over the teachables and draw the details for each.
+    teachables.forEach(teachable =>
+    {
+      // default with 0 for the x coordinate.
+      const x = 0;
+
+      // start with the nextY.
+      const nextY = this.nextY();
+
+      // calculate the left column width for the icon+label.
+      const leftW = Math.floor(this.contentsWidth() * 0.60);
+
+      // extract the AP required to learn this skill.
+      const { requiredAp, skillId } = teachable;
+
+      // identify the skill.
+      const skill = actor.skill(skillId);
+
+      // determine if the actor is learning this teachable.
+      const learning = actor.getAptitudeLearning(sourceKey, skillId);
+
+      // identify if the learning exists or not.
+      const hasLearning = learning !== null;
+
+      // render the learnable skill name.
+      this.drawTextEx(`\\I[${skill.iconIndex}]${skill.name}`, x, nextY, this.contentsWidth());
+
+      // determine the current AP count for this skill.
+      const currentAp = hasLearning
+        ? learning.currentAp
+        : 0;
+
+      // determine learned state for this specific source.
+      const learned = hasLearning && learning.isLearned() === true;
+
+      // determine if the actor already knows the skill via some other source.
+      const knownElsewhere = (learned === false) &&
+        this.actor()
+          .hasSkill(skillId);
+
+      // decide the right-side text content.
+      let rightText = '';
+      if (learned === true)
+      {
+        // if learned from this source, show DONE.
+        rightText = 'DONE';
+      }
+      else if (knownElsewhere === true)
+      {
+        // if not learned from this source but the actor already knows the skill, show KNOWN.
+        rightText = 'KNOWN';
+      }
+      else
+      {
+        // otherwise, show the current/required AP counts.
+        rightText = `${currentAp}/${requiredAp}`;
+      }
+
+      // decide the right-side color index.
+      let rightColor = 7; // gray by default
+      if (learned === true)
+      {
+        // green when learned.
+        rightColor = 11;
+      }
+      else if (currentAp > 0)
+      {
+        // yellow when in-progress.
+        rightColor = 6;
+      }
+
+      // apply the right-side color and draw the right-aligned status text.
+      this.changeTextColor(ColorManager.textColor(rightColor));
+      const rightW = this.contentsWidth() - leftW;
+      this.drawText(rightText, 0, nextY, rightW, Window_Base.TextAlignments.Right);
+
+      // Only draw a gauge if the skill is neither DONE nor KNOWN.
+      const shouldDrawGauge = learned === false && knownElsewhere === false;
+      if (shouldDrawGauge === true)
+      {
+        // compute the gauge rectangle centered vertically within the row.
+        const gaugeX = Math.floor(this.contentsWidth() * 0.40);
+        const gaugeY = nextY + Math.round(this.lineHeight() / 2) - Math.round(this.gaugeHeight() / 2);
+        const rect = new Rectangle(gaugeX, gaugeY, this.gaugeWidth(), this.gaugeHeight());
+
+        // compute the rate between 0..1 for the gauge.
+        const progressRate = Math.max(0, Math.min(currentAp / requiredAp, 1));
+
+        // build the gauge options with a dynamic segment count and colors.
+        const segOpts = WindowGaugeOptions.Builder()
+          .gaugeType(Window_Base.GAUGE_TYPES.Segmented)
+          .segments(Math.max(1, Math.ceil(requiredAp / this.segmentValue())))
+          .gap(2)
+          .leftGradientColor(this.gaugeColor1())
+          .rightGradientColor(this.gaugeColor2())
+          .build();
+
+        // draw the segmented gauge.
+        this.drawGauge(rect, progressRate, segOpts);
+      }
+
+      // and add a line for the next row.
+      this.setNextY(nextY + this.lineHeight());
+    });
+  }
+
+  //endregion draw
+
+  //region helpers
+  /**
+   * The width of the gauges in this window.
+   * @returns {number}
+   */
+  gaugeWidth()
+  {
+    return 256;
+  }
+
+  /**
+   * The height of the gauges in this window.
+   * @returns {number}
+   */
+  gaugeHeight()
+  {
+    return 12;
+  }
+
+  /**
+   * The back color of the gauges in this window.
+   * @returns {string}
+   */
+  gaugeBackColor()
+  {
+    return 'rgba(255, 255, 255, 0.1)';
+  }
+
+  /**
+   * The color to gradient from.
+   * Defaults to blue.
+   * @returns {string}
+   */
+  gaugeColor1()
+  {
+    return 'rgba(179, 89, 0, 1)';
+  }
+
+  /**
+   * The color to gradient into.
+   * Defaults to green.
+   * @returns {string}
+   */
+  gaugeColor2()
+  {
+    return 'rgba(255, 166, 77, 1)';
+  }
+
+  inactiveColor1()
+  {
+    return 'rgba(77, 77, 77, 1)';
+  }
+
+  inactiveColor2()
+  {
+    return 'rgba(153, 153, 153, 1)';
+  }
+
+  /**
+   * The amount that one segment represents.
+   * @returns {number}
+   */
+  segmentValue()
+  {
+    return 10;
+  }
+
+  //endregion helpers
+}
+
+//endregion Window_AptitudeSourceDetails

--- a/src/plugins/apt/core/windows/Window_AptitudeSourceList.js
+++ b/src/plugins/apt/core/windows/Window_AptitudeSourceList.js
@@ -1,0 +1,154 @@
+//region Window_AptitudeSourceList
+/**
+ * A window listing all aptitude sources currently applied to the actor.
+ */
+class Window_AptitudeSourceList
+  extends Window_Command
+{
+  //region properties
+  /**
+   * The actor bound to this window.
+   * @type {Game_Actor|null}
+   */
+  _actor = null;
+
+  /**
+   * The list of sources bound to this window.
+   * @type {(RPG_Actor|RPG_Class|RPG_EquipItem|RPG_Weapon|RPG_Armor|RPG_Skill|RPG_State)[]}
+   */
+  _sources = [];
+
+  //endregion properties
+
+  //region init
+  constructor(rect)
+  {
+    // call parent ctor.
+    super(rect);
+
+    // initialize members.
+    this.initMembers();
+  }
+
+  /**
+   * Initializes the members of this window.
+   */
+  initMembers()
+  {
+    // initialize the actor.
+    this._actor = null;
+
+    // initialize the sources bucket.
+    this._sources = [];
+  }
+
+  //endregion init
+
+  //region accessors
+  /**
+   * Gets the actor that is bound to this window.
+   * @returns {Game_Actor|null}
+   */
+  actor()
+  {
+    return this._actor;
+  }
+
+  /**
+   * Sets the actor for this window.
+   * @param {Game_Actor} actor The actor to bind.
+   */
+  setActor(actor)
+  {
+    this._actor = actor;
+  }
+
+  /**
+   * The
+   * @returns {(RPG_Actor|RPG_Class|RPG_EquipItem|RPG_Weapon|RPG_Armor|RPG_Skill|RPG_State)[]}
+   */
+  sources()
+  {
+    return this._sources || [];
+  }
+
+  /**
+   * Sets the sources for this window.
+   * @param {(RPG_Actor|RPG_Class|RPG_EquipItem|RPG_Weapon|RPG_Armor|RPG_Skill|RPG_State)[]} sources The new sources.
+   */
+  setSources(sources)
+  {
+    // assign the sources.
+    this._sources = sources;
+
+    // rebuild the command list with the new data.
+    this.refresh();
+  }
+
+  //endregion accessors
+
+  /**
+   * Rebuilds the command list for the current actor.
+   */
+  makeCommandList()
+  {
+    // if we don’t have an actor, there is nothing to build.
+    if (this.actor() === null) return;
+
+    // build all commands for this window.
+    const commands = this.buildCommands();
+
+    // add all built commands to this window.
+    commands.forEach(this.addBuiltCommand, this);
+  }
+
+  /**
+   * Builds all commands for this command window.
+   * @returns {BuiltWindowCommand[]}
+   */
+  buildCommands()
+  {
+    // grab all the sources to build commands for.
+    const sources = this.sources();
+
+    // if no sources, nothing to render.
+    if (sources.length === 0) return [];
+
+    // build each command based on the source.
+    const commands = sources.map(this.buildCommand, this);
+
+    // return the built command set.
+    return commands;
+  }
+
+  /**
+   * Builds a single command for the given source.
+   * @param {RPG_Actor|RPG_Class|RPG_EquipItem|RPG_Weapon|RPG_Armor|RPG_Skill|RPG_State} source The source.
+   * @returns {BuiltWindowCommand}
+   */
+  buildCommand(source)
+  {
+    let { iconIndex } = source;
+
+    // actors don't normally have an icon index, so lets give em one.
+    if (source.isActor())
+    {
+      iconIndex = 2727;
+    }
+    // classes also don't normally have an icon index, so lets give em one.
+    else if (source.isClass())
+    {
+      iconIndex = 2694;
+    }
+
+    const builtWindowCommand = new WindowCommandBuilder(source.name)
+      .setSymbol(`source:${source.implementationType()}`)
+      .setExtensionData(source)
+      .setIconIndex(iconIndex)
+      .build();
+
+    return builtWindowCommand;
+  }
+}
+
+//endregion Window_AptitudeSourceList

--- a/src/plugins/apt/core/windows/Window_MenuCommand.js
+++ b/src/plugins/apt/core/windows/Window_MenuCommand.js
@@ -1,0 +1,29 @@
+//region Window_MenuCommand
+/**
+ * Extends {@link #addOriginalCommands}.</br>
+ * Adds the Aptitude menu command if enabled via plugin parameter.
+ */
+J.APT.Aliased.Window_MenuCommand.set('addOriginalCommands', Window_MenuCommand.prototype.addOriginalCommands);
+Window_MenuCommand.prototype.addOriginalCommands = function()
+{
+  // perform original logic.
+  J.APT.Aliased.Window_MenuCommand.get('addOriginalCommands')
+    .call(this);
+
+  // add the APT menu command if enabled via plugin parameter.
+  const switchId = J.APT.Metadata.menuSwitchId;
+
+  // if no switch configured or the switch is ON, show the command.
+  if (switchId === 0 || $gameSwitches.value(switchId))
+  {
+    // build the command.
+    const builtCommand = new WindowCommandBuilder('Aptitude')
+      .setSymbol('aptitude')
+      .setIconIndex(186)
+      .build();
+
+    // add the command to the menu.
+    this.addBuiltCommand(builtCommand);
+  }
+};
+//endregion Window_MenuCommand

--- a/src/plugins/hud/ext/input/sprites/Sprite_CooldownGauge.js
+++ b/src/plugins/hud/ext/input/sprites/Sprite_CooldownGauge.js
@@ -135,7 +135,7 @@ class Sprite_CooldownGauge
    */
   gaugeColor1()
   {
-    return "rgba(0, 0, 255, 1)";
+    return 'rgba(0, 0, 255, 1)';
   }
 
   /**
@@ -145,7 +145,7 @@ class Sprite_CooldownGauge
    */
   gaugeColor2()
   {
-    return "rgba(0, 255, 0, 1)";
+    return 'rgba(0, 255, 0, 1)';
   }
 
   /**
@@ -155,7 +155,7 @@ class Sprite_CooldownGauge
    */
   gaugeBackColor()
   {
-    return "rgba(0, 0, 0, 0.5)";
+    return 'rgba(0, 0, 0, 0.5)';
   }
 
   /**
@@ -339,6 +339,7 @@ class Sprite_CooldownGauge
       fillW,                // the width to fill.
       fillH,                // the hieght to fill.
       this.gaugeColor1(),   // the color gradient to start with.
-      this.gaugeColor2());  // the color gradient to end with.
+      this.gaugeColor2()
+    );  // the color gradient to end with.
   }
 }

--- a/src/plugins/level/managers/LevelScaling.js
+++ b/src/plugins/level/managers/LevelScaling.js
@@ -2,6 +2,7 @@
 /**
  * A helper class for calculating level-based scaling multipliers.
  */
+// eslint-disable-next-line no-unused-vars
 class LevelScaling
 {
   //region properties
@@ -55,7 +56,7 @@ class LevelScaling
    */
   constructor()
   {
-    throw new Error("This is a static class.");
+    throw new Error('This is a static class.');
   }
 
   /**

--- a/src/plugins/level/objects/Game_Actor.js
+++ b/src/plugins/level/objects/Game_Actor.js
@@ -165,7 +165,8 @@ Game_Actor.prototype.getLevelSources = function()
     ...this.equips(),
 
     // add all currently applied states to the source list.
-    ...this.allStates(), ];
+    ...this.allStates(),
+  ];
 };
 
 /**

--- a/src/plugins/log/_models/ActionLogBuilder.js
+++ b/src/plugins/log/_models/ActionLogBuilder.js
@@ -8,7 +8,7 @@ class ActionLogBuilder
    * The current message that this log contains.
    * @type {string}
    */
-  #message = "message-unset";
+  #message = 'message-unset';
 
   /**
    * Builds the log based on the currently provided info.
@@ -81,14 +81,14 @@ class ActionLogBuilder
     if (isCritical)
     {
       hurtOrHeal = isHealing
-        ? "critically healed"
-        : "landed a critical";
+        ? 'critically healed'
+        : 'landed a critical';
     }
     else
     {
       hurtOrHeal = isHealing
-        ? "healed"
-        : "hit";
+        ? 'healed'
+        : 'hit';
     }
 
     // the text color index is based on whether or not its flagged as healing.
@@ -117,14 +117,14 @@ class ActionLogBuilder
     if (isCritical)
     {
       hurtOrHeal = isHealing
-        ? "critically healed"
-        : "devastatingly damaged";
+        ? 'critically healed'
+        : 'devastatingly damaged';
     }
     else
     {
       hurtOrHeal = isHealing
-        ? "restored"
-        : "struck";
+        ? 'restored'
+        : 'struck';
     }
 
     // the text color index is based on whether or not its flagged as healing.
@@ -261,11 +261,11 @@ class ActionLogBuilder
 
     // construct the message.
     const prefix = isPreciseParry
-      ? "precise-"
-      : "";
+      ? 'precise-'
+      : '';
     const suffix = isPreciseParry
-      ? " with finesse!"
-      : ".";
+      ? ' with finesse!'
+      : '.';
     const message = `${defender} ${prefix}parried ${casterName}'s \\Skill[${skillId}]${suffix}`;
 
     // assign the message to this log.

--- a/src/plugins/popups/_models/TextPopBuilder.js
+++ b/src/plugins/popups/_models/TextPopBuilder.js
@@ -360,13 +360,13 @@ class TextPopBuilder
     if (elementalRate < 1)
     {
       // add an arbitrary elipses at the end of the damage.
-      this.setSuffix("...");
+      this.setSuffix('...');
     }
     // check if the rate is above 1, such as 1.5 aka 150% damage.
     else if (elementalRate > 1)
     {
       // add an arbitrary triple bang at the end of the damage.
-      this.setSuffix("!!!");
+      this.setSuffix('!!!');
     }
 
     // return the builder for continuous building.

--- a/src/plugins/sdp/windows/Window_SdpPoints.js
+++ b/src/plugins/sdp/windows/Window_SdpPoints.js
@@ -66,7 +66,7 @@ class Window_SdpPoints
     const x = 240;
     const y = 0;
     const textWidth = 300;
-    const alignment = "left";
+    const alignment = 'left';
     this.drawText(points, x, y, textWidth, alignment);
   }
 
@@ -79,8 +79,13 @@ class Window_SdpPoints
     if (!this._actor) return;
 
     this.drawFace(
-      this._actor.faceName(), this._actor.faceIndex(), 0, 0,   // x,y
-      128, 40);// w,h
+      this._actor.faceName(),
+      this._actor.faceIndex(),
+      0,
+      0,
+      128,
+      40
+    );
   }
 
   /**


### PR DESCRIPTION
## `J-Aptitude` implementation
Implements a basic AP system (similar to that found in various games). Things that are on the actor (the actor itself, its class, its equips, any applied states) are all considered "sources" that can potentially have "teachables" on them, that allow an actor to learn said skills for the defined number of AP. AP is gained either from enemy defeat (regular battle or JABS), or plugin commands. This implements the system as a "core" with expectation of extension plugins to come next.

## `J-BASE` patch updates
- Extended database object type-checking.
- Added API for deterministic unique identifier generation on database objects (as a string).
- Added gauge drawing into the `Window_Base` class.
- Added API for `Game_Party` and `Game_Actor` classes to directly set a level.

## `J-HUD-InputFrame` cleanup updates
Cleaned up some quotes; no new version.

## `J-LevelMaster` cleanup updates
Cleaned up some quotes; no new version.

## `J-Log` cleanup updates
Cleaned up some quotes; no new version.

## `J-SDP` cleanup updates
Cleaned up some weird line breaks; no new version.

## `J-TextPops` cleanup updates
Cleaned up some quotes; no new version.