### PR TITLE
cleanup: JABS phase 1 style normalization

### DIFF
--- a/project/js/plugins/abs/J-ABS.js
+++ b/project/js/plugins/abs/J-ABS.js
@@ -14,13 +14,41 @@ class JABS_Aabb
    */
   constructor(x, y, w, h)
   {
-    /** @type {number} */ this.x = x; // top-left x in pixels.
-    /** @type {number} */ this.y = y; // top-left y in pixels.
-    /** @type {number} */ this.w = w; // width in pixels.
-    /** @type {number} */ this.h = h; // height in pixels.
+    /**
+     * The top-left x coordinate in pixels.
+     * @type {number}
+     */
+    this.x = x;
 
-    /** @type {number} */ this.cx = x + (w / 2); // center x in pixels.
-    /** @type {number} */ this.cy = y + (h / 2); // center y in pixels.
+    /**
+     * The top-left y coordinate in pixels.
+     * @type {number}
+     */
+    this.y = y;
+
+    /**
+     * The width in pixels.
+     * @type {number}
+     */
+    this.w = w;
+
+    /**
+     * The height in pixels.
+     * @type {number}
+     */
+    this.h = h;
+
+    /**
+     * The center x coordinate in pixels.
+     * @type {number}
+     */
+    this.cx = x + (w / 2);
+
+    /**
+     * The center y coordinate in pixels.
+     * @type {number}
+     */
+    this.cy = y + (h / 2);
   }
 
   /**
@@ -33,8 +61,10 @@ class JABS_Aabb
    */
   static fromFeet(feetX, feetY, tw, th)
   {
-    const x = feetX - (tw / 2); // left edge half a tile left of feet.
-    const y = feetY - th;       // top edge one tile above feet.
+    // left edge half a tile left of feet.
+    const x = feetX - (tw / 2);
+    // top edge one tile above feet.
+    const y = feetY - th;
     return new JABS_Aabb(x, y, tw, th);
   }
 
@@ -414,10 +444,9 @@ class JABS_Action
     const event = this.getActionSprite();
 
     // check if the action has an animation to play before destroying.
-    if (this.hasSelfAnimationId())
+    if (this.hasSelfAnimationId() && event)
     {
-      // play it on oneself.
-      event?.requestAnimation(this.getSelfAnimationId());
+      event.requestAnimation(this.getSelfAnimationId());
     }
   }
 
@@ -581,8 +610,10 @@ class JABS_Action
   {
     const damageType = this.getBaseSkill().damage.type;
     return [
-      3, // HP recover
-      4, // MP recover
+      // hP recover.
+      3,
+      // mP recover.
+      4,
     ].includes(damageType);
   }
 
@@ -1213,7 +1244,8 @@ class JABS_Action
     // this allows sprite-less actions to still render a pulse anchored to the caster.
     let originX = 0;
     let originY = 0;
-    let facing = 2; // default to down as a safe fallback.
+    // default to down as a safe fallback.
+    let facing = 2;
 
     // attempt to use the action event for origin and facing when present.
     if (actionEvent)
@@ -2286,7 +2318,8 @@ JABS_Battler.prototype.initCoreData = function(battlerCoreData)
    * @type {boolean}
    */
   this._canIdle = battlerCoreData.isInanimate()
-    ? false // don't move idly if inanimate.
+    // don't move idly if inanimate.
+    ? false
     : battlerCoreData.canIdle();
 
   /**
@@ -2295,7 +2328,8 @@ JABS_Battler.prototype.initCoreData = function(battlerCoreData)
    * @type {boolean}
    */
   this._showHpBar = battlerCoreData.isInanimate()
-    ? false // don't show hp bar if inanimate.
+    // don't show hp bar if inanimate.
+    ? false
     : battlerCoreData.showHpBar();
 
   /**
@@ -2304,7 +2338,8 @@ JABS_Battler.prototype.initCoreData = function(battlerCoreData)
    * @type {boolean}
    */
   this._showBattlerName = battlerCoreData.isInanimate()
-    ? false // don't show battler name if inanimate.
+    // don't show battler name if inanimate.
+    ? false
     : battlerCoreData.showBattlerName();
 
   /**
@@ -2631,7 +2666,8 @@ JABS_Battler.prototype.initBattleInfo = function()
    * Default window for the in‑combat countdown (60fps × seconds).
    * @type {number}
    */
-  this._inCombatWindowMax = 600; // 10s default.
+  // 10s default.
+  this._inCombatWindowMax = 600;
 };
 
 /**
@@ -3661,15 +3697,18 @@ JABS_Battler.prototype.isDead = function()
   const battler = this.getBattler();
 
   if (!battler)
-  { // has no battler.
+  // has no battler.
+  {
     return true;
   }
   else if (!JABS_AiManager.getBattlerByUuid(battler.getUuid()))
-  { // battler isn't on the map.
+  // battler isn't on the map.
+  {
     return true;
   }
   else if (battler.isDead() || this.isDying())
-  { // battler is actually dead.
+  // battler is actually dead.
+  {
     return true;
   }
   // battler is OK!
@@ -6675,7 +6714,8 @@ JABS_Battler.prototype.applyToolForAllAllies = function(toolId)
   const battlers = $gameParty.battleMembers();
   if (battlers.length > 1)
   {
-    battlers.shift(); // remove the leader, because that's the player.
+    // remove the leader, because that's the player.
+    battlers.shift();
     battlers.forEach(battler =>
     {
       const gameAction = new Game_Action(battler, false);
@@ -7898,10 +7938,14 @@ JABS_Battler.prototype.slipEval = function(formula, sourceBattler, afflictedBatt
 {
   // variables for contextual eval().
   /* eslint-disable no-unused-vars */
-  const a = sourceBattler;        // the one who applied the state.
-  const b = afflictedBattler;     // this battler, afflicted by the state.
-  const v = $gameVariables._data; // access to variables if you need it.
-  const s = state;                // access to the state itself if you need it.
+  // the one who applied the state.
+  const a = sourceBattler;
+  // this battler, afflicted by the state.
+  const b = afflictedBattler;
+  // access to variables if you need it.
+  const v = $gameVariables._data;
+  // access to the state itself if you need it.
+  const s = state;
   /* eslint-enable no-unused-vars */
 
   // initialize the result.
@@ -7994,13 +8038,16 @@ JABS_Battler.prototype.configureSlipPop = function(amount, type)
   // based on the hp/mp/tp type, we apply different visual effects.
   switch (type)
   {
-    case 0: // hp
+    // hp.
+    case 0:
       textPopBuilder.isHpDamage();
       break;
-    case 1: // mp
+    // mp.
+    case 1:
       textPopBuilder.isMpDamage();
       break;
-    case 2: // tp
+    // tp.
+    case 2:
       textPopBuilder.isTpDamage();
       break;
   }
@@ -9861,9 +9908,12 @@ class JABS_EnemyAI
     {
       const testAction = new Game_Action(user.getBattler());
       testAction.setSkill(skillId);
-      return (testAction.isForAliveFriend() &&  // must target living allies.
-        testAction.isRecover() &&               // must recover something.
-        testAction.isHpEffect());               // must affect hp.
+      // must target living allies.
+      return (testAction.isForAliveFriend() &&
+        // must recover something.
+        testAction.isRecover() &&
+        // must affect hp.
+        testAction.isHpEffect());
     });
 
     // if we have 0 or 1 skills left after healing, just return that.
@@ -10937,7 +10987,7 @@ class JABS_Location
    * @param {JABS_Location} sourceLocation The source location to copy the values of.
    * @returns {JABS_Location} A new instance of the same location.
    */
-  static Clone = sourceLocation => new JABS_Location(sourceLocation?.x, sourceLocation?.y, sourceLocation?.d);
+  static Clone = sourceLocation => new JABS_Location(sourceLocation.x, sourceLocation.y, sourceLocation.d);
 
   /**
    * A factory that generates builders for creating {@link JABS_Location}s.
@@ -15495,7 +15545,8 @@ J.ABS.Metadata.UnassignedText = J.ABS.PluginParameters['unassignedText'];
 J.ABS.Metadata.HitboxStyles = {
   // Base defaults used for all shapes unless overridden below.
   base: {
-    fillColor: 0xFFA500, // orange
+    // orange.
+    fillColor: 0xFFA500,
     fillAlpha: 0.35,
     lineColor: 0xE08000,
     lineAlpha: 0.9,
@@ -15505,13 +15556,16 @@ J.ABS.Metadata.HitboxStyles = {
   // Optional per-shape overrides.
   byShape: {
     circle: {
-      fillColor: 0xFF7F50, // coral
+      // coral.
+      fillColor: 0xFF7F50,
     },
     rhombus: {
-      fillColor: 0xFFD580, // light orange
+      // light orange.
+      fillColor: 0xFFD580,
     },
     square: {
-      fillColor: 0xFFA64D, // darker orange
+      // darker orange.
+      fillColor: 0xFFA64D,
     },
     frontsquare: {
       fillAlpha: 0.28,
@@ -15548,7 +15602,8 @@ J.ABS.Metadata.HitboxStyles = {
     {
       colliding:
         {
-          fillColor: 0xFF3B30, // bright red while overlapping an action.
+          // bright red while overlapping an action.
+          fillColor: 0xFF3B30,
           fillAlpha: 0.35,
           lineColor: 0xC12722,
           lineWidth: 3,
@@ -15818,19 +15873,29 @@ J.ABS.Shapes = {
  * Strongly-typed projectile formation names used across JABS.
  */
 J.ABS.ProjectileFormations = {
-  /** A single spoke in the forward direction. */
+  /**
+   * A single spoke in the forward direction.
+   */
   Line: 'line',
 
-  /** Three spokes: forward, forward-left, forward-right. */
+  /**
+   * Three spokes: forward, forward-left, forward-right.
+   */
   Spray: 'spray',
 
-  /** Four cardinals: up, right, down, left. */
+  /**
+   * Four cardinals: up, right, down, left.
+   */
   Cross: 'cross',
 
-  /** Four diagonals: up-right, down-right, down-left, up-left. */
+  /**
+   * Four diagonals: up-right, down-right, down-left, up-left.
+   */
   Xburst: 'xburst',
 
-  /** All eight directions: cardinals + diagonals. */
+  /**
+   * All eight directions: cardinals + diagonals.
+   */
   Nova: 'nova',
 };
 
@@ -15937,11 +16002,13 @@ J.ABS.RegExp = {
   KnockbackResist: /<knockbackResist:[ ]?(\d+)>/gi,
 
   // parry-related.
-  IgnoreParry: /<ignoreParry:[ ]?(\d+)>/gi, //endregion ON EQUIPS
+  IgnoreParry: /<ignoreParry:[ ]?(\d+)>/gi,
+  //endregion ON EQUIPS
 
   //region ON ITEMS
   UseOnPickup: /<useOnPickup>/gi,
-  Expires: /<expires:[ ]?(\d+)>/gi, //endregion ON ITEMS
+  Expires: /<expires:[ ]?(\d+)>/gi,
+  //endregion ON ITEMS
 
   //region ON STATES
   // definition-related.
@@ -15985,7 +16052,8 @@ J.ABS.RegExp = {
   // state duration-related.
   StateDurationFlatPlus: /<stateDurationFlat:[ ]?([-+]?\d+)>/gi,
   StateDurationPercentPlus: /<stateDurationPerc:[ ]?([-+]?\d+)>/gi,
-  StateDurationFormulaPlus: /<stateDurationForm:\[([+\-*/ ().\w]+)]>/gi, //endregion ON STATES
+  StateDurationFormulaPlus: /<stateDurationForm:\[([+\-*/ ().\w]+)]>/gi,
+  //endregion ON STATES
 
   //region ON BATTLERS
   // core concepts.
@@ -16022,7 +16090,8 @@ J.ABS.RegExp = {
   ConfigInvincible: /<jabsConfig:[ ]?invincible>/i,
   ConfigNotInvincible: /<jabsConfig:[ ]?notInvincible>/i,
   ConfigNoName: /<jabsConfig:[ ]?noName>/i,
-  ConfigShowName: /<jabsConfig:[ ]?showName>/i, //endregion ON BATTLERS
+  ConfigShowName: /<jabsConfig:[ ]?showName>/i,
+  //endregion ON BATTLERS
 
   //region ON ACTORS/CLASSES
   ConfigNoSwitch: /<noSwitch>/i,
@@ -16034,12 +16103,18 @@ J.ABS.RegExp = {
  * Visual customization for action sprites (per-skill).
  * All tags are optional and purely visual; physics/hitboxes remain unchanged.
  */
-J.ABS.RegExp.VisOffset = /<visOffset:[ ]?(\[-?\d+,[ ]?-?\d+])>/gi; // capture full [x, y]
-J.ABS.RegExp.VisAnchor = /<visAnchor:[ ]?(\[(?:0|1|0?\.\d+),[ ]?(?:0|1|0?\.\d+)])>/gi; // capture full [ax, ay]
-J.ABS.RegExp.VisRotate = /<visRotate>/gi; // boolean
-J.ABS.RegExp.VisScale = /<visScale:[ ]?(\[-?\d+(?:\.\d+)?,[ ]?-?\d+(?:\.\d+)?])>/gi; // capture full [sx, sy]
-J.ABS.RegExp.VisZ = /<visZ:[ ]?(-?\d+)>/gi; // z-order override (number only)
-J.ABS.RegExp.VisDebug = /<visDebug>/gi; // show visual center/debug gizmo
+// capture full [x, y].
+J.ABS.RegExp.VisOffset = /<visOffset:[ ]?(\[-?\d+,[ ]?-?\d+])>/gi;
+// capture full [ax, ay].
+J.ABS.RegExp.VisAnchor = /<visAnchor:[ ]?(\[(?:0|1|0?\.\d+),[ ]?(?:0|1|0?\.\d+)])>/gi;
+// boolean.
+J.ABS.RegExp.VisRotate = /<visRotate>/gi;
+// capture full [sx, sy].
+J.ABS.RegExp.VisScale = /<visScale:[ ]?(\[-?\d+(?:\.\d+)?,[ ]?-?\d+(?:\.\d+)?])>/gi;
+// z-order override (number only).
+J.ABS.RegExp.VisZ = /<visZ:[ ]?(-?\d+)>/gi;
+// show visual center/debug gizmo.
+J.ABS.RegExp.VisDebug = /<visDebug>/gi;
 //endregion visual metadata (new)
 
 //region visual directional metadata (new)
@@ -16049,16 +16124,24 @@ J.ABS.RegExp.VisDebug = /<visDebug>/gi; // show visual center/debug gizmo
  * Cardinal: U/D/L/R
  * Optional diagonals: UR/UL/DR/DL
  */
-J.ABS.RegExp.VisOffsetU = /<visOffsetU:[ ]?(\[-?\d+,[ ]?-?\d+])>/gi;  // [x, y]
-J.ABS.RegExp.VisOffsetD = /<visOffsetD:[ ]?(\[-?\d+,[ ]?-?\d+])>/gi;  // [x, y]
-J.ABS.RegExp.VisOffsetL = /<visOffsetL:[ ]?(\[-?\d+,[ ]?-?\d+])>/gi;  // [x, y]
-J.ABS.RegExp.VisOffsetR = /<visOffsetR:[ ]?(\[-?\d+,[ ]?-?\d+])>/gi;  // [x, y]
+// [x, y].
+J.ABS.RegExp.VisOffsetU = /<visOffsetU:[ ]?(\[-?\d+,[ ]?-?\d+])>/gi;
+// [x, y].
+J.ABS.RegExp.VisOffsetD = /<visOffsetD:[ ]?(\[-?\d+,[ ]?-?\d+])>/gi;
+// [x, y].
+J.ABS.RegExp.VisOffsetL = /<visOffsetL:[ ]?(\[-?\d+,[ ]?-?\d+])>/gi;
+// [x, y].
+J.ABS.RegExp.VisOffsetR = /<visOffsetR:[ ]?(\[-?\d+,[ ]?-?\d+])>/gi;
 
 // Optional diagonals for future use.
-J.ABS.RegExp.VisOffsetUR = /<visOffsetUR:[ ]?(\[-?\d+,[ ]?-?\d+])>/gi; // [x, y]
-J.ABS.RegExp.VisOffsetUL = /<visOffsetUL:[ ]?(\[-?\d+,[ ]?-?\d+])>/gi; // [x, y]
-J.ABS.RegExp.VisOffsetDR = /<visOffsetDR:[ ]?(\[-?\d+,[ ]?-?\d+])>/gi; // [x, y]
-J.ABS.RegExp.VisOffsetDL = /<visOffsetDL:[ ]?(\[-?\d+,[ ]?-?\d+])>/gi; // [x, y]
+// [x, y].
+J.ABS.RegExp.VisOffsetUR = /<visOffsetUR:[ ]?(\[-?\d+,[ ]?-?\d+])>/gi;
+// [x, y].
+J.ABS.RegExp.VisOffsetUL = /<visOffsetUL:[ ]?(\[-?\d+,[ ]?-?\d+])>/gi;
+// [x, y].
+J.ABS.RegExp.VisOffsetDR = /<visOffsetDR:[ ]?(\[-?\d+,[ ]?-?\d+])>/gi;
+// [x, y].
+J.ABS.RegExp.VisOffsetDL = /<visOffsetDL:[ ]?(\[-?\d+,[ ]?-?\d+])>/gi;
 //endregion visual directional metadata (new)
 
 //region cast preview tags
@@ -16308,7 +16391,9 @@ PluginManager.registerCommand(J.ABS.Metadata.Name, "Spawn Loot", args =>
   const parsedArmors = JSON.parse(lootArmorIds)
     .map(id => $dataArmors.at(parseInt(id)));
   const parsedAnimationId = parseInt(spawnAnimationId);
-  /** @type {Game_Event} */
+  /**
+   * @type {Game_Event}
+   */
   let lastDropped = null;
 
   // iterate and drop all the item loot.
@@ -17710,27 +17795,36 @@ Object.defineProperty(RPG_Skill.prototype, 'jabsVisOffsetDL', {
 RPG_Skill.prototype.getJabsVisOffsetFor = function(direction)
 {
   // start from the default offset (may be [0, 0]).
-  const def = this.jabsVisOffset; // default visual offset.
+  // default visual offset.
+  const def = this.jabsVisOffset;
 
   // resolve directional override if present.
   switch (direction)
   {
-    case 8: // UP
+    // uP.
+    case 8:
       return this.jabsVisOffsetU || def || [ 0, 0 ];
-    case 2: // DOWN
+    // dOWN.
+    case 2:
       return this.jabsVisOffsetD || def || [ 0, 0 ];
-    case 4: // LEFT
+    // lEFT.
+    case 4:
       return this.jabsVisOffsetL || def || [ 0, 0 ];
-    case 6: // RIGHT
+    // rIGHT.
+    case 6:
       return this.jabsVisOffsetR || def || [ 0, 0 ];
 
-    case 9: // UP-RIGHT
+    // uP-RIGHT.
+    case 9:
       return this.jabsVisOffsetUR || this.jabsVisOffsetU || this.jabsVisOffsetR || def || [ 0, 0 ];
-    case 7: // UP-LEFT
+    // uP-LEFT.
+    case 7:
       return this.jabsVisOffsetUL || this.jabsVisOffsetU || this.jabsVisOffsetL || def || [ 0, 0 ];
-    case 3: // DOWN-RIGHT
+    // dOWN-RIGHT.
+    case 3:
       return this.jabsVisOffsetDR || this.jabsVisOffsetD || this.jabsVisOffsetR || def || [ 0, 0 ];
-    case 1: // DOWN-LEFT
+    // dOWN-LEFT.
+    case 1:
       return this.jabsVisOffsetDL || this.jabsVisOffsetD || this.jabsVisOffsetL || def || [ 0, 0 ];
   }
 
@@ -18250,7 +18344,7 @@ DataManager.getSkillMasterMap = function()
 DataManager.loadSkillMasterMap = function(name, src)
 {
   const xhr = new XMLHttpRequest();
-  const url = 'data/' + src;
+  const url = `data/${src}`;
   xhr.open('GET', url);
   xhr.overrideMimeType('application/json');
   xhr.onload = () => this.onMapGet(xhr, name, src, url);
@@ -18299,7 +18393,9 @@ DataManager.makeSaveContents = function()
   const contents = J.ABS.Aliased.DataManager.get('makeSaveContents')
     .call(this);
 
-  /** @type {Game_Event[]} */
+  /**
+   * @type {Game_Event[]}
+   */
   const originalEvents = contents.map._events;
 
   const actionlessEvents = originalEvents.map(event =>
@@ -18322,6 +18418,7 @@ DataManager.makeSaveContents = function()
 };
 //endregion
 
+//region JABS_ActionSpawner
 /**
  * The action spawner is responsible for translating projectile directions into
  * fully-formed `JABS_Action` instances, including per-spoke odd/even parallel
@@ -18377,7 +18474,9 @@ class JABS_ActionSpawner
   static buildProjectileCountsByDirection(projectileDirections)
   {
     // initialize the per-direction counts.
-    /** @type {Object.<number, number>} */
+    /**
+     * @type {Object.<number, number>}
+     */
     const totalByDir = {};
 
     // iterate over all projectile directions.
@@ -18406,7 +18505,9 @@ class JABS_ActionSpawner
   static buildOffsetsByDirection(countsByDir)
   {
     // initialize the per-direction offsets.
-    /** @type {Object.<number, number[]>} */
+    /**
+     * @type {Object.<number, number[]>}
+     */
     const offsetsByDir = {};
 
     // iterate over the directions present.
@@ -18537,7 +18638,9 @@ class JABS_ActionSpawner
   )
   {
     // track how many offsets have been consumed per direction.
-    /** @type {Object.<number, number>} */
+    /**
+     * @type {Object.<number, number>}
+     */
     const usedIndexByDir = {};
 
     // a mapping function to build one action for a projectile in a specific direction.
@@ -18599,6 +18702,8 @@ class JABS_ActionSpawner
     return actions;
   }
 }
+//endregion JABS_ActionSpawner
+
 
 //region JABS_AiManager
 /**
@@ -18704,7 +18809,9 @@ class JABS_AiManager
     const nearbyBattlers = this.getAlliedBattlersWithinRange(leaderBattler, leaderBattler.getPursuitRadius());
 
     // the filter function for determining if a battler is a follower to this leader.
-    /** @param battler {JABS_Battler} */
+    /**
+     * @param {JABS_Battler} battler
+     */
     const filtering = battler =>
     {
       // actors are not considered for leader/follower.
@@ -20462,14 +20569,13 @@ class JABS_Engine
       };
     }
 
-    // determine the tile height for vertical correction.
-    const th = $gameMap.tileHeight(); // tile height in pixels.
+    // tile height is needed to vertically center the origin above the feet.
+    const th = $gameMap.tileHeight();
 
-    // compute the corrected origin at the center of the tile above the feet.
-    const x = actionEvent.screenX(); // on-screen x at feet.
-    const y = actionEvent.screenY() - (th / 2); // corrected y above feet.
+    // center the origin one tile above the feet position.
+    const x = actionEvent.screenX();
+    const y = actionEvent.screenY() - (th / 2);
 
-    // provide the computed origin.
     return {
       x,
       y
@@ -20851,7 +20957,9 @@ class JABS_Engine
   getPositiveJabsStatesByUuid(uuid)
   {
     // a filter function defining what is a "positive" state.
-    /** @param {JABS_State} trackedState */
+    /**
+     * @param {JABS_State} trackedState
+     */
     const filtering = trackedState =>
     {
       // if the state is expired, it is not positive.
@@ -21719,7 +21827,8 @@ class JABS_Engine
     actionEventData.uniqueId = action.getUuid();
 
     // default the deletion flag.
-    actionEventData.actionDeleted = false; // not deleted by default.
+    // not deleted by default.
+    actionEventData.actionDeleted = false;
 
     // return the mutated copy.
     return actionEventData;
@@ -22202,78 +22311,110 @@ class JABS_Engine
   addJabsActionToMap(actionEventData, action)
   {
     // find the first available hole in the data map event list.
-    let index = -1; // the index we will insert at.
+    // the index we will insert at.
+    let index = -1;
     for (let i = 0; i < $dataMap.events.length; i++)
     {
       // if an empty spot is found, use that.
       if (!$dataMap.events[i])
       {
-        index = i; // capture the hole index.
-        break; // stop searching.
+        // capture the hole index.
+        index = i;
+        // stop searching.
+        break;
       }
     }
 
     // if no hole was found, append to the end.
     if (index === -1)
     {
-      index = $dataMap.events.length; // assign next index.
+      // assign next index.
+      index = $dataMap.events.length;
     }
 
     // add the data to the $dataMap.events at the chosen index.
-    $dataMap.events[index] = actionEventData; // keep array dense.
-    actionEventData.actionIndex = index; // persist the action index.
+    // keep array dense.
+    $dataMap.events[index] = actionEventData;
+    // persist the action index.
+    actionEventData.actionIndex = index;
 
     // assign this so it exists, but isn't valid.
-    actionEventData.lootIndex = 0; // not a loot event.
+    // not a loot event.
+    actionEventData.lootIndex = 0;
 
     // create the event by hand with this new data.
-    const actionEventSprite = new Game_Event(J.ABS.DefaultValues.ActionMap, index); // construct sprite.
+    // construct sprite.
+    const actionEventSprite = new Game_Event(J.ABS.DefaultValues.ActionMap, index);
 
     const {
       x: actionX,
       y: actionY
-    } = actionEventData; // extract coordinates.
-    actionEventSprite._realX = actionX; // align position.
-    actionEventSprite._realY = actionY; // align position.
-    actionEventSprite._x = actionX; // align grid x.
-    actionEventSprite._y = actionY; // align grid y.
+    // extract coordinates.
+    } = actionEventData;
+    // align position.
+    actionEventSprite._realX = actionX;
+    // align position.
+    actionEventSprite._realY = actionY;
+    // align grid x.
+    actionEventSprite._x = actionX;
+    // align grid y.
+    actionEventSprite._y = actionY;
 
     // give it a name.
-    const skillName = action.getBaseSkill().name; // get skill name.
+    // get skill name.
+    const skillName = action.getBaseSkill().name;
     const casterName = action.getCaster()
-      .battlerName(); // get caster name.
-    actionEventSprite.__actionName = `_${casterName}-${skillName}-${index}`; // tag for debugging/tools.
+      // get caster name.
+      .battlerName();
+    // tag for debugging/tools.
+    actionEventSprite.__actionName = `_${casterName}-${skillName}-${index}`;
 
     // on rare occasions, the timing of adding an action to the map coincides with the removal of the caster.
     if (!actionEventData || !actionEventData.pages.length)
     {
-      console.error('that rare error occurred!'); // preserve existing behavior.
-      return; // stop if invalid.
+      // preserve existing behavior.
+      console.error('that rare error occurred!');
+      // stop if invalid.
+      return;
     }
 
-    const pageIndex = actionEventSprite.findProperPageIndex(); // resolve page index.
+    // resolve page index.
+    const pageIndex = actionEventSprite.findProperPageIndex();
     const {
       characterIndex,
       characterName
-    } = actionEventData.pages[pageIndex].image; // extract image data.
+    // extract image data.
+    } = actionEventData.pages[pageIndex].image;
 
-    actionEventSprite.setActionSpriteNeedsAdding(); // flag to add sprite.
-    actionEventSprite._eventId = actionEventData.id; // assign event id.
-    actionEventSprite._characterName = characterName; // assign sprite name.
-    actionEventSprite._characterIndex = characterIndex; // assign sprite index.
-    const pageData = actionEventData.pages[pageIndex]; // get page.
-    actionEventSprite.setMoveFrequency(pageData.moveFrequency); // frequency.
-    actionEventSprite.setMoveRoute(pageData.moveRoute); // route.
-    actionEventSprite.setCastedDirection($gamePlayer.direction()); // cast facing.
+    // flag to add sprite.
+    actionEventSprite.setActionSpriteNeedsAdding();
+    // assign event id.
+    actionEventSprite._eventId = actionEventData.id;
+    // assign sprite name.
+    actionEventSprite._characterName = characterName;
+    // assign sprite index.
+    actionEventSprite._characterIndex = characterIndex;
+    // get page.
+    const pageData = actionEventData.pages[pageIndex];
+    // frequency.
+    actionEventSprite.setMoveFrequency(pageData.moveFrequency);
+    // route.
+    actionEventSprite.setMoveRoute(pageData.moveRoute);
+    // cast facing.
+    actionEventSprite.setCastedDirection($gamePlayer.direction());
 
     this.applyActionToActionEventSprite(actionEventSprite, action);
 
     // prevent player interaction with the action event.
-    actionEventSprite.start = () => false; // no-op start.
+    // no-op start.
+    actionEventSprite.start = () => false;
 
-    action.setActionSprite(actionEventSprite); // associate back.
-    $gameMap.addEvent(actionEventSprite); // add to map, with hole reuse.
-    this.requestActionRendering = true; // trigger render.
+    // associate back.
+    action.setActionSprite(actionEventSprite);
+    // add to map, with hole reuse.
+    $gameMap.addEvent(actionEventSprite);
+    // trigger render.
+    this.requestActionRendering = true;
   }
 
   /**
@@ -22283,8 +22424,10 @@ class JABS_Engine
    */
   applyActionToActionEventSprite(actionEventSprite, action)
   {
-    actionEventSprite.setJabsAction(action); // wire action.
-    actionEventSprite.setDirection(action.direction()); // facing.
+    // wire action.
+    actionEventSprite.setJabsAction(action);
+    // facing.
+    actionEventSprite.setDirection(action.direction());
   }
 
   /**
@@ -22296,54 +22439,72 @@ class JABS_Engine
   addLootDropToMap(x, y, item)
   {
     // clone the loot data from the action map event id of 1.
-    const lootEventData = JsonEx.makeDeepCopy($actionMap.events[1]); // base template.
+    // base template.
+    const lootEventData = JsonEx.makeDeepCopy($actionMap.events[1]);
 
-    lootEventData.x = x; // position x.
-    lootEventData.y = y; // position y.
+    // position x.
+    lootEventData.x = x;
+    // position y.
+    lootEventData.y = y;
 
     // find the first available hole in the data map event list.
-    let index = -1; // the index we will insert at.
+    // the index we will insert at.
+    let index = -1;
     for (let i = 0; i < $dataMap.events.length; i++)
     {
       // if an empty spot is found, use that.
       if (!$dataMap.events[i])
       {
-        index = i; // capture the hole index.
-        break; // stop searching.
+        // capture the hole index.
+        index = i;
+        // stop searching.
+        break;
       }
     }
 
     // if no hole was found, append to the end.
     if (index === -1)
     {
-      index = $dataMap.events.length; // assign next index.
+      // assign next index.
+      index = $dataMap.events.length;
     }
 
     // add the loot event to the datamap list of events.
-    $dataMap.events[index] = lootEventData; // keep array dense.
-    lootEventData.lootIndex = index; // persist the loot index.
+    // keep array dense.
+    $dataMap.events[index] = lootEventData;
+    // persist the loot index.
+    lootEventData.lootIndex = index;
 
     // create the loot event by hand with this new data.
-    const jabsLootData = new JABS_LootDrop(item); // create loot model.
-    lootEventData.uuid = jabsLootData.uuid; // associate unique id.
+    // create loot model.
+    const jabsLootData = new JABS_LootDrop(item);
+    // associate unique id.
+    lootEventData.uuid = jabsLootData.uuid;
 
     // set the duration of this loot drop
     // if a custom time is available, then use that, otherwise use the default.
-    jabsLootData.duration = item.jabsExpiration ?? J.ABS.Metadata.DefaultLootExpiration; // lifetime.
+    // lifetime.
+    jabsLootData.duration = item.jabsExpiration ?? J.ABS.Metadata.DefaultLootExpiration;
 
     // generate a new event to visually represent the loot drop and flag it for adding.
-    const eventId = index; // use the reused/appended index.
-    const lootEvent = new Game_Event($gameMap.mapId(), eventId); // construct sprite.
-    lootEvent.setJabsLoot(jabsLootData); // attach loot.
+    // use the reused/appended index.
+    const eventId = index;
+    // construct sprite.
+    const lootEvent = new Game_Event($gameMap.mapId(), eventId);
+    // attach loot.
+    lootEvent.setJabsLoot(jabsLootData);
 
     // flag for adding a character sprite later via HUD/spriteset integration (unchanged elsewhere).
-    lootEvent.setLootNeedsAdding(); // if your code uses such a flag.
+    // if your code uses such a flag.
+    lootEvent.setLootNeedsAdding();
 
     // add to the map, reusing holes in the live event list as well.
-    $gameMap.addEvent(lootEvent); // will reuse holes per updated addEvent().
+    // will reuse holes per updated addEvent().
+    $gameMap.addEvent(lootEvent);
 
     // trigger the spriteset to scan and add loot sprites.
-    this.requestLootRendering = true; // ensure loot renders this frame.
+    // ensure loot renders this frame.
+    this.requestLootRendering = true;
 
     // return the loot drop that was added.
     return lootEvent;
@@ -22920,7 +23081,8 @@ class JABS_Engine
     const defenderGrd = (baseGrd + bonusGrdFromAgi + bonusGrdFromLuk) * parryIgnoredFactor;
 
     // attacker's stat calculation of hit, bonuses from agi/luk.
-    const defaultHit = 50; // this flat amount is necessary to not be ridiculously parryful early game.
+    // this flat amount is necessary to not be ridiculously parryful early game.
+    const defaultHit = 50;
     const baseHit = hundredX(casterBattler.hit) + defaultHit;
     const bonusHitFromAgi = tenPercent(casterBattler.agi);
     const bonusHitFromLuk = tenPercent(casterBattler.luk);
@@ -22947,7 +23109,8 @@ class JABS_Engine
     if (difference > 100)
     {
       return false;
-    }// the grd is too great, there is no chance of landing a hit.
+    // the grd is too great, there is no chance of landing a hit.
+    }
     else if (difference <= 0) return true;
 
     return rng > difference;
@@ -23973,9 +24136,12 @@ class JABS_Engine
   collisionSector(target, action, range, facing, degrees)
   {
     // derive pixel radius from tiles.
-    const tw = $gameMap.tileWidth(); // tile width in px.
-    const th = $gameMap.tileHeight(); // tile height in px.
-    const rPx = range * tw; // convert to pixels (use tw for circles/sectors).
+    // tile width in px.
+    const tw = $gameMap.tileWidth();
+    // tile height in px.
+    const th = $gameMap.tileHeight();
+    // convert to pixels (use tw for circles/sectors).
+    const rPx = range * tw;
 
     // get the unified, corrected origin for the action.
     const {
@@ -24002,8 +24168,10 @@ class JABS_Engine
 
     // build a unit facing vector from the numeric direction.
     // Note: J.ABS.Directions.* uses cardinals; diagonals are not used for gating.
-    let fx = 0; // facing x component.
-    let fy = 0; // facing y component.
+    // facing x component.
+    let fx = 0;
+    // facing y component.
+    let fy = 0;
     switch (facing)
     {
       case J.ABS.Directions.DOWN:
@@ -24024,8 +24192,10 @@ class JABS_Engine
     }
 
     // compute vector from origin to the target rect’s center.
-    const tx = targetRect.cx - cx; // delta x to target center.
-    const ty = targetRect.cy - cy; // delta y to target center.
+    // delta x to target center.
+    const tx = targetRect.cx - cx;
+    // delta y to target center.
+    const ty = targetRect.cy - cy;
 
     // degenerate case: target’s center exactly at origin → accept.
     if (tx === 0 && ty === 0)
@@ -24035,16 +24205,22 @@ class JABS_Engine
     }
 
     // normalize the target vector for dot-product angle testing.
-    const tLen = Math.hypot(tx, ty); // Euclidean length.
-    const tnx = tx / tLen; // unit x.
-    const tny = ty / tLen; // unit y.
+    // euclidean length.
+    const tLen = Math.hypot(tx, ty);
+    // unit x.
+    const tnx = tx / tLen;
+    // unit y.
+    const tny = ty / tLen;
 
     // compute cosine threshold for the half-angle.
-    const halfAngleRad = (degrees * 0.5) * (Math.PI / 180); // half-angle in radians.
-    const cosHalf = Math.cos(halfAngleRad); // cosine threshold.
+    // half-angle in radians.
+    const halfAngleRad = (degrees * 0.5) * (Math.PI / 180);
+    // cosine threshold.
+    const cosHalf = Math.cos(halfAngleRad);
 
     // dot-product with the facing unit vector yields cos(theta).
-    const dot = (fx * tnx) + (fy * tny); // cos(theta).
+    // cos(theta).
+    const dot = (fx * tnx) + (fy * tny);
 
     // accept if the angle is within the wedge sweep.
     return dot >= cosHalf;
@@ -24061,20 +24237,25 @@ class JABS_Engine
   collisionCircle(target, action, range)
   {
     // derive circle parameters in pixels.
-    const tw = $gameMap.tileWidth(); // assume square tiles unless specified otherwise.
-    const rPx = range * tw; // radius in pixels.
+    // assume square tiles unless specified otherwise.
+    const tw = $gameMap.tileWidth();
+    // radius in pixels.
+    const rPx = range * tw;
 
     // centralized, corrected origin for action.
     const {
       x: originCx,
       y: originCy
-    } = JABS_Engine.getActionOriginPixels(action); // unified origin.
+    // unified origin.
+    } = JABS_Engine.getActionOriginPixels(action);
 
     // build the target’s AABB.
-    const targetRect = JABS_Engine.getBattlerAabbModel(target); // target rect.
+    // target rect.
+    const targetRect = JABS_Engine.getBattlerAabbModel(target);
 
     // circle-vs-rect test.
-    return targetRect.intersectsCircle(originCx, originCy, rPx); // overlap?
+    // overlap?
+    return targetRect.intersectsCircle(originCx, originCy, rPx);
   }
 
   /**
@@ -24088,17 +24269,21 @@ class JABS_Engine
   collisionRhombus(target, action, range)
   {
     // grab tile dimensions for normalization.
-    const tw = $gameMap.tileWidth(); // tile width in px.
-    const th = $gameMap.tileHeight(); // tile height in px.
+    // tile width in px.
+    const tw = $gameMap.tileWidth();
+    // tile height in px.
+    const th = $gameMap.tileHeight();
 
     // unified action origin in pixels.
     const {
       x: cx,
       y: cy
-    } = JABS_Engine.getActionOriginPixels(action); // action origin.
+    // action origin.
+    } = JABS_Engine.getActionOriginPixels(action);
 
     // target’s AABB in pixels.
-    const rect = JABS_Engine.getBattlerAabbModel(target); // target rect.
+    // target rect.
+    const rect = JABS_Engine.getBattlerAabbModel(target);
 
     // initialize the unsigned horizontal pixel gap from origin point to rect.
     let dxPx = 0;
@@ -24129,8 +24314,10 @@ class JABS_Engine
     }
 
     // convert pixel gaps to tile distances.
-    const dxTiles = dxPx / tw; // x in tiles.
-    const dyTiles = dyPx / th; // y in tiles.
+    // x in tiles.
+    const dxTiles = dxPx / tw;
+    // y in tiles.
+    const dyTiles = dyPx / th;
 
     // inside the diamond if L1 distance in tile units is within range.
     return (dxTiles + dyTiles) <= range;
@@ -24147,27 +24334,37 @@ class JABS_Engine
   collisionSquare(target, action, range)
   {
     // compute action-centered square size in pixels.
-    const tw = $gameMap.tileWidth(); // tile width.
-    const th = $gameMap.tileHeight(); // tile height.
-    const tilesW = (2 * range + 1); // width in tiles.
-    const tilesH = (2 * range + 1); // height in tiles.
-    const wPx = tilesW * tw; // width in px.
-    const hPx = tilesH * th; // height in px.
+    // tile width.
+    const tw = $gameMap.tileWidth();
+    // tile height.
+    const th = $gameMap.tileHeight();
+    // width in tiles.
+    const tilesW = (2 * range + 1);
+    // height in tiles.
+    const tilesH = (2 * range + 1);
+    // width in px.
+    const wPx = tilesW * tw;
+    // height in px.
+    const hPx = tilesH * th;
 
     // centralized, corrected origin for action.
     const {
       x: originCx,
       y: originCy
-    } = JABS_Engine.getActionOriginPixels(action); // unified origin.
+    // unified origin.
+    } = JABS_Engine.getActionOriginPixels(action);
 
     // build action area rect centered at the corrected origin.
-    const actionRect = JABS_Aabb.centerSized(originCx, originCy, wPx, hPx); // action rect.
+    // action rect.
+    const actionRect = JABS_Aabb.centerSized(originCx, originCy, wPx, hPx);
 
     // build target AABB.
-    const targetRect = JABS_Engine.getBattlerAabbModel(target); // target rect.
+    // target rect.
+    const targetRect = JABS_Engine.getBattlerAabbModel(target);
 
     // rect-rect test.
-    return actionRect.intersectsRect(targetRect); // overlap?
+    // overlap?
+    return actionRect.intersectsRect(targetRect);
   }
 
   /**
@@ -24182,29 +24379,38 @@ class JABS_Engine
   collisionFrontSquare(target, action, range, facing)
   {
     // compute half-square dimensions in pixels.
-    const tw = $gameMap.tileWidth(); // tile width.
-    const th = $gameMap.tileHeight(); // tile height.
+    // tile width.
+    const tw = $gameMap.tileWidth();
+    // tile height.
+    const th = $gameMap.tileHeight();
 
     // total full-square tiles and derived pixel dimensions.
-    const fullTiles = (2 * range + 1); // full square tiles.
-    const fullW = fullTiles * tw; // full width in px.
-    const fullH = fullTiles * th; // full height in px.
+    // full square tiles.
+    const fullTiles = (2 * range + 1);
+    // full width in px.
+    const fullW = fullTiles * tw;
+    // full height in px.
+    const fullH = fullTiles * th;
 
     // centralized, corrected origin for action.
     const {
       x: originCx,
       y: originCy
-    } = JABS_Engine.getActionOriginPixels(action); // unified origin.
+    // unified origin.
+    } = JABS_Engine.getActionOriginPixels(action);
 
     // derive the front-half rectangle based on facing (anchored at corrected origin).
-    let actionRect; // will be computed based on facing.
+    // will be computed based on facing.
+    let actionRect;
     switch (facing)
     {
-      case J.ABS.Directions.DOWN: // 2 → bottom half from origin
+      // 2 → bottom half from origin.
+      case J.ABS.Directions.DOWN:
         actionRect = new JABS_Aabb(originCx - (fullW / 2), originCy, fullW, (fullH / 2) + (th / 2));
         break;
 
-      case J.ABS.Directions.UP: // 8 → top half up from origin
+      // 8 → top half up from origin.
+      case J.ABS.Directions.UP:
         actionRect = new JABS_Aabb(
           originCx - (fullW / 2),
           originCy - (fullH / 2) - (th / 2),
@@ -24213,11 +24419,13 @@ class JABS_Engine
         );
         break;
 
-      case J.ABS.Directions.RIGHT: // 6 → right half from origin
+      // 6 → right half from origin.
+      case J.ABS.Directions.RIGHT:
         actionRect = new JABS_Aabb(originCx, originCy - (fullH / 2), (fullW / 2) + (tw / 2), fullH);
         break;
 
-      case J.ABS.Directions.LEFT: // 4 → left half from origin
+      // 4 → left half from origin.
+      case J.ABS.Directions.LEFT:
         actionRect = new JABS_Aabb(
           originCx - (fullW / 2) - (tw / 2),
           originCy - (fullH / 2),
@@ -24232,10 +24440,12 @@ class JABS_Engine
     }
 
     // build target AABB.
-    const targetRect = JABS_Engine.getBattlerAabbModel(target); // target rect.
+    // target rect.
+    const targetRect = JABS_Engine.getBattlerAabbModel(target);
 
     // test overlap.
-    return actionRect.intersectsRect(targetRect); // overlap?
+    // overlap?
+    return actionRect.intersectsRect(targetRect);
   }
 
   /**
@@ -24250,37 +24460,48 @@ class JABS_Engine
   collisionLine(target, action, range, facing)
   {
     // acquire tile dimensions.
-    const tw = $gameMap.tileWidth(); // tile width in px.
-    const th = $gameMap.tileHeight(); // tile height in px.
+    // tile width in px.
+    const tw = $gameMap.tileWidth();
+    // tile height in px.
+    const th = $gameMap.tileHeight();
 
     // line length in pixels (use major axis for length, matching visualization elsewhere).
-    const lengthPx = range * Math.max(tw, th); // length in px.
+    // length in px.
+    const lengthPx = range * Math.max(tw, th);
 
     // determine configured thickness in tiles, fallback to default of 1 tile.
-    const thicknessTiles = this.getActionThicknessTiles(action) ?? 1; // tiles.
+    // tiles.
+    const thicknessTiles = this.getActionThicknessTiles(action) ?? 1;
 
     // clamp to a very small positive minimum in pixels to ensure the AABB has area.
-    const minPx = 1; // small positive safeguard.
+    // small positive safeguard.
+    const minPx = 1;
 
     // compute thickness in pixels along each orientation.
-    const thicknessX = Math.max(minPx, thicknessTiles * tw); // horizontal thickness.
-    const thicknessY = Math.max(minPx, thicknessTiles * th); // vertical thickness.
+    // horizontal thickness.
+    const thicknessX = Math.max(minPx, thicknessTiles * tw);
+    // vertical thickness.
+    const thicknessY = Math.max(minPx, thicknessTiles * th);
 
     // centralized, corrected origin.
     const {
       x: originCx,
       y: originCy
-    } = JABS_Engine.getActionOriginPixels(action); // unified origin.
+    // unified origin.
+    } = JABS_Engine.getActionOriginPixels(action);
 
     // build the line-as-rect based on facing from origin.
-    let actionRect; // rectangle approximation of the line.
+    // rectangle approximation of the line.
+    let actionRect;
     switch (facing)
     {
-      case J.ABS.Directions.DOWN: // 2
+      // 2.
+      case J.ABS.Directions.DOWN:
         // extend downward from the origin center, include a small extra half-tile pad.
         actionRect = new JABS_Aabb(originCx - (thicknessX / 2), originCy, thicknessX, lengthPx + (th / 2));
         break;
-      case J.ABS.Directions.UP: // 8
+      // 8.
+      case J.ABS.Directions.UP:
         // extend upward from the origin center, include a small extra half-tile pad.
         actionRect = new JABS_Aabb(
           originCx - (thicknessX / 2),
@@ -24289,11 +24510,13 @@ class JABS_Engine
           lengthPx + (th / 2)
         );
         break;
-      case J.ABS.Directions.RIGHT: // 6
+      // 6.
+      case J.ABS.Directions.RIGHT:
         // extend rightward from the origin center, include a small extra half-tile pad.
         actionRect = new JABS_Aabb(originCx, originCy - (thicknessY / 2), lengthPx + (tw / 2), thicknessY);
         break;
-      case J.ABS.Directions.LEFT: // (4)
+      // (4).
+      case J.ABS.Directions.LEFT:
         // extend leftward from the origin center, include a small extra half-tile pad.
         actionRect = new JABS_Aabb(
           originCx - lengthPx - (tw / 2),
@@ -24308,8 +24531,10 @@ class JABS_Engine
     }
 
     // build target AABB and test overlap.
-    const targetRect = JABS_Engine.getBattlerAabbModel(target); // target rect.
-    return actionRect.intersectsRect(targetRect); // overlap?
+    // target rect.
+    const targetRect = JABS_Engine.getBattlerAabbModel(target);
+    // overlap?
+    return actionRect.intersectsRect(targetRect);
   }
 
   /**
@@ -24348,8 +24573,10 @@ class JABS_Engine
     // resolve thickness (depth) in tiles (default 1 tile if not specified).
     const thicknessTiles = this.getActionThicknessTiles(action) ?? 1;
     const minPx = 1;
-    const depthW = Math.max(minPx, thicknessTiles * tw); // depth when vertical
-    const depthH = Math.max(minPx, thicknessTiles * th); // depth when horizontal
+    // depth when vertical.
+    const depthW = Math.max(minPx, thicknessTiles * tw);
+    // depth when horizontal.
+    const depthH = Math.max(minPx, thicknessTiles * th);
 
     // unified origin consistent with other shapes.
     const {
@@ -24365,16 +24592,20 @@ class JABS_Engine
     let actionRect;
     switch (facing)
     {
-      case J.ABS.Directions.DOWN: // 2 → horizontal wall below origin
+      // 2 → horizontal wall below origin.
+      case J.ABS.Directions.DOWN:
         actionRect = new JABS_Aabb(originCx - (breadthW / 2), originCy, breadthW, depthH);
         break;
-      case J.ABS.Directions.UP: // 8 → horizontal wall above origin
+      // 8 → horizontal wall above origin.
+      case J.ABS.Directions.UP:
         actionRect = new JABS_Aabb(originCx - (breadthW / 2), originCy - depthH, breadthW, depthH);
         break;
-      case J.ABS.Directions.RIGHT: // 6 → vertical wall right of origin
+      // 6 → vertical wall right of origin.
+      case J.ABS.Directions.RIGHT:
         actionRect = new JABS_Aabb(originCx, originCy - (breadthH / 2), depthW, breadthH);
         break;
-      case J.ABS.Directions.LEFT: // (4) → vertical wall left of origin
+      // (4) → vertical wall left of origin.
+      case J.ABS.Directions.LEFT:
         actionRect = new JABS_Aabb(originCx - depthW, originCy - (breadthH / 2), depthW, breadthH);
         break;
       default:
@@ -24983,19 +25214,29 @@ class JABS_Engine
 class JABS_HitboxPulseManager
 {
   //region static fields
-  /** @type {PIXI.Container|null} */
+  /**
+   * @type {PIXI.Container|null}
+   */
   static _layer = null;
 
-  /** @type {Sprite_HitboxPulse[]} */
+  /**
+   * @type {Sprite_HitboxPulse[]}
+   */
   static _active = [];
 
-  /** @type {Sprite_HitboxPulse[]} */
+  /**
+   * @type {Sprite_HitboxPulse[]}
+   */
   static _pool = [];
 
-  /** @type {number} */
+  /**
+   * @type {number}
+   */
   static _cap = 8;
 
-  /** @type {JABS_HitboxPulseOptions} */
+  /**
+   * @type {JABS_HitboxPulseOptions}
+   */
   static _defaults = JABS_HitboxPulseOptions.defaults();
   //endregion static fields
 
@@ -25245,7 +25486,8 @@ class JABS_HitboxPulseManager
   static directionToRadians(dir)
   {
     // precomputed constants for clarity.
-    const RAD_0 = 0;           // right
+    // right.
+    const RAD_0 = 0;
     const RAD_45 = Math.PI / 4;
     const RAD_90 = Math.PI / 2;
     const RAD_180 = Math.PI;
@@ -25254,14 +25496,22 @@ class JABS_HitboxPulseManager
 
     switch (dir)
     {
-      case 6: return RAD_0;                // right
-      case 3: return RAD_45;               // down-right
-      case 2: return RAD_90;               // down
-      case 1: return RAD_180 - RAD_45;     // down-left (135°)
-      case 4: return RAD_180;              // left
-      case 7: return -RAD_180 + RAD_45;    // up-left (-135°)
-      case 8: return RAD_N90;              // up
-      case 9: return RAD_N45;              // up-right (-45°)
+      // right.
+      case 6: return RAD_0;
+      // down-right.
+      case 3: return RAD_45;
+      // down.
+      case 2: return RAD_90;
+      // down-left (135°).
+      case 1: return RAD_180 - RAD_45;
+      // left.
+      case 4: return RAD_180;
+      // up-left (-135°).
+      case 7: return -RAD_180 + RAD_45;
+      // up.
+      case 8: return RAD_N90;
+      // up-right (-45°).
+      case 9: return RAD_N45;
     }
 
     // default: point right.
@@ -25774,7 +26024,8 @@ Game_Action.prototype.itemEffectAddState = function(target, effect)
 Game_Action.prototype.canItemEffectAddState = function(target, effect)
 {
   // if the target parried the result, then its state-related effects do not apply.
-  if (target.result()?.parried) return false;
+  const result = target.result();
+  if (result && result.parried) return false;
 
   // see if the state-related effects are applied!
   return true;
@@ -27467,7 +27718,9 @@ J.ABS.Aliased.Game_Battler.set('states', Game_Battler.prototype.states);
 Game_Battler.prototype.states = function()
 {
   // grab the original states as they were.
-  /** @type {RPG_State[]} */
+  /**
+   * @type {RPG_State[]}
+   */
   const originalStates = J.ABS.Aliased.Game_Battler.get('states')
     .call(this);
 
@@ -30338,7 +30591,9 @@ Game_Map.prototype.expiredActionEvents = function()
 Game_Map.prototype.actionEventsFromDataMapByUuid = function(uuid)
 {
   // the filter function for retrieving action metadatas from the datamap.
-  /** @param {rm.types.Event} metadata */
+  /**
+   * @param {rm.types.Event} metadata
+   */
   const filtering = metadata =>
   {
     // don't include invalid or non-action event metadatas.
@@ -30426,7 +30681,9 @@ Game_Map.prototype.expiredLootEvents = function()
 Game_Map.prototype.lootEventsFromDataMapByUuid = function(uuid)
 {
   // the filter function for retrieving loot metadatas from the datamap.
-  /** @param {rm.types.Event} metadata */
+  /**
+   * @param {rm.types.Event} metadata
+   */
   const filtering = metadata =>
   {
     // don't include invalid or non-action event metadatas.
@@ -30520,23 +30777,28 @@ Game_Map.prototype.newBattlerEvents = function()
 Game_Map.prototype.addEvent = function(event)
 {
   // attempt to find the first available hole in the event list.
-  let inserted = false; // whether or not we found a spot to insert.
+  // whether or not we found a spot to insert.
+  let inserted = false;
 
   for (let i = 0; i < this._events.length; i++)
   {
     // if the slot is empty/nullish, then reuse it.
     if (!this._events[i])
     {
-      this._events[i] = event; // assign into the first available hole.
-      inserted = true; // flag that we inserted.
-      break; // stop looking for holes.
+      // assign into the first available hole.
+      this._events[i] = event;
+      // flag that we inserted.
+      inserted = true;
+      // stop looking for holes.
+      break;
     }
   }
 
   // if we didn't find a hole, then append to the end as usual.
   if (!inserted)
   {
-    this._events.push(event); // append to the end.
+    // append to the end.
+    this._events.push(event);
   }
 };
 
@@ -30559,7 +30821,8 @@ Game_Map.prototype.removeEvent = function(eventToRemove)
     this.handleLootEventRemoval(eventToRemove);
 
     // mark the slot as empty to avoid sparseness while preserving indices.
-    this._events[eventIndex] = null; // keep array dense and reusable.
+    // keep array dense and reusable.
+    this._events[eventIndex] = null;
   }
 };
 
@@ -30570,22 +30833,26 @@ Game_Map.prototype.removeEvent = function(eventToRemove)
 Game_Map.prototype.handleActionEventRemoval = function(actionToRemove)
 {
   // don't process if this event isn't an action.
-  if (!actionToRemove.isJabsAction()) return; // only handle actions.
+  // only handle actions.
+  if (!actionToRemove.isJabsAction()) return;
 
   // get the relevant metadatas for the action.
   const actionMetadatas = this.actionEventsFromDataMapByUuid(actionToRemove.getJabsActionUuid());
 
   // all removed events get erased.
-  actionToRemove.erase(); // ensure event is erased visually/logic-wise.
+  // ensure event is erased visually/logic-wise.
+  actionToRemove.erase();
 
   // and also to cleanup the current list of active jabs action events.
-  $jabsEngine.clearActionEvents(); // purge internal tracking.
+  // purge internal tracking.
+  $jabsEngine.clearActionEvents();
 
   // iterate over each of the metadatas for deletion.
   actionMetadatas.forEach(actionMetadata =>
   {
     // instead of deleting (which creates sparse arrays), null the slot.
-    $dataMap.events[actionMetadata.actionIndex] = null; // maintain dense array kind.
+    // maintain dense array kind.
+    $dataMap.events[actionMetadata.actionIndex] = null;
   });
 };
 
@@ -30596,7 +30863,8 @@ Game_Map.prototype.handleActionEventRemoval = function(actionToRemove)
 Game_Map.prototype.handleLootEventRemoval = function(lootToRemove)
 {
   // don't process if this event isn't loot.
-  if (!lootToRemove.isJabsLoot()) return; // only handle loot.
+  // only handle loot.
+  if (!lootToRemove.isJabsLoot()) return;
 
   // get the relevant metadatas for the loot.
   const lootMetadatas = this.lootEventsFromDataMapByUuid(lootToRemove.getJabsLoot().uuid);
@@ -30605,7 +30873,8 @@ Game_Map.prototype.handleLootEventRemoval = function(lootToRemove)
   lootMetadatas.forEach(lootMetadata =>
   {
     // instead of deleting (which creates sparse arrays), null the slot.
-    $dataMap.events[lootMetadata.lootIndex] = null; // maintain dense array kind.
+    // maintain dense array kind.
+    $dataMap.events[lootMetadata.lootIndex] = null;
   });
 };
 
@@ -30669,7 +30938,7 @@ Game_Map.prototype.hasInteractableEventInFront = function(jabsBattler)
 
   // when using cyclone's movement plugin, rounding is necessary to accommodate interacting with events
   // without actually executing your weapon attack.
-  if (J.ABS.EXT?.CYCLE)
+  if (J.ABS.EXT.CYCLE)
   {
     x2 = Math.round($gameMap.roundXWithDirection(x1, direction));
     y2 = Math.round($gameMap.roundYWithDirection(y1, direction));
@@ -32838,6 +33107,7 @@ Scene_Map.prototype.forceCloseAbsMenu = function()
 };
 //endregion Scene_Map
 
+//region Sprite_Animation
 /**
  * Extends {@link Sprite_Animation.prototype.targetPosition}.<br/>
  * Adds a guard to ensure we don't attempt to calculate positions for destroyed sprites.
@@ -32909,7 +33179,10 @@ Sprite_Animation.prototype.targetSpritePosition = function (sprite)
     return new Point(0, 0);
   }
 };
+//endregion Sprite_Animation
 
+
+//region Sprite_AnimationMV
 /**
  * Extends/Overrides {@link Sprite_AnimationMV.prototype.updatePosition}.<br/>
  * Adds a guard to ensure we don't attempt to follow destroyed or removed sprites.
@@ -32988,6 +33261,8 @@ Sprite_AnimationMV.prototype.updatePosition = function ()
       .call(this);
   }
 };
+//endregion Sprite_AnimationMV
+
 
 //region Sprite_Character
 //region init
@@ -36249,7 +36524,7 @@ Spriteset_Map.prototype.getActionHitboxStyleFor = function (shape)
 
   // apply shape-specific overrides if provided.
   const key = (shape || String.empty).toLowerCase(); // normalized key.
-  const shapeOverrides = styles.byShape?.[key] || null; // optional per-shape.
+  const shapeOverrides = (styles.byShape || {})[key] || null;
 
   // produce the final style.
   const finalStyle = Object.assign({}, base, shapeOverrides || {}); // merged final style.
@@ -37039,13 +37314,13 @@ Spriteset_Map.prototype.getBattlerHitboxStyle = function (
 
   // apply kind-specific overrides if provided.
   const kindKey = (kind || 'battler').toLowerCase(); // normalized.
-  const byKind = styles.byKind?.[kindKey] || null; // optional kind overrides.
+  const byKind = (styles.byKind || {})[kindKey] || null;
 
   // apply state-specific overrides if provided (e.g., colliding).
-  const stateKey = (state || String.empty).toLowerCase(); // normalized.
+  const stateKey = (state || String.empty).toLowerCase();
   const byState = stateKey
-    ? (styles.byState?.[stateKey] || null)
-    : null; // optional state overrides.
+    ? ((styles.byState || {})[stateKey] || null)
+    : null;
 
   // layered result: base -> kind -> state.
   const finalStyle = Object.assign({}, base, byKind || {}, byState || {}); // merged final style.
@@ -37074,6 +37349,7 @@ Spriteset_Map.prototype.destroyBattlerHitboxSprite = function (sprite)
 //endregion hitbox sprites
 //endregion Spriteset_Map
 
+//region Window_AbsHelp
 class Window_AbsHelp
   extends Window_Help
 {
@@ -37082,6 +37358,8 @@ class Window_AbsHelp
     super(rect);
   }
 }
+//endregion Window_AbsHelp
+
 
 //region Window_AbsMenu
 /**
@@ -37480,7 +37758,9 @@ class Window_AbsMenuSelect
     const leader = $gameParty.leader();
 
     // an iterator function for iterating over skill slots and rendering their data.
-    /** @param {JABS_SkillSlot} skillSlot */
+    /**
+     * @param {JABS_SkillSlot} skillSlot
+     */
     const forEacher = skillSlot =>
     {
       // initialize the command variables.

--- a/project/js/plugins/abs/ext/J-ABS-AllyAI.js
+++ b/project/js/plugins/abs/ext/J-ABS-AllyAI.js
@@ -247,6 +247,7 @@
  *
  */
 
+//region Introduction
 /* eslint-disable max-len */
 /**
  * The core where all of my extensions live: in the `J` object.
@@ -325,12 +326,18 @@ J.ABS.EXT.ALLYAI.Metadata.FormationTypes = [
     description: "The rear-wedge formation.\nAllies will fan out behind you for support.",
     formation:
       [
-        [ -1, -1 ], // 1 back-left (behind is negative Y when facing DOWN)
-        [  1, -1 ], // 2 back-right
-        [  0, -2 ], // 3 two tiles behind
-        [ -1, -2 ], // 4 farther back-left
-        [  1, -2 ], // 5 farther back-right
-        [  0, -4 ], // 6 three tiles behind
+        // 1 back-left (behind is negative Y when facing DOWN).
+        [ -1, -1 ],
+        // 2 back-right.
+        [  1, -1 ],
+        // 3 two tiles behind.
+        [  0, -2 ],
+        // 4 farther back-left.
+        [ -1, -2 ],
+        // 5 farther back-right.
+        [  1, -2 ],
+        // 6 three tiles behind.
+        [  0, -4 ],
       ],
     effects: [],
   },
@@ -340,12 +347,18 @@ J.ABS.EXT.ALLYAI.Metadata.FormationTypes = [
     description: "A side- flank formation.\nAllies will flank you at either side to look extra menacing.",
     formation:
       [
-        [ -1,  0 ], // 1 left
-        [  1,  0 ], // 2 right
-        [ -2,  0 ], // 3 far-left
-        [  2,  0 ], // 4 far-right
-        [ -3,  0 ], // 5 farther-left
-        [  3,  0 ], // 6 farther-right
+        // 1 left.
+        [ -1,  0 ],
+        // 2 right.
+        [  1,  0 ],
+        // 3 far-left.
+        [ -2,  0 ],
+        // 4 far-right.
+        [  2,  0 ],
+        // 5 farther-left.
+        [ -3,  0 ],
+        // 6 farther-right.
+        [  3,  0 ],
       ],
     effects: [],
   },
@@ -355,14 +368,22 @@ J.ABS.EXT.ALLYAI.Metadata.FormationTypes = [
     description: "The tight circle formation.\nNo one will get to most delicate squishy innard!",
     formation:
       [
-        [  0,  1 ], // 1 below
-        [  1,  0 ], // 2 right
-        [  0, -1 ], // 3 above
-        [ -1,  0 ], // 4 left
-        [  1,  1 ], // 5 lower-right
-        [ -1,  1 ], // 6 lower-left
-        [  1, -1 ], // 7 upper-right
-        [ -1, -1 ], // 8 upper-left
+        // 1 below.
+        [  0,  1 ],
+        // 2 right.
+        [  1,  0 ],
+        // 3 above.
+        [  0, -1 ],
+        // 4 left.
+        [ -1,  0 ],
+        // 5 lower-right.
+        [  1,  1 ],
+        // 6 lower-left.
+        [ -1,  1 ],
+        // 7 upper-right.
+        [  1, -1 ],
+        // 8 upper-left.
+        [ -1, -1 ],
       ],
     effects: [],
   },
@@ -865,7 +886,8 @@ JABS_AllyAI.prototype.decideSupportCleansing = function(availableSkills, healer)
       // the find the first one that we can cleanse.
       const cleansableState = allyStates.find(state =>
       {
-        const isNegative = state.jabsNegative; // skills to be cleansed have a "negative" tag.
+        // skills to be cleansed have a "negative" tag.
+        const isNegative = state.jabsNegative;
         const canBeCleansed = this.determineBestSkillForStateCleansing(availableSkills, state.id, healer);
         return isNegative && canBeCleansed;
       });
@@ -935,9 +957,12 @@ JABS_AllyAI.prototype.decideSupportHealing = function(availableSkills, healer)
   {
     const testAction = new Game_Action(healer.getBattler());
     testAction.setSkill(skillId);
-    return (testAction.isForAliveFriend() &&  // must target living allies.
-      testAction.isRecover() &&               // must recover something.
-      testAction.isHpEffect());               // must affect hp.
+    // must target living allies.
+    return (testAction.isForAliveFriend() &&
+      // must recover something.
+      testAction.isRecover() &&
+      // must affect hp.
+      testAction.isHpEffect());
   });
 
   let bestSkillId = 0;
@@ -1040,7 +1065,8 @@ JABS_AllyAI.prototype.countLowHpAllies = function(healer, threshold = 0.6)
 JABS_AllyAI.prototype.bestFitHealingOneSkill = function(healingTypeSkills, healerBattler, lowestAllyBattler)
 {
   let bestSkillId = 0;
-  let smallestDifference = Number.MAX_SAFE_INTEGER; // need it to be an unrealistically high difference to start.
+  // need it to be an unrealistically high difference to start.
+  let smallestDifference = Number.MAX_SAFE_INTEGER;
   healingTypeSkills.forEach(skillId =>
   {
     const skill = healerBattler.skill(skillId);
@@ -1096,7 +1122,8 @@ JABS_AllyAI.prototype.bestFitHealingAllSkill = function(healingTypeSkills, heale
   // if there is only one skill that multi-targets, then use that.
   if (multiTargetHealingTypeSkills.length === 1) return multiTargetHealingTypeSkills[0];
 
-  let smallestDifference = 99999999; // need it to be an unrealistically high difference to start.
+  // need it to be an unrealistically high difference to start.
+  let smallestDifference = 99999999;
   multiTargetHealingTypeSkills.forEach(skillId =>
   {
     const skill = healerBattler.skill(skillId);
@@ -3063,7 +3090,9 @@ Scene_Map.prototype.commandSelectAllyFormation = function()
 {
   const window = this.getAllyFormationWindow();
 
-  /** @type {JABS_Formation} */
+  /**
+   * @type {JABS_Formation}
+   */
   const selectedFormation = window.currentExt();
   $gameParty.setPartyFormation(selectedFormation.key);
   window.refresh();
@@ -3385,9 +3414,11 @@ Window_AbsMenuSelect.prototype.addAllyFormationCommand = function()
 {
   // define the icons for passive/aggressive ally AI aggro settings.
   // build the command.
-  const allyFormationsCommand = new WindowCommandBuilder("Ally Formations") // TODO: parameterize this.
+  // tODO: parameterize this.
+  const allyFormationsCommand = new WindowCommandBuilder("Ally Formations")
     .setSymbol('ally-formations')
-    .setIconIndex(289) // TODO: parameterize this.
+    // tODO: parameterize this.
+    .setIconIndex(289)
     .setColorIndex(23)
     .build();
 
@@ -3459,6 +3490,7 @@ Window_AbsMenuSelect.prototype.itemHeight = function()
 };
 //endregion Window_AbsMenuSelect
 
+//region Window_Formations
 /**
  * A window that allows selection from a list of ally AI formations.
  */
@@ -3526,3 +3558,4 @@ class Window_Formations
     return this.lineHeight() * 2;
   }
 }
+//endregion Window_Formations

--- a/project/js/plugins/abs/ext/J-ABS-Charge.js
+++ b/project/js/plugins/abs/ext/J-ABS-Charge.js
@@ -265,6 +265,7 @@
  * 
  */
 
+//region Introduction
 /**
  * The core where all of my extensions live: in the `J` object.
  */

--- a/project/js/plugins/abs/ext/J-ABS-CycloneAdapter.js
+++ b/project/js/plugins/abs/ext/J-ABS-CycloneAdapter.js
@@ -21,6 +21,7 @@
  * ----------------------------------------------------------------------------
  */
 
+//region Introduction
 /**
  * The core where all of my extensions live: in the `J` object.
  */
@@ -90,6 +91,7 @@ J.ABS.EXT.CYCLE.Aliased = {
 };
 //endregion Introduction
 
+//region JABS_Battler
 /**
  * Sets the number of steps that will be force-moved when dodging.
  * @param {number} stepCount The number of steps to dodge.
@@ -127,6 +129,8 @@ JABS_Battler.prototype.destroy = function()
     CycloneMovement.loadDefaultCollisionTable();
   }
 };
+//endregion JABS_Battler
+
 
 /**
  * A collection of all command codes that are associated with movement of the character.
@@ -352,6 +356,7 @@ Game_Character.prototype.updateRepeatedMovements = function()
   }
 };
 
+//region Game_Follower
 /**
  * Overrides {@link Game_Follower.chaseCharacter}.<br>
  * Prevents the follower from chasing after the player while they are in combat.
@@ -387,6 +392,8 @@ Game_Follower.prototype.isDoingJabsAllyAiThings = function()
   // we must be doing JABS AI things!
   return true;
 };
+//endregion Game_Follower
+
 
 //region Game_Player
 /**

--- a/project/js/plugins/abs/ext/J-ABS-DangerIndicator.js
+++ b/project/js/plugins/abs/ext/J-ABS-DangerIndicator.js
@@ -76,6 +76,7 @@
  * @default 588
 */
 
+//region Introduction
 /**
  * The core where all of my extensions live: in the `J` object.
  */
@@ -308,6 +309,7 @@ Game_Actor.prototype.showDangerIndicator = function()
 };
 //endregion Game_Actor
 
+//region Game_Battler
 /**
  * Gets the numeric representation of this battler's strength.
  * @returns {number}
@@ -385,6 +387,8 @@ Game_Battler.prototype.getDangerIndicatorIcon = function()
       return -1;
   }
 };
+//endregion Game_Battler
+
 
 //region Game_Enemy
 /**

--- a/project/js/plugins/abs/ext/J-ABS-Diagonals.js
+++ b/project/js/plugins/abs/ext/J-ABS-Diagonals.js
@@ -87,6 +87,7 @@
  * ============================================================================
  */
 
+//region Initialization
 /**
  * The core where all of my extensions live: in the `J` object.
  */
@@ -274,7 +275,7 @@ Game_Event.prototype.moveDiagonally = function(horz, vert)
   if (this.isJabsAction() === false) return;
 
   // if this is not a diagonal direction, don't try to modify facing.
-  if (this.isDiagonalDirection(this.direction()) === false) return;
+  if (!this.isDiagonalDirection(this.direction())) return;
 
   // determine the correct direction to face and set it.
   const newDirection = this.normalizeActionDirection();
@@ -300,55 +301,76 @@ Game_Event.prototype.normalizeActionDirection = function()
   // normalize the direction that should be faced.
   switch (castedDirection)
   {
-    case 2: // caster faced down
+    // caster faced down.
+    case 2:
       switch (actionDirection)
       {
-        case 1: // action moving lower left
-        case 3: // action moving lower right
+        // action moving lower left.
+        case 1:
+        // action moving lower right.
+        case 3:
           return castedDirection;
-        case 7: // action moving upper left
-        case 9: // action moving upper right
+        // action moving upper left.
+        case 7:
+        // action moving upper right.
+        case 9:
           return this.reverseDir(castedDirection);
       }
       return castedDirection;
 
-    case 4: // caster faced left
+    // caster faced left.
+    case 4:
       switch (actionDirection)
       {
-        case 1: // action moving lower left
-        case 7: // action moving upper left
+        // action moving lower left.
+        case 1:
+        // action moving upper left.
+        case 7:
           return castedDirection;
-        case 3: // action moving lower right
-        case 9: // action moving upper right
+        // action moving lower right.
+        case 3:
+        // action moving upper right.
+        case 9:
           return this.reverseDir(castedDirection);
       }
       return castedDirection;
 
-    case 6: // caster faced right
+    // caster faced right.
+    case 6:
       switch (actionDirection)
       {
-        case 3: // action moving lower right
-        case 9: // action moving upper right
+        // action moving lower right.
+        case 3:
+        // action moving upper right.
+        case 9:
           return castedDirection;
-        case 1: // action moving lower left
-        case 7: // action moving upper left
+        // action moving lower left.
+        case 1:
+        // action moving upper left.
+        case 7:
           return this.reverseDir(castedDirection);
       }
       return castedDirection;
 
-    case 8: // caster faced up
+    // caster faced up.
+    case 8:
       switch (actionDirection)
       {
-        case 7: // action moving upper left
-        case 9: // action moving upper right
+        // action moving upper left.
+        case 7:
+        // action moving upper right.
+        case 9:
           return castedDirection;
-        case 1: // action moving lower left
-        case 3: // action moving lower right
+        // action moving lower left.
+        case 1:
+        // action moving lower right.
+        case 3:
           return this.reverseDir(castedDirection);
       }
       return castedDirection;
 
-    default: // somehow we were not facing one of the four cardinal directions, return default.
+    // somehow we were not facing one of the four cardinal directions, return default.
+    default:
       return castedDirection;
   }
 };

--- a/project/js/plugins/abs/ext/J-ABS-Formula.js
+++ b/project/js/plugins/abs/ext/J-ABS-Formula.js
@@ -619,13 +619,19 @@ J.ABS.EXT.FORMULA.Aliased.JABS_Engine = new Map();
  * Execution-time context flags and helpers for this extension.
  */
 J.ABS.EXT.FORMULA.Context = {
-  /** Whether sub-executions should suppress cascading of this extension. */
+  /**
+   * Whether sub-executions should suppress cascading of this extension.
+   */
   suppressCascades: false,
 
-  /** Whether to suppress applyGlobal() (i.e., skip child skill common events). */
+  /**
+   * Whether to suppress applyGlobal() (i.e., skip child skill common events).
+   */
   suppressCommonEvents: false,
 
-  /** The active trigger while applying packets ("hit" | "use"). */
+  /**
+   * The active trigger while applying packets ("hit" | "use").
+   */
   activeTrigger: null,
 
   /**
@@ -647,7 +653,9 @@ J.ABS.EXT.FORMULA.Settings = {
    */
   logFlushTiming: "after-base",
 
-  /** Prefer appending if supported by the manager (so base logs remain visually first). */
+  /**
+   * Prefer appending if supported by the manager (so base logs remain visually first).
+   */
   preferAppend: true,
 };
 
@@ -680,8 +688,10 @@ PluginManager.registerCommand(J.ABS.EXT.FORMULA.Metadata.name, "do-the-thing", a
 RPG_Skill.prototype.jabsFormulaEffects = function()
 {
   // initialize cache location if missing.
-  this._j ||= {}; // shared J root.
-  this._j._abs ||= {}; // JABS root.
+  // shared J root.
+  this._j ||= {};
+  // jABS root.
+  this._j._abs ||= {};
 
   // build and cache on first access.
   if (!this._j._abs._formulaEffects)
@@ -751,14 +761,17 @@ JABS_Engine.prototype.applyOnUseFormulaPackets = function(caster, primaryAction)
 {
   // obtain the underlying Game_Action from the JABS action.
   const gameAction = primaryAction.getAction();
-  if (!gameAction) return; // no underlying action => nothing to apply.
+  // no underlying action => nothing to apply.
+  if (!gameAction) return;
 
   // set context to on-use while evaluating packets.
   const ctx = J.ABS.EXT.FORMULA.Context;
   const prevTrigger = ctx.activeTrigger;
   const prevCascade = ctx.suppressCascades;
-  ctx.activeTrigger = FormulaEffect.Trigger.USE; // "use"
-  ctx.suppressCascades = false; // parent-level packets should execute.
+  // "use".
+  ctx.activeTrigger = FormulaEffect.Trigger.USE;
+  // parent-level packets should execute.
+  ctx.suppressCascades = false;
 
   try
   {
@@ -796,34 +809,44 @@ JABS_Engine.prototype.forceMapAction = function(
 {
   // build options based on inputs (to derive a primary action for on-use packets).
   const actionLocation = JABS_Location.Builder()
-    .setX(targetX) // set the target x.
-    .setY(targetY) // set the target y.
-    .build(); // build the location.
+    // set the target x.
+    .setX(targetX)
+    // set the target y.
+    .setY(targetY)
+    // build the location.
+    .build();
   const actionOptions = JABS_ActionOptions.Builder()
-    .setIsRetaliation(isRetaliation) // set if this is a retaliation.
-    .setLocation(actionLocation) // apply the action location.
-    .setIsTerrainDamage(isMapDamage) // set if this is environmental damage.
-    .build(); // build the options.
+    // set if this is a retaliation.
+    .setIsRetaliation(isRetaliation)
+    // apply the action location.
+    .setLocation(actionLocation)
+    // set if this is environmental damage.
+    .setIsTerrainDamage(isMapDamage)
+    // build the options.
+    .build();
 
   // generate the actions to obtain the primary action for on-use packet firing.
   // NOTE: this preview is used only to feed the on-use hook below; actual execution is
   // performed by the original method to avoid duplication and preserve core behavior.
-  const previewActions = caster.createJabsActionFromSkill(skillId, actionOptions); // create preview.
+  // create preview.
+  const previewActions = caster.createJabsActionFromSkill(skillId, actionOptions);
 
   // if we cannot execute map actions, then do not proceed.
-  if (!this.canExecuteMapActions(caster, previewActions)) return; // guard execution.
+  // guard execution.
+  if (!this.canExecuteMapActions(caster, previewActions)) return;
 
   // fire on-use packets at launch time for forced actions using the primary preview action.
-  this.applyOnUseFormulaPackets(caster, previewActions[0]); // launch-time on-use.
+  // launch-time on-use.
+  this.applyOnUseFormulaPackets(caster, previewActions[0]);
 
   // delegate to the original forceMapAction (immediate execution path without costs/cooldowns/cast time),
   // preserving all core behavior (animations, collisions, effects, logs, threat, etc.).
   J.ABS.EXT.FORMULA.Aliased.JABS_Engine.get("forceMapAction")
-    .call(this, caster, skillId, isRetaliation, targetX, targetY, isMapDamage); // call original.
+    // call original.
+    .call(this, caster, skillId, isRetaliation, targetX, targetY, isMapDamage);
 };
 //endregion JABS_Engine
 
-//region Game_Action
 //region Game_Action
 /**
  * Extends {@link Game_Action.applyVirtualJabsAction}.<br/>
@@ -862,7 +885,8 @@ Game_Action.prototype.applyFormulaPackets = function(trigger, parentTarget)
 {
   // ensure we have an item/skill to check.
   const skill = this.item();
-  if (!skill || !skill.isSkill()) return; // only skills for now.
+  // only skills for now.
+  if (!skill || !skill.isSkill()) return;
 
   // gather all effects and filter by trigger.
   const allEffects = skill.jabsFormulaEffects();
@@ -1015,15 +1039,19 @@ Game_Action.prototype.applyFormulaModePacket = function(effect, recipient)
   const raw = this.evaluateFormula(effect.formula, this.subject(), recipient, this.item());
   if (!raw) return;
 
-  const isDamage = raw > 0; // identify damage vs healing/gain.
-  const baseMag = Math.abs(raw); // pipeline expects a positive magnitude.
+  // identify damage vs healing/gain.
+  const isDamage = raw > 0;
+  // pipeline expects a positive magnitude.
+  const baseMag = Math.abs(raw);
 
   // run magnitude through battle pipeline (element/phys-mag/guard/variance/JABS guard; REC on heals).
   const piped = this.pipeFormulaThroughBattleCalculations(recipient, baseMag, effect, isDamage);
 
   // finalize and apply by resource.
-  const mag = Math.max(0, Math.round(piped)); // enforce non-negative integer.
-  if (mag === 0) return; // no net impact.
+  // enforce non-negative integer.
+  const mag = Math.max(0, Math.round(piped));
+  // no net impact.
+  if (mag === 0) return;
 
   // snapshot the current result so our packet doesn't overwrite the base action's result.
   const r = recipient.result();
@@ -1075,7 +1103,8 @@ Game_Action.prototype.applyFormulaModePacket = function(effect, recipient)
   // action log for any resource, attributed to the parent skill id.
   const signed = isDamage
     ? mag
-    : -mag; // negative => heal/gain, positive => damage/loss.
+    // negative => heal/gain, positive => damage/loss.
+    : -mag;
   const parentSkillId = this.item()
     ? this.item().id
     : 0;
@@ -1123,7 +1152,8 @@ Game_Action.prototype.pipeFormulaThroughBattleCalculations = function(target, ma
   value *= this.calcElementRate(target);
 
   // 2) critical only for damage and only if parent was critical (on-hit context).
-  if (isDamage && J.ABS.EXT.FORMULA.Context.activeTrigger === FormulaEffect.Trigger.HIT && target.result()?.critical)
+  const targetResult = target.result();
+  if (isDamage && J.ABS.EXT.FORMULA.Context.activeTrigger === FormulaEffect.Trigger.HIT && targetResult && targetResult.critical)
   {
     value = this.applyCritical(value);
   }
@@ -1199,12 +1229,14 @@ Game_Action.prototype.executeChildSkillPacket = function(effect, recipient, pare
 {
   // look up the child skill.
   const child = $dataSkills[effect.skillId];
-  if (!child) return; // invalid skill id => nothing to do.
+  // invalid skill id => nothing to do.
+  if (!child) return;
 
   // resolve the subject as a JABS battler; full JABS actions require a JABS_Battler caster.
   const subject = this.subject();
   const jabsSubject = JABS_AiManager.getBattlerByUuid(subject.getUuid());
-  if (!jabsSubject) return; // subject must exist on-map as a JABS battler.
+  // subject must exist on-map as a JABS battler.
+  if (!jabsSubject) return;
 
   // optionally bias execution with the recipient’s current coordinates (useful for target/ground casts).
   let targetX = null;
@@ -1319,7 +1351,8 @@ Game_Action.prototype.generateFormulaActionLogIfAvailable = function(recipient, 
   const isHeal = signed < 0;
 
   // heals can also be critical; use the recipient's current action result flag if present.
-  const wasCrit = recipient.result()?.critical === true;
+  const recipientResult = recipient.result();
+  const wasCrit = recipientResult ? recipientResult.critical === true : false;
 
   // build and enqueue the action log entry using the standard execution line.
   const log = new ActionLogBuilder()

--- a/project/js/plugins/abs/ext/J-ABS-Hitstop.js
+++ b/project/js/plugins/abs/ext/J-ABS-Hitstop.js
@@ -141,7 +141,7 @@ class JHitstop_PluginMetadata
      */
     this.flashOnHit = false;
 
-    // region shake
+    //region shake
     /**
      * Enables a tiny screen shake when hitstop is applied.
      * @type {boolean}
@@ -260,11 +260,17 @@ J.ABS.EXT.HITSTOP.Aliased.JABS_Action = new Map();
  * All regular expressions used by this plugin.
  */
 J.ABS.EXT.HITSTOP.RegExp = {
-  /** Skill: `<hitstop:N>` */
+  /**
+   * Skill: `<hitstop:N>`
+   */
   Hitstop: /<hitstop:[ ]?(\d+)>/i,
-  /** Skill: `<noHitstop>` */
+  /**
+   * Skill: `<noHitstop>`
+   */
   NoHitstop: /<noHitstop>/i,
-  /** Actor/Enemy: `<hitstopScale:P%>` */
+  /**
+   * Actor/Enemy: `<hitstopScale:P%>`
+   */
   HitstopScale: /<hitstopScale:[ ]?(\d+)%>/i,
 };
 //endregion initialization

--- a/project/js/plugins/abs/ext/J-ABS-InputManager.js
+++ b/project/js/plugins/abs/ext/J-ABS-InputManager.js
@@ -55,6 +55,7 @@
  * ============================================================================
  */
 
+//region introduction
 /**
  * The core where all of my extensions live: in the `J` object.
  */
@@ -1679,37 +1680,56 @@ Input.keyMapper = {
   ...Input.keyMapper,
 
   // this is the new debug move-through for use with JABS.
-  192: J.ABS.EXT.INPUT.Symbols.Debug,       // ` (backtick)
+  // ` (backtick).
+  192: J.ABS.EXT.INPUT.Symbols.Debug,
 
   // core buttons.
-  90: J.ABS.EXT.INPUT.Symbols.Mainhand,       // z
-  88: J.ABS.EXT.INPUT.Symbols.Offhand,        // x
-  16: J.ABS.EXT.INPUT.Symbols.Dash,           // shift (already defined)
-  67: J.ABS.EXT.INPUT.Symbols.Tool,           // c
+  // z.
+  90: J.ABS.EXT.INPUT.Symbols.Mainhand,
+  // x.
+  88: J.ABS.EXT.INPUT.Symbols.Offhand,
+  // shift (already defined).
+  16: J.ABS.EXT.INPUT.Symbols.Dash,
+  // c.
+  67: J.ABS.EXT.INPUT.Symbols.Tool,
 
   // functional buttons.
-  81: J.ABS.EXT.INPUT.Symbols.SkillTrigger,   // q
-  17: J.ABS.EXT.INPUT.Symbols.StrafeTrigger,  // ctrl
-  69: J.ABS.EXT.INPUT.Symbols.GuardTrigger,   // e
-  9: J.ABS.EXT.INPUT.Symbols.MobilitySkill,   // tab
+  // q.
+  81: J.ABS.EXT.INPUT.Symbols.SkillTrigger,
+  // ctrl.
+  17: J.ABS.EXT.INPUT.Symbols.StrafeTrigger,
+  // e.
+  69: J.ABS.EXT.INPUT.Symbols.GuardTrigger,
+  // tab.
+  9: J.ABS.EXT.INPUT.Symbols.MobilitySkill,
 
   // quickmenu button.
-  13: J.ABS.EXT.INPUT.Symbols.Quickmenu,      // enter
+  // enter.
+  13: J.ABS.EXT.INPUT.Symbols.Quickmenu,
 
   // party cycling button.
-  46: J.ABS.EXT.INPUT.Symbols.PartyCycle,     // del
+  // del.
+  46: J.ABS.EXT.INPUT.Symbols.PartyCycle,
 
   // movement buttons.
-  38: J.ABS.EXT.INPUT.Symbols.DirUp,          // arrow up
-  40: J.ABS.EXT.INPUT.Symbols.DirDown,        // arrow down
-  37: J.ABS.EXT.INPUT.Symbols.DirLeft,        // arrow left
-  39: J.ABS.EXT.INPUT.Symbols.DirRight,       // arrow right
+  // arrow up.
+  38: J.ABS.EXT.INPUT.Symbols.DirUp,
+  // arrow down.
+  40: J.ABS.EXT.INPUT.Symbols.DirDown,
+  // arrow left.
+  37: J.ABS.EXT.INPUT.Symbols.DirLeft,
+  // arrow right.
+  39: J.ABS.EXT.INPUT.Symbols.DirRight,
 
   // keyboard alternative for the multi-button skills.
-  49: J.ABS.EXT.INPUT.Symbols.CombatSkill1,   // 1 = L1 + cross
-  50: J.ABS.EXT.INPUT.Symbols.CombatSkill2,   // 2 = L1 + circle
-  51: J.ABS.EXT.INPUT.Symbols.CombatSkill3,   // 3 = L1 + square
-  52: J.ABS.EXT.INPUT.Symbols.CombatSkill4,   // 4 = L1 + triangle
+  // 1 = L1 + cross.
+  49: J.ABS.EXT.INPUT.Symbols.CombatSkill1,
+  // 2 = L1 + circle.
+  50: J.ABS.EXT.INPUT.Symbols.CombatSkill2,
+  // 3 = L1 + square.
+  51: J.ABS.EXT.INPUT.Symbols.CombatSkill3,
+  // 4 = L1 + triangle.
+  52: J.ABS.EXT.INPUT.Symbols.CombatSkill4,
 };
 
 /**
@@ -1727,44 +1747,66 @@ Input.keyMapper = {
  */
 Input.gamepadMapper = {
   // action face buttons.
-  0: J.ABS.EXT.INPUT.Symbols.Mainhand,      // kross
-  1: J.ABS.EXT.INPUT.Symbols.Offhand,       // circle
-  2: J.ABS.EXT.INPUT.Symbols.Dash,          // square
-  3: J.ABS.EXT.INPUT.Symbols.Tool,          // triangle
+  // kross.
+  0: J.ABS.EXT.INPUT.Symbols.Mainhand,
+  // circle.
+  1: J.ABS.EXT.INPUT.Symbols.Offhand,
+  // square.
+  2: J.ABS.EXT.INPUT.Symbols.Dash,
+  // triangle.
+  3: J.ABS.EXT.INPUT.Symbols.Tool,
 
   // shoulder/trigger buttons.
-  4: J.ABS.EXT.INPUT.Symbols.SkillTrigger,  // (L1) left bumper
-  5: J.ABS.EXT.INPUT.Symbols.GuardTrigger,  // (R1) right bumper
-  6: J.ABS.EXT.INPUT.Symbols.StrafeTrigger, // (L2) left trigger
-  7: J.ABS.EXT.INPUT.Symbols.MobilitySkill, // (R2) right trigger
+  // (L1) left bumper.
+  4: J.ABS.EXT.INPUT.Symbols.SkillTrigger,
+  // (R1) right bumper.
+  5: J.ABS.EXT.INPUT.Symbols.GuardTrigger,
+  // (L2) left trigger.
+  6: J.ABS.EXT.INPUT.Symbols.StrafeTrigger,
+  // (R2) right trigger.
+  7: J.ABS.EXT.INPUT.Symbols.MobilitySkill,
 
   // meta/menu buttons.
-  8: J.ABS.EXT.INPUT.Symbols.PartyCycle,    // select
-  9: J.ABS.EXT.INPUT.Symbols.Quickmenu,     // start
+  // select.
+  8: J.ABS.EXT.INPUT.Symbols.PartyCycle,
+  // start.
+  9: J.ABS.EXT.INPUT.Symbols.Quickmenu,
 
   // stick-click buttons.
-  10: J.ABS.EXT.INPUT.Symbols.L3,           // (L3) left stick button
-  11: J.ABS.EXT.INPUT.Symbols.R3,           // (R3) right stick button
+  // (L3) left stick button.
+  10: J.ABS.EXT.INPUT.Symbols.L3,
+  // (R3) right stick button.
+  11: J.ABS.EXT.INPUT.Symbols.R3,
 
   // D-pad buttons remapped to dedicated shortcut symbols (not movement directions).
-  12: J.ABS.EXT.INPUT.Symbols.DPadUp,       // d-pad up (shortcut)
-  13: J.ABS.EXT.INPUT.Symbols.DPadDown,     // d-pad down (shortcut)
-  14: J.ABS.EXT.INPUT.Symbols.DPadLeft,     // d-pad left (shortcut)
-  15: J.ABS.EXT.INPUT.Symbols.DPadRight,    // d-pad right (shortcut)
+  // d-pad up (shortcut).
+  12: J.ABS.EXT.INPUT.Symbols.DPadUp,
+  // d-pad down (shortcut).
+  13: J.ABS.EXT.INPUT.Symbols.DPadDown,
+  // d-pad left (shortcut).
+  14: J.ABS.EXT.INPUT.Symbols.DPadLeft,
+  // d-pad right (shortcut).
+  15: J.ABS.EXT.INPUT.Symbols.DPadRight,
 
   // the analog stick should be natively supported for movement.
 };
 
-// region registries
+//region registries
 
 // Ensure a single bag for registry/bindings data on Input.
 Input._jRegistries ||= {
-  actions: Object.create(null),     // ns -> Array<action def>
-  symbolLabels: Object.create(null),// symbol -> label
-  capture: new Set(),               // Set<string>
-  bindings: Object.create(null),    // ns -> { key: string[] }
-  defaults: Object.create(null),    // ns -> { key: string[] }
-  bootstrapped: false,              // idempotency flag
+  // ns -> Array<action def>.
+  actions: Object.create(null),
+  // symbol -> label.
+  symbolLabels: Object.create(null),
+  // set<string>.
+  capture: new Set(),
+  // ns -> { key: string[] }.
+  bindings: Object.create(null),
+  // ns -> { key: string[] }.
+  defaults: Object.create(null),
+  // idempotency flag.
+  bootstrapped: false,
 };
 
 /**
@@ -3748,7 +3790,8 @@ class Scene_JabsRemap
     const extKeys = Object.keys(ext);
     for (let i = 0; i < extKeys.length; i++)
     {
-      const compound = extKeys[i]; // in the form ns:key
+      // in the form ns:key.
+      const compound = extKeys[i];
       const arr = ext[compound];
       combined[`__ext__${compound}`] = Array.isArray(arr)
         ? arr.slice(0)
@@ -4257,6 +4300,7 @@ class Scene_JabsRemap
 
 //endregion Scene_JabsRemap
 
+//region Scene_Menu
 /**
  * Extends {@link #createCommandWindow}.<br/>
  * Also wires the handler for opening the JABS input remapping scene.
@@ -4275,6 +4319,8 @@ Scene_Menu.prototype.createCommandWindow = function()
     SceneManager.push(Scene_JabsRemap);
   });
 };
+//endregion Scene_Menu
+
 
 /* eslint-disable max-len */
 
@@ -5156,21 +5202,21 @@ class Window_JabsRemapActions
     if (button === 'Primary Actions')
     {
       // describe the purpose of primary actions.
-      return 'Primary actions used moment-to-moment: mainhand/offhand attacks and tools.\n' + 'These are your core mapped buttons for direct, immediate use.';
+      return 'Primary actions used moment-to-moment: mainhand/offhand attacks and tools.\nThese are your core mapped buttons for direct, immediate use.';
     }
 
     // provide descriptions for section headers when selected.
     if (button === 'Secondary Actions')
     {
       // describe the purpose of secondary actions.
-      return 'Secondary and modifier inputs: Skill Trigger, Rotate, Strafe, Dodge.\n' + 'Hold or tap to modify movement or enable combat skill slots.';
+      return 'Secondary and modifier inputs: Skill Trigger, Rotate, Strafe, Dodge.\nHold or tap to modify movement or enable combat skill slots.';
     }
 
     // provide descriptions for section headers when selected.
     if (button === 'Functional Actions')
     {
       // describe the purpose of functional actions.
-      return 'Functional shortcuts unrelated to attacks: open the JABS menu, cycle party leader.\n' + 'Useful for management between encounters or to swap leaders on the fly.';
+      return 'Functional shortcuts unrelated to attacks: open the JABS menu, cycle party leader.\nUseful for management between encounters or to swap leaders on the fly.';
     }
 
     // a small dictionary of descriptions per logical action.
@@ -5302,7 +5348,8 @@ class Window_JabsRemapPrompt
    * Can be migrated to plugin parameters later.
    * @type {number}
    */
-  static WarmupFrames = 20; // ~0.33s
+  // ~0.33s.
+  static WarmupFrames = 20;
 
   /**
    * Maximum frames the prompt remains active before auto-closing.
@@ -5310,7 +5357,8 @@ class Window_JabsRemapPrompt
    * Can be migrated to plugin parameters later.
    * @type {number}
    */
-  static TimeoutFrames = 5 * 60; // 5s
+  // 5s.
+  static TimeoutFrames = 5 * 60;
   //endregion static
 
   /**
@@ -5750,6 +5798,7 @@ class Window_JabsRemapUsageHelp
 
 //endregion Window_JabsRemapUsageHelp
 
+//region Window_MenuCommand
 /**
  * Extends {@link #addOriginalCommands}.<br/>
  * Also adds a command to open the JABS input remapping scene from the main menu.
@@ -5808,6 +5857,8 @@ Window_MenuCommand.prototype.canAddJabsRemapCommand = function()
   // render the command!
   return true;
 };
+//endregion Window_MenuCommand
+
 
 //region Window_Selectable
 /**

--- a/project/js/plugins/abs/ext/J-ABS-PixelMovement.js
+++ b/project/js/plugins/abs/ext/J-ABS-PixelMovement.js
@@ -105,7 +105,9 @@ J.ABS.EXT.PIXEL.Aliased = {
  * A small debug container for one-frame collision sampling traces.
  */
 J.ABS.EXT.PIXEL.Debug = {
-  /** @type {{x:number,y:number,color:string}[]} */
+  /**
+   * @type {{x:number,y:number,color:string}[]}
+   */
   samples: [],
 
   /**
@@ -119,7 +121,9 @@ J.ABS.EXT.PIXEL.Debug = {
     this.samples.push({ x, y, color });
   },
 
-  /** Clears samples at end-of-frame. */
+  /**
+   * Clears samples at end-of-frame.
+   */
   clear()
   {
     this.samples.length = 0;
@@ -163,8 +167,10 @@ JABS_AiManager.moveTowardSlotIfNeeded = function(allyBattler, desiredX, desiredY
   const chr = allyBattler.getCharacter();
 
   // resolve tolerances.
-  let tolerance = 0.45; // default if ALLYAI not present.
-  let hysteresis = 0.25; // extra ring outside tolerance for gentle throttling near target.
+  // default if ALLYAI not present.
+  let tolerance = 0.45;
+  // extra ring outside tolerance for gentle throttling near target.
+  let hysteresis = 0.25;
   if (J.ABS.EXT.ALLYAI && J.ABS.EXT.ALLYAI.Metadata)
   {
     // use the configured formation tolerance if available.
@@ -279,8 +285,10 @@ JABS_AiManager.moveTowardSlotIfNeeded = function(allyBattler, desiredX, desiredY
   const chr = allyBattler.getCharacter();
 
   // resolve tolerances.
-  let tolerance = 0.45; // default if ALLYAI not present.
-  let hysteresis = 0.25; // extra ring outside tolerance for gentle throttling near target.
+  // default if ALLYAI not present.
+  let tolerance = 0.45;
+  // extra ring outside tolerance for gentle throttling near target.
+  let hysteresis = 0.25;
   if (J.ABS.EXT.ALLYAI && J.ABS.EXT.ALLYAI.Metadata)
   {
     tolerance = J.ABS.EXT.ALLYAI.Metadata.FormationTolerance;
@@ -935,6 +943,7 @@ PIXEL_CollisionManager.GridShiftX = 0;
 PIXEL_CollisionManager.GridShiftY = 0;
 //endregion PIXEL_CollisionManager
 
+//region Game_Character
 /**
  * Extends {@link processMoveCommand}.<br>
  * Ensures when move routes are being processed, that we adjust the x,y coordinates.
@@ -968,6 +977,8 @@ Game_Character.prototype.searchLimit = function()
 {
   return 40;
 };
+//endregion Game_Character
+
 
 //region Game_CharacterBase
 //region init
@@ -1485,7 +1496,8 @@ Game_CharacterBase.prototype.recordPixelPosition = function()
     const point = {
       x: this.x,
       y: this.y
-    }; //new Point(this.x, this.y);
+    // new Point(this.x, this.y);.
+    };
 
     // add the point to the tracking.
     this.addPositionalRecord(point);
@@ -3029,8 +3041,10 @@ Game_CharacterBase.prototype._pixelCheckLeftPassage = function(x, y, xDest, hb, 
     const ny = row / count;
 
     // DEBUG markers.
-    J.ABS.EXT.PIXEL.Debug.push(curColX,  ny, "rgba(255, 255, 0, 0.6)"); // yellow current
-    J.ABS.EXT.PIXEL.Debug.push(destColX, ny, "rgba(0, 255, 255, 0.6)"); // cyan dest
+    // yellow current.
+    J.ABS.EXT.PIXEL.Debug.push(curColX,  ny, "rgba(255, 255, 0, 0.6)");
+    // cyan dest.
+    J.ABS.EXT.PIXEL.Debug.push(destColX, ny, "rgba(0, 255, 255, 0.6)");
 
     // Current left-most subcell must allow moving LEFT (exiting left).
     if (this._pixelIsPositionPassable(curColX, ny, J.ABS.Directions.LEFT) === false) return false;
@@ -3092,8 +3106,10 @@ Game_CharacterBase.prototype._pixelCheckRightPassage = function(x, y, xDest, hb,
     const ny = row / count;
 
     // DEBUG markers.
-    J.ABS.EXT.PIXEL.Debug.push(curColX,  ny, "rgba(255, 255, 0, 0.6)"); // yellow current
-    J.ABS.EXT.PIXEL.Debug.push(destColX, ny, "rgba(0, 255, 255, 0.6)");  // cyan dest
+    // yellow current.
+    J.ABS.EXT.PIXEL.Debug.push(curColX,  ny, "rgba(255, 255, 0, 0.6)");
+    // cyan dest.
+    J.ABS.EXT.PIXEL.Debug.push(destColX, ny, "rgba(0, 255, 255, 0.6)");
 
     // Current right-most must allow RIGHT (exiting right).
     if (this._pixelIsPositionPassable(curColX, ny, J.ABS.Directions.RIGHT) === false) return false;
@@ -3157,8 +3173,10 @@ Game_CharacterBase.prototype._pixelCheckUpPassage = function(x, y, yDest, hb, co
     const nx = col / count;
 
     // DEBUG markers.
-    J.ABS.EXT.PIXEL.Debug.push(nx, curRowY,  "rgba(255, 255, 0, 0.6)");    // yellow current
-    J.ABS.EXT.PIXEL.Debug.push(nx, destRowY, "rgba(0, 255, 255, 0.6)");    // cyan dest
+    // yellow current.
+    J.ABS.EXT.PIXEL.Debug.push(nx, curRowY,  "rgba(255, 255, 0, 0.6)");
+    // cyan dest.
+    J.ABS.EXT.PIXEL.Debug.push(nx, destRowY, "rgba(0, 255, 255, 0.6)");
 
     // Current top must allow UP (exiting upward).
     if (this._pixelIsPositionPassable(nx, curRowY,  J.ABS.Directions.UP)   === false) return false;
@@ -3220,8 +3238,10 @@ Game_CharacterBase.prototype._pixelCheckDownPassage = function(x, y, yDest, hb, 
     const nx = col / count;
 
     // DEBUG markers.
-    J.ABS.EXT.PIXEL.Debug.push(nx, curRowY,  "rgba(255, 255, 0, 0.6)"); // yellow current
-    J.ABS.EXT.PIXEL.Debug.push(nx, destRowY, "rgba(0, 255, 255, 0.6)"); // cyan dest
+    // yellow current.
+    J.ABS.EXT.PIXEL.Debug.push(nx, curRowY,  "rgba(255, 255, 0, 0.6)");
+    // cyan dest.
+    J.ABS.EXT.PIXEL.Debug.push(nx, destRowY, "rgba(0, 255, 255, 0.6)");
 
     // Current bottom must allow DOWN (exiting downward).
     if (this._pixelIsPositionPassable(nx, curRowY,  J.ABS.Directions.DOWN) === false) return false;
@@ -3412,6 +3432,7 @@ Game_Event.prototype.isCollidedWithEvents = function(x, y)
 
 //endregion Game_Event
 
+//region Game_Follower
 /**
  * Updates the direction and position based on the preceding character.
  * This forces followers to always face the character infront of them in the follower train.
@@ -3568,6 +3589,8 @@ Game_Follower.prototype.moveDiagonally = function(horz, vert)
   J.ABS.EXT.PIXEL.Aliased.Game_Follower.get("moveDiagonally")
     .call(this, horz, vert);
 };
+//endregion Game_Follower
+
 
 //region Game_Map
 /**
@@ -3587,6 +3610,7 @@ Game_Map.prototype.setup = function(mapId)
 };
 //endregion Game_Map
 
+//region Game_Player
 /**
  * Overrides {@link Game_Player.checkEventTriggerHere}.<br>
  * Includes the rounding of the x,y coordinates when checking event triggers for things beneath you.
@@ -3660,7 +3684,8 @@ Game_Player.prototype.checkEventTriggerTouch = function(x, y)
 
   // TODO: does this actually need to round?
   // determine the threshold for pixel movement regarding event triggering.
-  const didTrigger = Math.abs(roundX - x) < 0.3 && Math.abs(roundY - y) < 0.3; // within 1/3 of a tile triggers?
+  // within 1/3 of a tile triggers?
+  const didTrigger = Math.abs(roundX - x) < 0.3 && Math.abs(roundY - y) < 0.3;
 
   // check if the event was triggered with the threshold coordinates.
   if (didTrigger)
@@ -3907,6 +3932,8 @@ Game_Player.prototype.stopFollowersPixelMoving = function()
     follower.stopPixelMoving();
   });
 };
+//endregion Game_Player
+
 
 //region JABS_Battler
 /**
@@ -4435,61 +4462,77 @@ JABS_Battler.prototype.angleToDirection = function(angle)
   const half = 22.5;
 
   // RIGHT: -22.5 .. 22.5
-  const isRight = angle > -half && angle <= half; // 6
+  // 6.
+  const isRight = angle > -half && angle <= half;
 
   // DOWN-RIGHT: 22.5 .. 67.5
-  const isDownRight = angle > half && angle <= (half + 45); // 3
+  // 3.
+  const isDownRight = angle > half && angle <= (half + 45);
 
   // DOWN: 67.5 .. 112.5
-  const isDown = angle > (half + 45) && angle <= (half + 90); // 2
+  // 2.
+  const isDown = angle > (half + 45) && angle <= (half + 90);
 
   // DOWN-LEFT: 112.5 .. 157.5
-  const isDownLeft = angle > (half + 90) && angle <= (half + 135); // 1
+  // 1.
+  const isDownLeft = angle > (half + 90) && angle <= (half + 135);
 
   // LEFT: >157.5 or <= -157.5
-  const isLeft = angle > (half + 135) || angle <= -(half + 135); // 4
+  // 4.
+  const isLeft = angle > (half + 135) || angle <= -(half + 135);
 
   // UP-LEFT: -157.5 .. -112.5
-  const isUpLeft = angle > -(half + 135) && angle <= -(half + 90); // 7
+  // 7.
+  const isUpLeft = angle > -(half + 135) && angle <= -(half + 90);
 
   // UP: -112.5 .. -67.5
-  const isUp = angle > -(half + 90) && angle <= -(half + 45); // 8
+  // 8.
+  const isUp = angle > -(half + 90) && angle <= -(half + 45);
 
   // UP-RIGHT: -67.5 .. -22.5
-  const isUpRight = angle > -(half + 45) && angle <= -half; // 9
+  // 9.
+  const isUpRight = angle > -(half + 45) && angle <= -half;
 
   // Map the sector to the direction numbers.
   if (isRight)
   {
-    return J.ABS.Directions.RIGHT; // 6
+    // 6.
+    return J.ABS.Directions.RIGHT;
   }
   else if (isDownRight)
   {
-    return J.ABS.Directions.LOWERRIGHT; // 3
+    // 3.
+    return J.ABS.Directions.LOWERRIGHT;
   }
   else if (isDown)
   {
-    return J.ABS.Directions.DOWN; // 2
+    // 2.
+    return J.ABS.Directions.DOWN;
   }
   else if (isDownLeft)
   {
-    return J.ABS.Directions.LOWERLEFT; // 1
+    // 1.
+    return J.ABS.Directions.LOWERLEFT;
   }
   else if (isLeft)
   {
-    return J.ABS.Directions.LEFT; // 4
+    // 4.
+    return J.ABS.Directions.LEFT;
   }
   else if (isUpLeft)
   {
-    return J.ABS.Directions.UPPERLEFT; // 7
+    // 7.
+    return J.ABS.Directions.UPPERLEFT;
   }
   else if (isUp)
   {
-    return J.ABS.Directions.UP; // 8
+    // 8.
+    return J.ABS.Directions.UP;
   }
   else if (isUpRight)
   {
-    return J.ABS.Directions.UPPERRIGHT; // 9
+    // 9.
+    return J.ABS.Directions.UPPERRIGHT;
   }
 
   // Unknown sector; return 0.

--- a/project/js/plugins/abs/ext/J-ABS-Shield.js
+++ b/project/js/plugins/abs/ext/J-ABS-Shield.js
@@ -1230,11 +1230,13 @@ Game_Battler.prototype.getShieldStates = function()
       const bPri = bShield.getPriority() || 0;
       if (aPri !== bPri)
       {
-        return bPri - aPri; // DESC
+        // dESC.
+        return bPri - aPri;
       }
 
       // tie-breaker: FIFO by appliedAt (earlier first).
-      return aShield.getAppliedAt() - bShield.getAppliedAt(); // ASC
+      // aSC.
+      return aShield.getAppliedAt() - bShield.getAppliedAt();
     });
 };
 

--- a/project/js/plugins/abs/ext/J-ABS-Speed.js
+++ b/project/js/plugins/abs/ext/J-ABS-Speed.js
@@ -73,6 +73,7 @@
  * ============================================================================
  */
 
+//region Introduction
 /**
  * The core where all of my extensions live: in the `J` object.
  */
@@ -169,7 +170,8 @@ IconManager.longParam = function(paramId)
   switch (paramId)
   {
     case 31:
-      return this.movespeed(); // move
+      // move.
+      return this.movespeed();
     default:
       return J.ABS.EXT.SPEED.Aliased.IconManager.get('longParam')
         .call(this, paramId);
@@ -197,7 +199,8 @@ TextManager.longParam = function(paramId)
   switch (paramId)
   {
     case 31:
-      return this.movespeed(); // move speed boost
+      // move speed boost.
+      return this.movespeed();
     default:
       // perform original logic.
       return J.ABS.EXT.SPEED.Aliased.TextManager.get('longParam')
@@ -224,7 +227,8 @@ TextManager.longParamDescription = function(paramId)
   switch (paramId)
   {
     case 31:
-      return this.moveSpeedDescription(); // move speed boost
+      // move speed boost.
+      return this.moveSpeedDescription();
     default:
       // perform original logic.
       return J.ABS.EXT.SPEED.Aliased.TextManager.get('longParamDescription')
@@ -416,7 +420,8 @@ Game_Character.prototype.minimumDistancePerFrame = function()
 {
   // the minimum speed is "2" aka "4x slower" according to events.
   // remove comment to let it go lower, but be careful, thats really low!
-  const minimumDistance = 0.015625; // / 2;
+  // / 2;.
+  const minimumDistance = 0.015625;
 
   // return the calculated amount.
   return minimumDistance;

--- a/project/js/plugins/abs/ext/J-ABS-Star.js
+++ b/project/js/plugins/abs/ext/J-ABS-Star.js
@@ -93,6 +93,7 @@ J.ABS.EXT.STAR.Regexp = {
   BattleMapId: /<battleMapId:(\d+)>/gi,
 };
 
+//region StarOrigin
 /**
  * A simple container of the coordinates of a destination.
  */
@@ -129,7 +130,10 @@ class StarOrigin
     this.y = y;
   }
 }
+//endregion StarOrigin
 
+
+//region StarPhase
 /**
  * A single phase in the stars battle.
  */
@@ -158,7 +162,10 @@ class StarPhase
    */
   key = 0;
 }
+//endregion StarPhase
 
+
+//region StarPhases
 /**
  * A collection of {@link StarPhase}s that represent the flow of a star battle.
  * @type {StarPhases}
@@ -213,7 +220,10 @@ class StarPhases
    */
   static BACKTOMAP = new StarPhase("Back-to-map", 5);
 }
+//endregion StarPhases
 
+
+//region BattleManager
 /**
  * The `enemyMap` is a property containing the master map from which enemies
  * from the troop are derived from.
@@ -394,7 +404,10 @@ BattleManager.origin = function()
 {
   return this._originLocation;
 };
+//endregion BattleManager
 
+
+//region DataManager
 /**
  * Extends {@link DataManager.createGameObjects}.<br>
  * Includes fetching the enemy map and storing it memory.
@@ -473,7 +486,10 @@ DataManager.onEnemyMapGet = function(xhr, name, src, url)
     this.gracefulFail(name, src, url);
   }
 };
+//endregion DataManager
 
+
+//region Game_Interpreter
 /**
  * Overrides {@link Game_Interpreter.command301}.<br>
  * Alters the event command handler of "Battle Processing".
@@ -540,6 +556,8 @@ Game_Interpreter.prototype.command301convertToTroopId = function(designationType
   console.error(`invalid event command params, `, designationType, troopIdentifier);
   throw new Error('borked');
 };
+//endregion Game_Interpreter
+
 
 /**
  * Extends {@link Game_Map.update}.<br>
@@ -781,6 +799,7 @@ Game_Map.prototype.returnPlayerToOrigin = function()
 //region phase 5 - backtomap
 //endregion phase 5 - backtomap
 
+//region Game_Player
 /**
  * Extends {@link Game_Player.clearTransferInfo}.<br>
  * Parse out enemy data from the troop and convert them into JABS battlers.
@@ -827,7 +846,10 @@ Game_Player.prototype.reserveOriginTransfer = function()
   } = BattleManager.origin();
   this.reserveTransfer(mapId, x, y);
 };
+//endregion Game_Player
 
+
+//region Game_Troop
 /**
  * Extends {@link Game_Troop.initialize}.<br>
  * Initializes our additional members for STABS.
@@ -890,7 +912,10 @@ Game_Troop.prototype.areEnemiesAlive = function()
 {
   return this.getRemainingEnemyCount() > 0;
 };
+//endregion Game_Troop
 
+
+//region Scene_Map
 /**
  * Overrides {@link Scene_Map.updateEncounter}.<br>
  * Disables base encounter scene management.
@@ -917,3 +942,4 @@ Scene_Map.prototype.update = function()
 
   //? TODO: Modify encountereffect here.
 };
+//endregion Scene_Map

--- a/project/js/plugins/abs/ext/J-ABS-Timing.js
+++ b/project/js/plugins/abs/ext/J-ABS-Timing.js
@@ -222,6 +222,7 @@
  * ==============================================================================
  */
 
+//region Introduction
 /**
  * The core where all of my extensions live: in the `J` object.
  */
@@ -809,13 +810,16 @@ Game_Battler.prototype.applyFastCooldown = function(originalCooldownTime)
   if (!originalCooldownTime) return 0;
 
   // get the base value.
-  const baseParam = this.baseFastCooldown(); // this.getBaseFastCooldown();
+  // this.getBaseFastCooldown();.
+  const baseParam = this.baseFastCooldown();
 
   // grab the flat modifier.
-  const flatModifier = this.fastCooldownFlat(); //this.getFastCooldownFlat();
+  // this.getFastCooldownFlat();.
+  const flatModifier = this.fastCooldownFlat();
 
   // grab the multiplicative modifier, and add the base-100 to the value.
-  const multModifier = this.fastCooldownRate(); //this.getFastCooldownRate();
+  // this.getFastCooldownRate();.
+  const multModifier = this.fastCooldownRate();
 
   // short circuit before calculations if we have no values.
   if (!baseParam && !flatModifier && !multModifier) return originalCooldownTime;

--- a/project/js/plugins/abs/ext/J-ABS-Tools.js
+++ b/project/js/plugins/abs/ext/J-ABS-Tools.js
@@ -88,6 +88,7 @@
  * @default false
  */
 
+//region Introduction
 /**
  * The core where all of my extensions live: in the `J` object.
  */
@@ -231,6 +232,7 @@ J.ABS.EXT.TOOLS.GapClosePositions = {
 };
 //endregion Introduction
 
+//region JABS_Battler
 /**
  * Initializes the properties of this battler that are not related to anything in particular.
  */
@@ -529,6 +531,8 @@ JABS_Battler.gapCloseWiggleRoom = function()
 {
   return 0.5;
 };
+//endregion JABS_Battler
+
 
 //region gapClose
 /**
@@ -572,6 +576,7 @@ Object.defineProperty(RPG_Skill.prototype, 'jabsGapClosePosition', {
 });
 //endregion gapClosePosition
 
+//region JABS_Engine
 /**
  * Processes the various on-hit effects against the target.
  * @param {JABS_Action} action The JABS action containing the action data.
@@ -623,7 +628,10 @@ JABS_Engine.prototype.canGapClose = function(action, target)
   // we can gap close!
   return true;
 };
+//endregion JABS_Engine
 
+
+//region Game_Battler
 /**
  * Determines whether or not this battler is a gap close target.
  * @returns {boolean} True if this battler is a gap close target, false otherwise.
@@ -635,7 +643,10 @@ Game_Battler.prototype.isGapClosable = function()
     J.ABS.EXT.TOOLS.RegExp.GapCloseTarget
   );
 };
+//endregion Game_Battler
 
+
+//region Game_CharacterBase
 /**
  * Extends {@link Game_CharacterBase.initMembers}.<br>
  * Also initializes our new members.
@@ -682,7 +693,8 @@ Game_CharacterBase.prototype.initToolsMembers = function()
 
   this._j._tools._grabThrow._throw._through = false;
 
-  this._j._tools._grabThrow._throw._directionFixAlways = false; // TODO: from plugin params.
+  // tODO: from plugin params.
+  this._j._tools._grabThrow._throw._directionFixAlways = false;
 
   this._j._tools._grabThrow._throw._directionFix = false;
 
@@ -690,7 +702,10 @@ Game_CharacterBase.prototype.initToolsMembers = function()
 
   this._j._tools._grabThrow._throw._wait = new JABS_Timer(0);
 };
+//endregion Game_CharacterBase
 
+
+//region Game_Event
 /**
  * Determines whether or not this event has any gap close target overrides.
  * @returns {boolean} True if this event has a gap close override, false otherwise.
@@ -718,9 +733,12 @@ Game_Event.prototype.isGapClosable = function()
   // return what we found.
   return gapCloseTarget;
 };
+//endregion Game_Event
 
 
 
+
+//region Game_System
 /**
  * Extends {@link Game_System.initMembers}.<br>
  * Also initializes our new members.
@@ -752,7 +770,8 @@ Game_System.prototype.initToolsMembers = function()
    * Whether or not the grab and throw functionality is currently enabled.
    * @type {boolean}
    */
-  this._j._tools._grabThrowEnabled = true; // TODO: parameterize this.
+  // tODO: parameterize this.
+  this._j._tools._grabThrowEnabled = true;
 };
 
 /**
@@ -780,4 +799,6 @@ Game_System.prototype.toggleGrabThrowEnabled = function()
 {
   this._j._tools._grabThrowEnabled = !this.isGrabThrowEnabled();
 };
+//endregion Game_System
+
 

--- a/src/plugins/abs/core/__models/JABS_Aabb.js
+++ b/src/plugins/abs/core/__models/JABS_Aabb.js
@@ -14,13 +14,41 @@ class JABS_Aabb
    */
   constructor(x, y, w, h)
   {
-    /** @type {number} */ this.x = x; // top-left x in pixels.
-    /** @type {number} */ this.y = y; // top-left y in pixels.
-    /** @type {number} */ this.w = w; // width in pixels.
-    /** @type {number} */ this.h = h; // height in pixels.
+    /**
+     * The top-left x coordinate in pixels.
+     * @type {number}
+     */
+    this.x = x;
 
-    /** @type {number} */ this.cx = x + (w / 2); // center x in pixels.
-    /** @type {number} */ this.cy = y + (h / 2); // center y in pixels.
+    /**
+     * The top-left y coordinate in pixels.
+     * @type {number}
+     */
+    this.y = y;
+
+    /**
+     * The width in pixels.
+     * @type {number}
+     */
+    this.w = w;
+
+    /**
+     * The height in pixels.
+     * @type {number}
+     */
+    this.h = h;
+
+    /**
+     * The center x coordinate in pixels.
+     * @type {number}
+     */
+    this.cx = x + (w / 2);
+
+    /**
+     * The center y coordinate in pixels.
+     * @type {number}
+     */
+    this.cy = y + (h / 2);
   }
 
   /**
@@ -33,8 +61,10 @@ class JABS_Aabb
    */
   static fromFeet(feetX, feetY, tw, th)
   {
-    const x = feetX - (tw / 2); // left edge half a tile left of feet.
-    const y = feetY - th;       // top edge one tile above feet.
+    // left edge half a tile left of feet.
+    const x = feetX - (tw / 2);
+    // top edge one tile above feet.
+    const y = feetY - th;
     return new JABS_Aabb(x, y, tw, th);
   }
 

--- a/src/plugins/abs/core/__models/JABS_Action.js
+++ b/src/plugins/abs/core/__models/JABS_Action.js
@@ -312,10 +312,9 @@ class JABS_Action
     const event = this.getActionSprite();
 
     // check if the action has an animation to play before destroying.
-    if (this.hasSelfAnimationId())
+    if (this.hasSelfAnimationId() && event)
     {
-      // play it on oneself.
-      event?.requestAnimation(this.getSelfAnimationId());
+      event.requestAnimation(this.getSelfAnimationId());
     }
   }
 
@@ -479,8 +478,10 @@ class JABS_Action
   {
     const damageType = this.getBaseSkill().damage.type;
     return [
-      3, // HP recover
-      4, // MP recover
+      // hP recover.
+      3,
+      // mP recover.
+      4,
     ].includes(damageType);
   }
 
@@ -1111,7 +1112,8 @@ class JABS_Action
     // this allows sprite-less actions to still render a pulse anchored to the caster.
     let originX = 0;
     let originY = 0;
-    let facing = 2; // default to down as a safe fallback.
+    // default to down as a safe fallback.
+    let facing = 2;
 
     // attempt to use the action event for origin and facing when present.
     if (actionEvent)

--- a/src/plugins/abs/core/__models/JABS_Battler/_initialization.js
+++ b/src/plugins/abs/core/__models/JABS_Battler/_initialization.js
@@ -114,7 +114,8 @@ JABS_Battler.prototype.initCoreData = function(battlerCoreData)
    * @type {boolean}
    */
   this._canIdle = battlerCoreData.isInanimate()
-    ? false // don't move idly if inanimate.
+    // don't move idly if inanimate.
+    ? false
     : battlerCoreData.canIdle();
 
   /**
@@ -123,7 +124,8 @@ JABS_Battler.prototype.initCoreData = function(battlerCoreData)
    * @type {boolean}
    */
   this._showHpBar = battlerCoreData.isInanimate()
-    ? false // don't show hp bar if inanimate.
+    // don't show hp bar if inanimate.
+    ? false
     : battlerCoreData.showHpBar();
 
   /**
@@ -132,7 +134,8 @@ JABS_Battler.prototype.initCoreData = function(battlerCoreData)
    * @type {boolean}
    */
   this._showBattlerName = battlerCoreData.isInanimate()
-    ? false // don't show battler name if inanimate.
+    // don't show battler name if inanimate.
+    ? false
     : battlerCoreData.showBattlerName();
 
   /**
@@ -459,7 +462,8 @@ JABS_Battler.prototype.initBattleInfo = function()
    * Default window for the in‑combat countdown (60fps × seconds).
    * @type {number}
    */
-  this._inCombatWindowMax = 600; // 10s default.
+  // 10s default.
+  this._inCombatWindowMax = 600;
 };
 
 /**

--- a/src/plugins/abs/core/__models/JABS_Battler/_reference.js
+++ b/src/plugins/abs/core/__models/JABS_Battler/_reference.js
@@ -960,15 +960,18 @@ JABS_Battler.prototype.isDead = function()
   const battler = this.getBattler();
 
   if (!battler)
-  { // has no battler.
+  // has no battler.
+  {
     return true;
   }
   else if (!JABS_AiManager.getBattlerByUuid(battler.getUuid()))
-  { // battler isn't on the map.
+  // battler isn't on the map.
+  {
     return true;
   }
   else if (battler.isDead() || this.isDying())
-  { // battler is actually dead.
+  // battler is actually dead.
+  {
     return true;
   }
   // battler is OK!

--- a/src/plugins/abs/core/__models/JABS_Battler/map.js
+++ b/src/plugins/abs/core/__models/JABS_Battler/map.js
@@ -410,7 +410,8 @@ JABS_Battler.prototype.applyToolForAllAllies = function(toolId)
   const battlers = $gameParty.battleMembers();
   if (battlers.length > 1)
   {
-    battlers.shift(); // remove the leader, because that's the player.
+    // remove the leader, because that's the player.
+    battlers.shift();
     battlers.forEach(battler =>
     {
       const gameAction = new Game_Action(battler, false);

--- a/src/plugins/abs/core/__models/JABS_Battler/regeneration.js
+++ b/src/plugins/abs/core/__models/JABS_Battler/regeneration.js
@@ -480,10 +480,14 @@ JABS_Battler.prototype.slipEval = function(formula, sourceBattler, afflictedBatt
 {
   // variables for contextual eval().
   /* eslint-disable no-unused-vars */
-  const a = sourceBattler;        // the one who applied the state.
-  const b = afflictedBattler;     // this battler, afflicted by the state.
-  const v = $gameVariables._data; // access to variables if you need it.
-  const s = state;                // access to the state itself if you need it.
+  // the one who applied the state.
+  const a = sourceBattler;
+  // this battler, afflicted by the state.
+  const b = afflictedBattler;
+  // access to variables if you need it.
+  const v = $gameVariables._data;
+  // access to the state itself if you need it.
+  const s = state;
   /* eslint-enable no-unused-vars */
 
   // initialize the result.
@@ -576,13 +580,16 @@ JABS_Battler.prototype.configureSlipPop = function(amount, type)
   // based on the hp/mp/tp type, we apply different visual effects.
   switch (type)
   {
-    case 0: // hp
+    // hp.
+    case 0:
       textPopBuilder.isHpDamage();
       break;
-    case 1: // mp
+    // mp.
+    case 1:
       textPopBuilder.isMpDamage();
       break;
-    case 2: // tp
+    // tp.
+    case 2:
       textPopBuilder.isTpDamage();
       break;
   }

--- a/src/plugins/abs/core/__models/JABS_EnemyAI.js
+++ b/src/plugins/abs/core/__models/JABS_EnemyAI.js
@@ -643,9 +643,12 @@ class JABS_EnemyAI
     {
       const testAction = new Game_Action(user.getBattler());
       testAction.setSkill(skillId);
-      return (testAction.isForAliveFriend() &&  // must target living allies.
-        testAction.isRecover() &&               // must recover something.
-        testAction.isHpEffect());               // must affect hp.
+      // must target living allies.
+      return (testAction.isForAliveFriend() &&
+        // must recover something.
+        testAction.isRecover() &&
+        // must affect hp.
+        testAction.isHpEffect());
     });
 
     // if we have 0 or 1 skills left after healing, just return that.

--- a/src/plugins/abs/core/__models/JABS_Location.js
+++ b/src/plugins/abs/core/__models/JABS_Location.js
@@ -40,7 +40,7 @@ class JABS_Location
    * @param {JABS_Location} sourceLocation The source location to copy the values of.
    * @returns {JABS_Location} A new instance of the same location.
    */
-  static Clone = sourceLocation => new JABS_Location(sourceLocation?.x, sourceLocation?.y, sourceLocation?.d);
+  static Clone = sourceLocation => new JABS_Location(sourceLocation.x, sourceLocation.y, sourceLocation.d);
 
   /**
    * A factory that generates builders for creating {@link JABS_Location}s.

--- a/src/plugins/abs/core/_metadata/initialization.js
+++ b/src/plugins/abs/core/_metadata/initialization.js
@@ -181,7 +181,8 @@ J.ABS.Metadata.UnassignedText = J.ABS.PluginParameters['unassignedText'];
 J.ABS.Metadata.HitboxStyles = {
   // Base defaults used for all shapes unless overridden below.
   base: {
-    fillColor: 0xFFA500, // orange
+    // orange.
+    fillColor: 0xFFA500,
     fillAlpha: 0.35,
     lineColor: 0xE08000,
     lineAlpha: 0.9,
@@ -191,13 +192,16 @@ J.ABS.Metadata.HitboxStyles = {
   // Optional per-shape overrides.
   byShape: {
     circle: {
-      fillColor: 0xFF7F50, // coral
+      // coral.
+      fillColor: 0xFF7F50,
     },
     rhombus: {
-      fillColor: 0xFFD580, // light orange
+      // light orange.
+      fillColor: 0xFFD580,
     },
     square: {
-      fillColor: 0xFFA64D, // darker orange
+      // darker orange.
+      fillColor: 0xFFA64D,
     },
     frontsquare: {
       fillAlpha: 0.28,
@@ -234,7 +238,8 @@ J.ABS.Metadata.HitboxStyles = {
     {
       colliding:
         {
-          fillColor: 0xFF3B30, // bright red while overlapping an action.
+          // bright red while overlapping an action.
+          fillColor: 0xFF3B30,
           fillAlpha: 0.35,
           lineColor: 0xC12722,
           lineWidth: 3,
@@ -504,19 +509,29 @@ J.ABS.Shapes = {
  * Strongly-typed projectile formation names used across JABS.
  */
 J.ABS.ProjectileFormations = {
-  /** A single spoke in the forward direction. */
+  /**
+   * A single spoke in the forward direction.
+   */
   Line: 'line',
 
-  /** Three spokes: forward, forward-left, forward-right. */
+  /**
+   * Three spokes: forward, forward-left, forward-right.
+   */
   Spray: 'spray',
 
-  /** Four cardinals: up, right, down, left. */
+  /**
+   * Four cardinals: up, right, down, left.
+   */
   Cross: 'cross',
 
-  /** Four diagonals: up-right, down-right, down-left, up-left. */
+  /**
+   * Four diagonals: up-right, down-right, down-left, up-left.
+   */
   Xburst: 'xburst',
 
-  /** All eight directions: cardinals + diagonals. */
+  /**
+   * All eight directions: cardinals + diagonals.
+   */
   Nova: 'nova',
 };
 
@@ -623,11 +638,13 @@ J.ABS.RegExp = {
   KnockbackResist: /<knockbackResist:[ ]?(\d+)>/gi,
 
   // parry-related.
-  IgnoreParry: /<ignoreParry:[ ]?(\d+)>/gi, //endregion ON EQUIPS
+  IgnoreParry: /<ignoreParry:[ ]?(\d+)>/gi,
+  //endregion ON EQUIPS
 
   //region ON ITEMS
   UseOnPickup: /<useOnPickup>/gi,
-  Expires: /<expires:[ ]?(\d+)>/gi, //endregion ON ITEMS
+  Expires: /<expires:[ ]?(\d+)>/gi,
+  //endregion ON ITEMS
 
   //region ON STATES
   // definition-related.
@@ -671,7 +688,8 @@ J.ABS.RegExp = {
   // state duration-related.
   StateDurationFlatPlus: /<stateDurationFlat:[ ]?([-+]?\d+)>/gi,
   StateDurationPercentPlus: /<stateDurationPerc:[ ]?([-+]?\d+)>/gi,
-  StateDurationFormulaPlus: /<stateDurationForm:\[([+\-*/ ().\w]+)]>/gi, //endregion ON STATES
+  StateDurationFormulaPlus: /<stateDurationForm:\[([+\-*/ ().\w]+)]>/gi,
+  //endregion ON STATES
 
   //region ON BATTLERS
   // core concepts.
@@ -708,7 +726,8 @@ J.ABS.RegExp = {
   ConfigInvincible: /<jabsConfig:[ ]?invincible>/i,
   ConfigNotInvincible: /<jabsConfig:[ ]?notInvincible>/i,
   ConfigNoName: /<jabsConfig:[ ]?noName>/i,
-  ConfigShowName: /<jabsConfig:[ ]?showName>/i, //endregion ON BATTLERS
+  ConfigShowName: /<jabsConfig:[ ]?showName>/i,
+  //endregion ON BATTLERS
 
   //region ON ACTORS/CLASSES
   ConfigNoSwitch: /<noSwitch>/i,
@@ -720,12 +739,18 @@ J.ABS.RegExp = {
  * Visual customization for action sprites (per-skill).
  * All tags are optional and purely visual; physics/hitboxes remain unchanged.
  */
-J.ABS.RegExp.VisOffset = /<visOffset:[ ]?(\[-?\d+,[ ]?-?\d+])>/gi; // capture full [x, y]
-J.ABS.RegExp.VisAnchor = /<visAnchor:[ ]?(\[(?:0|1|0?\.\d+),[ ]?(?:0|1|0?\.\d+)])>/gi; // capture full [ax, ay]
-J.ABS.RegExp.VisRotate = /<visRotate>/gi; // boolean
-J.ABS.RegExp.VisScale = /<visScale:[ ]?(\[-?\d+(?:\.\d+)?,[ ]?-?\d+(?:\.\d+)?])>/gi; // capture full [sx, sy]
-J.ABS.RegExp.VisZ = /<visZ:[ ]?(-?\d+)>/gi; // z-order override (number only)
-J.ABS.RegExp.VisDebug = /<visDebug>/gi; // show visual center/debug gizmo
+// capture full [x, y].
+J.ABS.RegExp.VisOffset = /<visOffset:[ ]?(\[-?\d+,[ ]?-?\d+])>/gi;
+// capture full [ax, ay].
+J.ABS.RegExp.VisAnchor = /<visAnchor:[ ]?(\[(?:0|1|0?\.\d+),[ ]?(?:0|1|0?\.\d+)])>/gi;
+// boolean.
+J.ABS.RegExp.VisRotate = /<visRotate>/gi;
+// capture full [sx, sy].
+J.ABS.RegExp.VisScale = /<visScale:[ ]?(\[-?\d+(?:\.\d+)?,[ ]?-?\d+(?:\.\d+)?])>/gi;
+// z-order override (number only).
+J.ABS.RegExp.VisZ = /<visZ:[ ]?(-?\d+)>/gi;
+// show visual center/debug gizmo.
+J.ABS.RegExp.VisDebug = /<visDebug>/gi;
 //endregion visual metadata (new)
 
 //region visual directional metadata (new)
@@ -735,16 +760,24 @@ J.ABS.RegExp.VisDebug = /<visDebug>/gi; // show visual center/debug gizmo
  * Cardinal: U/D/L/R
  * Optional diagonals: UR/UL/DR/DL
  */
-J.ABS.RegExp.VisOffsetU = /<visOffsetU:[ ]?(\[-?\d+,[ ]?-?\d+])>/gi;  // [x, y]
-J.ABS.RegExp.VisOffsetD = /<visOffsetD:[ ]?(\[-?\d+,[ ]?-?\d+])>/gi;  // [x, y]
-J.ABS.RegExp.VisOffsetL = /<visOffsetL:[ ]?(\[-?\d+,[ ]?-?\d+])>/gi;  // [x, y]
-J.ABS.RegExp.VisOffsetR = /<visOffsetR:[ ]?(\[-?\d+,[ ]?-?\d+])>/gi;  // [x, y]
+// [x, y].
+J.ABS.RegExp.VisOffsetU = /<visOffsetU:[ ]?(\[-?\d+,[ ]?-?\d+])>/gi;
+// [x, y].
+J.ABS.RegExp.VisOffsetD = /<visOffsetD:[ ]?(\[-?\d+,[ ]?-?\d+])>/gi;
+// [x, y].
+J.ABS.RegExp.VisOffsetL = /<visOffsetL:[ ]?(\[-?\d+,[ ]?-?\d+])>/gi;
+// [x, y].
+J.ABS.RegExp.VisOffsetR = /<visOffsetR:[ ]?(\[-?\d+,[ ]?-?\d+])>/gi;
 
 // Optional diagonals for future use.
-J.ABS.RegExp.VisOffsetUR = /<visOffsetUR:[ ]?(\[-?\d+,[ ]?-?\d+])>/gi; // [x, y]
-J.ABS.RegExp.VisOffsetUL = /<visOffsetUL:[ ]?(\[-?\d+,[ ]?-?\d+])>/gi; // [x, y]
-J.ABS.RegExp.VisOffsetDR = /<visOffsetDR:[ ]?(\[-?\d+,[ ]?-?\d+])>/gi; // [x, y]
-J.ABS.RegExp.VisOffsetDL = /<visOffsetDL:[ ]?(\[-?\d+,[ ]?-?\d+])>/gi; // [x, y]
+// [x, y].
+J.ABS.RegExp.VisOffsetUR = /<visOffsetUR:[ ]?(\[-?\d+,[ ]?-?\d+])>/gi;
+// [x, y].
+J.ABS.RegExp.VisOffsetUL = /<visOffsetUL:[ ]?(\[-?\d+,[ ]?-?\d+])>/gi;
+// [x, y].
+J.ABS.RegExp.VisOffsetDR = /<visOffsetDR:[ ]?(\[-?\d+,[ ]?-?\d+])>/gi;
+// [x, y].
+J.ABS.RegExp.VisOffsetDL = /<visOffsetDL:[ ]?(\[-?\d+,[ ]?-?\d+])>/gi;
 //endregion visual directional metadata (new)
 
 //region cast preview tags

--- a/src/plugins/abs/core/_metadata/pluginCommands.js
+++ b/src/plugins/abs/core/_metadata/pluginCommands.js
@@ -191,7 +191,9 @@ PluginManager.registerCommand(J.ABS.Metadata.Name, "Spawn Loot", args =>
   const parsedArmors = JSON.parse(lootArmorIds)
     .map(id => $dataArmors.at(parseInt(id)));
   const parsedAnimationId = parseInt(spawnAnimationId);
-  /** @type {Game_Event} */
+  /**
+   * @type {Game_Event}
+   */
   let lastDropped = null;
 
   // iterate and drop all the item loot.

--- a/src/plugins/abs/core/database/RPG_Skill.js
+++ b/src/plugins/abs/core/database/RPG_Skill.js
@@ -883,27 +883,36 @@ Object.defineProperty(RPG_Skill.prototype, 'jabsVisOffsetDL', {
 RPG_Skill.prototype.getJabsVisOffsetFor = function(direction)
 {
   // start from the default offset (may be [0, 0]).
-  const def = this.jabsVisOffset; // default visual offset.
+  // default visual offset.
+  const def = this.jabsVisOffset;
 
   // resolve directional override if present.
   switch (direction)
   {
-    case 8: // UP
+    // uP.
+    case 8:
       return this.jabsVisOffsetU || def || [ 0, 0 ];
-    case 2: // DOWN
+    // dOWN.
+    case 2:
       return this.jabsVisOffsetD || def || [ 0, 0 ];
-    case 4: // LEFT
+    // lEFT.
+    case 4:
       return this.jabsVisOffsetL || def || [ 0, 0 ];
-    case 6: // RIGHT
+    // rIGHT.
+    case 6:
       return this.jabsVisOffsetR || def || [ 0, 0 ];
 
-    case 9: // UP-RIGHT
+    // uP-RIGHT.
+    case 9:
       return this.jabsVisOffsetUR || this.jabsVisOffsetU || this.jabsVisOffsetR || def || [ 0, 0 ];
-    case 7: // UP-LEFT
+    // uP-LEFT.
+    case 7:
       return this.jabsVisOffsetUL || this.jabsVisOffsetU || this.jabsVisOffsetL || def || [ 0, 0 ];
-    case 3: // DOWN-RIGHT
+    // dOWN-RIGHT.
+    case 3:
       return this.jabsVisOffsetDR || this.jabsVisOffsetD || this.jabsVisOffsetR || def || [ 0, 0 ];
-    case 1: // DOWN-LEFT
+    // dOWN-LEFT.
+    case 1:
       return this.jabsVisOffsetDL || this.jabsVisOffsetD || this.jabsVisOffsetL || def || [ 0, 0 ];
   }
 

--- a/src/plugins/abs/core/managers/DataManager.js
+++ b/src/plugins/abs/core/managers/DataManager.js
@@ -70,7 +70,7 @@ DataManager.getSkillMasterMap = function()
 DataManager.loadSkillMasterMap = function(name, src)
 {
   const xhr = new XMLHttpRequest();
-  const url = 'data/' + src;
+  const url = `data/${src}`;
   xhr.open('GET', url);
   xhr.overrideMimeType('application/json');
   xhr.onload = () => this.onMapGet(xhr, name, src, url);
@@ -119,7 +119,9 @@ DataManager.makeSaveContents = function()
   const contents = J.ABS.Aliased.DataManager.get('makeSaveContents')
     .call(this);
 
-  /** @type {Game_Event[]} */
+  /**
+   * @type {Game_Event[]}
+   */
   const originalEvents = contents.map._events;
 
   const actionlessEvents = originalEvents.map(event =>

--- a/src/plugins/abs/core/managers/JABS_ActionSpawner.js
+++ b/src/plugins/abs/core/managers/JABS_ActionSpawner.js
@@ -1,3 +1,4 @@
+//region JABS_ActionSpawner
 /**
  * The action spawner is responsible for translating projectile directions into
  * fully-formed `JABS_Action` instances, including per-spoke odd/even parallel
@@ -53,7 +54,9 @@ class JABS_ActionSpawner
   static buildProjectileCountsByDirection(projectileDirections)
   {
     // initialize the per-direction counts.
-    /** @type {Object.<number, number>} */
+    /**
+     * @type {Object.<number, number>}
+     */
     const totalByDir = {};
 
     // iterate over all projectile directions.
@@ -82,7 +85,9 @@ class JABS_ActionSpawner
   static buildOffsetsByDirection(countsByDir)
   {
     // initialize the per-direction offsets.
-    /** @type {Object.<number, number[]>} */
+    /**
+     * @type {Object.<number, number[]>}
+     */
     const offsetsByDir = {};
 
     // iterate over the directions present.
@@ -213,7 +218,9 @@ class JABS_ActionSpawner
   )
   {
     // track how many offsets have been consumed per direction.
-    /** @type {Object.<number, number>} */
+    /**
+     * @type {Object.<number, number>}
+     */
     const usedIndexByDir = {};
 
     // a mapping function to build one action for a projectile in a specific direction.
@@ -275,3 +282,4 @@ class JABS_ActionSpawner
     return actions;
   }
 }
+//endregion JABS_ActionSpawner

--- a/src/plugins/abs/core/managers/JABS_AiManager.js
+++ b/src/plugins/abs/core/managers/JABS_AiManager.js
@@ -102,7 +102,9 @@ class JABS_AiManager
     const nearbyBattlers = this.getAlliedBattlersWithinRange(leaderBattler, leaderBattler.getPursuitRadius());
 
     // the filter function for determining if a battler is a follower to this leader.
-    /** @param battler {JABS_Battler} */
+    /**
+     * @param {JABS_Battler} battler
+     */
     const filtering = battler =>
     {
       // actors are not considered for leader/follower.

--- a/src/plugins/abs/core/managers/JABS_Engine.js
+++ b/src/plugins/abs/core/managers/JABS_Engine.js
@@ -207,14 +207,13 @@ class JABS_Engine
       };
     }
 
-    // determine the tile height for vertical correction.
-    const th = $gameMap.tileHeight(); // tile height in pixels.
+    // tile height is needed to vertically center the origin above the feet.
+    const th = $gameMap.tileHeight();
 
-    // compute the corrected origin at the center of the tile above the feet.
-    const x = actionEvent.screenX(); // on-screen x at feet.
-    const y = actionEvent.screenY() - (th / 2); // corrected y above feet.
+    // center the origin one tile above the feet position.
+    const x = actionEvent.screenX();
+    const y = actionEvent.screenY() - (th / 2);
 
-    // provide the computed origin.
     return {
       x,
       y
@@ -596,7 +595,9 @@ class JABS_Engine
   getPositiveJabsStatesByUuid(uuid)
   {
     // a filter function defining what is a "positive" state.
-    /** @param {JABS_State} trackedState */
+    /**
+     * @param {JABS_State} trackedState
+     */
     const filtering = trackedState =>
     {
       // if the state is expired, it is not positive.
@@ -1464,7 +1465,8 @@ class JABS_Engine
     actionEventData.uniqueId = action.getUuid();
 
     // default the deletion flag.
-    actionEventData.actionDeleted = false; // not deleted by default.
+    // not deleted by default.
+    actionEventData.actionDeleted = false;
 
     // return the mutated copy.
     return actionEventData;
@@ -1947,78 +1949,110 @@ class JABS_Engine
   addJabsActionToMap(actionEventData, action)
   {
     // find the first available hole in the data map event list.
-    let index = -1; // the index we will insert at.
+    // the index we will insert at.
+    let index = -1;
     for (let i = 0; i < $dataMap.events.length; i++)
     {
       // if an empty spot is found, use that.
       if (!$dataMap.events[i])
       {
-        index = i; // capture the hole index.
-        break; // stop searching.
+        // capture the hole index.
+        index = i;
+        // stop searching.
+        break;
       }
     }
 
     // if no hole was found, append to the end.
     if (index === -1)
     {
-      index = $dataMap.events.length; // assign next index.
+      // assign next index.
+      index = $dataMap.events.length;
     }
 
     // add the data to the $dataMap.events at the chosen index.
-    $dataMap.events[index] = actionEventData; // keep array dense.
-    actionEventData.actionIndex = index; // persist the action index.
+    // keep array dense.
+    $dataMap.events[index] = actionEventData;
+    // persist the action index.
+    actionEventData.actionIndex = index;
 
     // assign this so it exists, but isn't valid.
-    actionEventData.lootIndex = 0; // not a loot event.
+    // not a loot event.
+    actionEventData.lootIndex = 0;
 
     // create the event by hand with this new data.
-    const actionEventSprite = new Game_Event(J.ABS.DefaultValues.ActionMap, index); // construct sprite.
+    // construct sprite.
+    const actionEventSprite = new Game_Event(J.ABS.DefaultValues.ActionMap, index);
 
     const {
       x: actionX,
       y: actionY
-    } = actionEventData; // extract coordinates.
-    actionEventSprite._realX = actionX; // align position.
-    actionEventSprite._realY = actionY; // align position.
-    actionEventSprite._x = actionX; // align grid x.
-    actionEventSprite._y = actionY; // align grid y.
+    // extract coordinates.
+    } = actionEventData;
+    // align position.
+    actionEventSprite._realX = actionX;
+    // align position.
+    actionEventSprite._realY = actionY;
+    // align grid x.
+    actionEventSprite._x = actionX;
+    // align grid y.
+    actionEventSprite._y = actionY;
 
     // give it a name.
-    const skillName = action.getBaseSkill().name; // get skill name.
+    // get skill name.
+    const skillName = action.getBaseSkill().name;
     const casterName = action.getCaster()
-      .battlerName(); // get caster name.
-    actionEventSprite.__actionName = `_${casterName}-${skillName}-${index}`; // tag for debugging/tools.
+      // get caster name.
+      .battlerName();
+    // tag for debugging/tools.
+    actionEventSprite.__actionName = `_${casterName}-${skillName}-${index}`;
 
     // on rare occasions, the timing of adding an action to the map coincides with the removal of the caster.
     if (!actionEventData || !actionEventData.pages.length)
     {
-      console.error('that rare error occurred!'); // preserve existing behavior.
-      return; // stop if invalid.
+      // preserve existing behavior.
+      console.error('that rare error occurred!');
+      // stop if invalid.
+      return;
     }
 
-    const pageIndex = actionEventSprite.findProperPageIndex(); // resolve page index.
+    // resolve page index.
+    const pageIndex = actionEventSprite.findProperPageIndex();
     const {
       characterIndex,
       characterName
-    } = actionEventData.pages[pageIndex].image; // extract image data.
+    // extract image data.
+    } = actionEventData.pages[pageIndex].image;
 
-    actionEventSprite.setActionSpriteNeedsAdding(); // flag to add sprite.
-    actionEventSprite._eventId = actionEventData.id; // assign event id.
-    actionEventSprite._characterName = characterName; // assign sprite name.
-    actionEventSprite._characterIndex = characterIndex; // assign sprite index.
-    const pageData = actionEventData.pages[pageIndex]; // get page.
-    actionEventSprite.setMoveFrequency(pageData.moveFrequency); // frequency.
-    actionEventSprite.setMoveRoute(pageData.moveRoute); // route.
-    actionEventSprite.setCastedDirection($gamePlayer.direction()); // cast facing.
+    // flag to add sprite.
+    actionEventSprite.setActionSpriteNeedsAdding();
+    // assign event id.
+    actionEventSprite._eventId = actionEventData.id;
+    // assign sprite name.
+    actionEventSprite._characterName = characterName;
+    // assign sprite index.
+    actionEventSprite._characterIndex = characterIndex;
+    // get page.
+    const pageData = actionEventData.pages[pageIndex];
+    // frequency.
+    actionEventSprite.setMoveFrequency(pageData.moveFrequency);
+    // route.
+    actionEventSprite.setMoveRoute(pageData.moveRoute);
+    // cast facing.
+    actionEventSprite.setCastedDirection($gamePlayer.direction());
 
     this.applyActionToActionEventSprite(actionEventSprite, action);
 
     // prevent player interaction with the action event.
-    actionEventSprite.start = () => false; // no-op start.
+    // no-op start.
+    actionEventSprite.start = () => false;
 
-    action.setActionSprite(actionEventSprite); // associate back.
-    $gameMap.addEvent(actionEventSprite); // add to map, with hole reuse.
-    this.requestActionRendering = true; // trigger render.
+    // associate back.
+    action.setActionSprite(actionEventSprite);
+    // add to map, with hole reuse.
+    $gameMap.addEvent(actionEventSprite);
+    // trigger render.
+    this.requestActionRendering = true;
   }
 
   /**
@@ -2028,8 +2062,10 @@ class JABS_Engine
    */
   applyActionToActionEventSprite(actionEventSprite, action)
   {
-    actionEventSprite.setJabsAction(action); // wire action.
-    actionEventSprite.setDirection(action.direction()); // facing.
+    // wire action.
+    actionEventSprite.setJabsAction(action);
+    // facing.
+    actionEventSprite.setDirection(action.direction());
   }
 
   /**
@@ -2041,54 +2077,72 @@ class JABS_Engine
   addLootDropToMap(x, y, item)
   {
     // clone the loot data from the action map event id of 1.
-    const lootEventData = JsonEx.makeDeepCopy($actionMap.events[1]); // base template.
+    // base template.
+    const lootEventData = JsonEx.makeDeepCopy($actionMap.events[1]);
 
-    lootEventData.x = x; // position x.
-    lootEventData.y = y; // position y.
+    // position x.
+    lootEventData.x = x;
+    // position y.
+    lootEventData.y = y;
 
     // find the first available hole in the data map event list.
-    let index = -1; // the index we will insert at.
+    // the index we will insert at.
+    let index = -1;
     for (let i = 0; i < $dataMap.events.length; i++)
     {
       // if an empty spot is found, use that.
       if (!$dataMap.events[i])
       {
-        index = i; // capture the hole index.
-        break; // stop searching.
+        // capture the hole index.
+        index = i;
+        // stop searching.
+        break;
       }
     }
 
     // if no hole was found, append to the end.
     if (index === -1)
     {
-      index = $dataMap.events.length; // assign next index.
+      // assign next index.
+      index = $dataMap.events.length;
     }
 
     // add the loot event to the datamap list of events.
-    $dataMap.events[index] = lootEventData; // keep array dense.
-    lootEventData.lootIndex = index; // persist the loot index.
+    // keep array dense.
+    $dataMap.events[index] = lootEventData;
+    // persist the loot index.
+    lootEventData.lootIndex = index;
 
     // create the loot event by hand with this new data.
-    const jabsLootData = new JABS_LootDrop(item); // create loot model.
-    lootEventData.uuid = jabsLootData.uuid; // associate unique id.
+    // create loot model.
+    const jabsLootData = new JABS_LootDrop(item);
+    // associate unique id.
+    lootEventData.uuid = jabsLootData.uuid;
 
     // set the duration of this loot drop
     // if a custom time is available, then use that, otherwise use the default.
-    jabsLootData.duration = item.jabsExpiration ?? J.ABS.Metadata.DefaultLootExpiration; // lifetime.
+    // lifetime.
+    jabsLootData.duration = item.jabsExpiration ?? J.ABS.Metadata.DefaultLootExpiration;
 
     // generate a new event to visually represent the loot drop and flag it for adding.
-    const eventId = index; // use the reused/appended index.
-    const lootEvent = new Game_Event($gameMap.mapId(), eventId); // construct sprite.
-    lootEvent.setJabsLoot(jabsLootData); // attach loot.
+    // use the reused/appended index.
+    const eventId = index;
+    // construct sprite.
+    const lootEvent = new Game_Event($gameMap.mapId(), eventId);
+    // attach loot.
+    lootEvent.setJabsLoot(jabsLootData);
 
     // flag for adding a character sprite later via HUD/spriteset integration (unchanged elsewhere).
-    lootEvent.setLootNeedsAdding(); // if your code uses such a flag.
+    // if your code uses such a flag.
+    lootEvent.setLootNeedsAdding();
 
     // add to the map, reusing holes in the live event list as well.
-    $gameMap.addEvent(lootEvent); // will reuse holes per updated addEvent().
+    // will reuse holes per updated addEvent().
+    $gameMap.addEvent(lootEvent);
 
     // trigger the spriteset to scan and add loot sprites.
-    this.requestLootRendering = true; // ensure loot renders this frame.
+    // ensure loot renders this frame.
+    this.requestLootRendering = true;
 
     // return the loot drop that was added.
     return lootEvent;
@@ -2665,7 +2719,8 @@ class JABS_Engine
     const defenderGrd = (baseGrd + bonusGrdFromAgi + bonusGrdFromLuk) * parryIgnoredFactor;
 
     // attacker's stat calculation of hit, bonuses from agi/luk.
-    const defaultHit = 50; // this flat amount is necessary to not be ridiculously parryful early game.
+    // this flat amount is necessary to not be ridiculously parryful early game.
+    const defaultHit = 50;
     const baseHit = hundredX(casterBattler.hit) + defaultHit;
     const bonusHitFromAgi = tenPercent(casterBattler.agi);
     const bonusHitFromLuk = tenPercent(casterBattler.luk);
@@ -2692,7 +2747,8 @@ class JABS_Engine
     if (difference > 100)
     {
       return false;
-    }// the grd is too great, there is no chance of landing a hit.
+    // the grd is too great, there is no chance of landing a hit.
+    }
     else if (difference <= 0) return true;
 
     return rng > difference;
@@ -3718,9 +3774,12 @@ class JABS_Engine
   collisionSector(target, action, range, facing, degrees)
   {
     // derive pixel radius from tiles.
-    const tw = $gameMap.tileWidth(); // tile width in px.
-    const th = $gameMap.tileHeight(); // tile height in px.
-    const rPx = range * tw; // convert to pixels (use tw for circles/sectors).
+    // tile width in px.
+    const tw = $gameMap.tileWidth();
+    // tile height in px.
+    const th = $gameMap.tileHeight();
+    // convert to pixels (use tw for circles/sectors).
+    const rPx = range * tw;
 
     // get the unified, corrected origin for the action.
     const {
@@ -3747,8 +3806,10 @@ class JABS_Engine
 
     // build a unit facing vector from the numeric direction.
     // Note: J.ABS.Directions.* uses cardinals; diagonals are not used for gating.
-    let fx = 0; // facing x component.
-    let fy = 0; // facing y component.
+    // facing x component.
+    let fx = 0;
+    // facing y component.
+    let fy = 0;
     switch (facing)
     {
       case J.ABS.Directions.DOWN:
@@ -3769,8 +3830,10 @@ class JABS_Engine
     }
 
     // compute vector from origin to the target rect’s center.
-    const tx = targetRect.cx - cx; // delta x to target center.
-    const ty = targetRect.cy - cy; // delta y to target center.
+    // delta x to target center.
+    const tx = targetRect.cx - cx;
+    // delta y to target center.
+    const ty = targetRect.cy - cy;
 
     // degenerate case: target’s center exactly at origin → accept.
     if (tx === 0 && ty === 0)
@@ -3780,16 +3843,22 @@ class JABS_Engine
     }
 
     // normalize the target vector for dot-product angle testing.
-    const tLen = Math.hypot(tx, ty); // Euclidean length.
-    const tnx = tx / tLen; // unit x.
-    const tny = ty / tLen; // unit y.
+    // euclidean length.
+    const tLen = Math.hypot(tx, ty);
+    // unit x.
+    const tnx = tx / tLen;
+    // unit y.
+    const tny = ty / tLen;
 
     // compute cosine threshold for the half-angle.
-    const halfAngleRad = (degrees * 0.5) * (Math.PI / 180); // half-angle in radians.
-    const cosHalf = Math.cos(halfAngleRad); // cosine threshold.
+    // half-angle in radians.
+    const halfAngleRad = (degrees * 0.5) * (Math.PI / 180);
+    // cosine threshold.
+    const cosHalf = Math.cos(halfAngleRad);
 
     // dot-product with the facing unit vector yields cos(theta).
-    const dot = (fx * tnx) + (fy * tny); // cos(theta).
+    // cos(theta).
+    const dot = (fx * tnx) + (fy * tny);
 
     // accept if the angle is within the wedge sweep.
     return dot >= cosHalf;
@@ -3806,20 +3875,25 @@ class JABS_Engine
   collisionCircle(target, action, range)
   {
     // derive circle parameters in pixels.
-    const tw = $gameMap.tileWidth(); // assume square tiles unless specified otherwise.
-    const rPx = range * tw; // radius in pixels.
+    // assume square tiles unless specified otherwise.
+    const tw = $gameMap.tileWidth();
+    // radius in pixels.
+    const rPx = range * tw;
 
     // centralized, corrected origin for action.
     const {
       x: originCx,
       y: originCy
-    } = JABS_Engine.getActionOriginPixels(action); // unified origin.
+    // unified origin.
+    } = JABS_Engine.getActionOriginPixels(action);
 
     // build the target’s AABB.
-    const targetRect = JABS_Engine.getBattlerAabbModel(target); // target rect.
+    // target rect.
+    const targetRect = JABS_Engine.getBattlerAabbModel(target);
 
     // circle-vs-rect test.
-    return targetRect.intersectsCircle(originCx, originCy, rPx); // overlap?
+    // overlap?
+    return targetRect.intersectsCircle(originCx, originCy, rPx);
   }
 
   /**
@@ -3833,17 +3907,21 @@ class JABS_Engine
   collisionRhombus(target, action, range)
   {
     // grab tile dimensions for normalization.
-    const tw = $gameMap.tileWidth(); // tile width in px.
-    const th = $gameMap.tileHeight(); // tile height in px.
+    // tile width in px.
+    const tw = $gameMap.tileWidth();
+    // tile height in px.
+    const th = $gameMap.tileHeight();
 
     // unified action origin in pixels.
     const {
       x: cx,
       y: cy
-    } = JABS_Engine.getActionOriginPixels(action); // action origin.
+    // action origin.
+    } = JABS_Engine.getActionOriginPixels(action);
 
     // target’s AABB in pixels.
-    const rect = JABS_Engine.getBattlerAabbModel(target); // target rect.
+    // target rect.
+    const rect = JABS_Engine.getBattlerAabbModel(target);
 
     // initialize the unsigned horizontal pixel gap from origin point to rect.
     let dxPx = 0;
@@ -3874,8 +3952,10 @@ class JABS_Engine
     }
 
     // convert pixel gaps to tile distances.
-    const dxTiles = dxPx / tw; // x in tiles.
-    const dyTiles = dyPx / th; // y in tiles.
+    // x in tiles.
+    const dxTiles = dxPx / tw;
+    // y in tiles.
+    const dyTiles = dyPx / th;
 
     // inside the diamond if L1 distance in tile units is within range.
     return (dxTiles + dyTiles) <= range;
@@ -3892,27 +3972,37 @@ class JABS_Engine
   collisionSquare(target, action, range)
   {
     // compute action-centered square size in pixels.
-    const tw = $gameMap.tileWidth(); // tile width.
-    const th = $gameMap.tileHeight(); // tile height.
-    const tilesW = (2 * range + 1); // width in tiles.
-    const tilesH = (2 * range + 1); // height in tiles.
-    const wPx = tilesW * tw; // width in px.
-    const hPx = tilesH * th; // height in px.
+    // tile width.
+    const tw = $gameMap.tileWidth();
+    // tile height.
+    const th = $gameMap.tileHeight();
+    // width in tiles.
+    const tilesW = (2 * range + 1);
+    // height in tiles.
+    const tilesH = (2 * range + 1);
+    // width in px.
+    const wPx = tilesW * tw;
+    // height in px.
+    const hPx = tilesH * th;
 
     // centralized, corrected origin for action.
     const {
       x: originCx,
       y: originCy
-    } = JABS_Engine.getActionOriginPixels(action); // unified origin.
+    // unified origin.
+    } = JABS_Engine.getActionOriginPixels(action);
 
     // build action area rect centered at the corrected origin.
-    const actionRect = JABS_Aabb.centerSized(originCx, originCy, wPx, hPx); // action rect.
+    // action rect.
+    const actionRect = JABS_Aabb.centerSized(originCx, originCy, wPx, hPx);
 
     // build target AABB.
-    const targetRect = JABS_Engine.getBattlerAabbModel(target); // target rect.
+    // target rect.
+    const targetRect = JABS_Engine.getBattlerAabbModel(target);
 
     // rect-rect test.
-    return actionRect.intersectsRect(targetRect); // overlap?
+    // overlap?
+    return actionRect.intersectsRect(targetRect);
   }
 
   /**
@@ -3927,29 +4017,38 @@ class JABS_Engine
   collisionFrontSquare(target, action, range, facing)
   {
     // compute half-square dimensions in pixels.
-    const tw = $gameMap.tileWidth(); // tile width.
-    const th = $gameMap.tileHeight(); // tile height.
+    // tile width.
+    const tw = $gameMap.tileWidth();
+    // tile height.
+    const th = $gameMap.tileHeight();
 
     // total full-square tiles and derived pixel dimensions.
-    const fullTiles = (2 * range + 1); // full square tiles.
-    const fullW = fullTiles * tw; // full width in px.
-    const fullH = fullTiles * th; // full height in px.
+    // full square tiles.
+    const fullTiles = (2 * range + 1);
+    // full width in px.
+    const fullW = fullTiles * tw;
+    // full height in px.
+    const fullH = fullTiles * th;
 
     // centralized, corrected origin for action.
     const {
       x: originCx,
       y: originCy
-    } = JABS_Engine.getActionOriginPixels(action); // unified origin.
+    // unified origin.
+    } = JABS_Engine.getActionOriginPixels(action);
 
     // derive the front-half rectangle based on facing (anchored at corrected origin).
-    let actionRect; // will be computed based on facing.
+    // will be computed based on facing.
+    let actionRect;
     switch (facing)
     {
-      case J.ABS.Directions.DOWN: // 2 → bottom half from origin
+      // 2 → bottom half from origin.
+      case J.ABS.Directions.DOWN:
         actionRect = new JABS_Aabb(originCx - (fullW / 2), originCy, fullW, (fullH / 2) + (th / 2));
         break;
 
-      case J.ABS.Directions.UP: // 8 → top half up from origin
+      // 8 → top half up from origin.
+      case J.ABS.Directions.UP:
         actionRect = new JABS_Aabb(
           originCx - (fullW / 2),
           originCy - (fullH / 2) - (th / 2),
@@ -3958,11 +4057,13 @@ class JABS_Engine
         );
         break;
 
-      case J.ABS.Directions.RIGHT: // 6 → right half from origin
+      // 6 → right half from origin.
+      case J.ABS.Directions.RIGHT:
         actionRect = new JABS_Aabb(originCx, originCy - (fullH / 2), (fullW / 2) + (tw / 2), fullH);
         break;
 
-      case J.ABS.Directions.LEFT: // 4 → left half from origin
+      // 4 → left half from origin.
+      case J.ABS.Directions.LEFT:
         actionRect = new JABS_Aabb(
           originCx - (fullW / 2) - (tw / 2),
           originCy - (fullH / 2),
@@ -3977,10 +4078,12 @@ class JABS_Engine
     }
 
     // build target AABB.
-    const targetRect = JABS_Engine.getBattlerAabbModel(target); // target rect.
+    // target rect.
+    const targetRect = JABS_Engine.getBattlerAabbModel(target);
 
     // test overlap.
-    return actionRect.intersectsRect(targetRect); // overlap?
+    // overlap?
+    return actionRect.intersectsRect(targetRect);
   }
 
   /**
@@ -3995,37 +4098,48 @@ class JABS_Engine
   collisionLine(target, action, range, facing)
   {
     // acquire tile dimensions.
-    const tw = $gameMap.tileWidth(); // tile width in px.
-    const th = $gameMap.tileHeight(); // tile height in px.
+    // tile width in px.
+    const tw = $gameMap.tileWidth();
+    // tile height in px.
+    const th = $gameMap.tileHeight();
 
     // line length in pixels (use major axis for length, matching visualization elsewhere).
-    const lengthPx = range * Math.max(tw, th); // length in px.
+    // length in px.
+    const lengthPx = range * Math.max(tw, th);
 
     // determine configured thickness in tiles, fallback to default of 1 tile.
-    const thicknessTiles = this.getActionThicknessTiles(action) ?? 1; // tiles.
+    // tiles.
+    const thicknessTiles = this.getActionThicknessTiles(action) ?? 1;
 
     // clamp to a very small positive minimum in pixels to ensure the AABB has area.
-    const minPx = 1; // small positive safeguard.
+    // small positive safeguard.
+    const minPx = 1;
 
     // compute thickness in pixels along each orientation.
-    const thicknessX = Math.max(minPx, thicknessTiles * tw); // horizontal thickness.
-    const thicknessY = Math.max(minPx, thicknessTiles * th); // vertical thickness.
+    // horizontal thickness.
+    const thicknessX = Math.max(minPx, thicknessTiles * tw);
+    // vertical thickness.
+    const thicknessY = Math.max(minPx, thicknessTiles * th);
 
     // centralized, corrected origin.
     const {
       x: originCx,
       y: originCy
-    } = JABS_Engine.getActionOriginPixels(action); // unified origin.
+    // unified origin.
+    } = JABS_Engine.getActionOriginPixels(action);
 
     // build the line-as-rect based on facing from origin.
-    let actionRect; // rectangle approximation of the line.
+    // rectangle approximation of the line.
+    let actionRect;
     switch (facing)
     {
-      case J.ABS.Directions.DOWN: // 2
+      // 2.
+      case J.ABS.Directions.DOWN:
         // extend downward from the origin center, include a small extra half-tile pad.
         actionRect = new JABS_Aabb(originCx - (thicknessX / 2), originCy, thicknessX, lengthPx + (th / 2));
         break;
-      case J.ABS.Directions.UP: // 8
+      // 8.
+      case J.ABS.Directions.UP:
         // extend upward from the origin center, include a small extra half-tile pad.
         actionRect = new JABS_Aabb(
           originCx - (thicknessX / 2),
@@ -4034,11 +4148,13 @@ class JABS_Engine
           lengthPx + (th / 2)
         );
         break;
-      case J.ABS.Directions.RIGHT: // 6
+      // 6.
+      case J.ABS.Directions.RIGHT:
         // extend rightward from the origin center, include a small extra half-tile pad.
         actionRect = new JABS_Aabb(originCx, originCy - (thicknessY / 2), lengthPx + (tw / 2), thicknessY);
         break;
-      case J.ABS.Directions.LEFT: // (4)
+      // (4).
+      case J.ABS.Directions.LEFT:
         // extend leftward from the origin center, include a small extra half-tile pad.
         actionRect = new JABS_Aabb(
           originCx - lengthPx - (tw / 2),
@@ -4053,8 +4169,10 @@ class JABS_Engine
     }
 
     // build target AABB and test overlap.
-    const targetRect = JABS_Engine.getBattlerAabbModel(target); // target rect.
-    return actionRect.intersectsRect(targetRect); // overlap?
+    // target rect.
+    const targetRect = JABS_Engine.getBattlerAabbModel(target);
+    // overlap?
+    return actionRect.intersectsRect(targetRect);
   }
 
   /**
@@ -4093,8 +4211,10 @@ class JABS_Engine
     // resolve thickness (depth) in tiles (default 1 tile if not specified).
     const thicknessTiles = this.getActionThicknessTiles(action) ?? 1;
     const minPx = 1;
-    const depthW = Math.max(minPx, thicknessTiles * tw); // depth when vertical
-    const depthH = Math.max(minPx, thicknessTiles * th); // depth when horizontal
+    // depth when vertical.
+    const depthW = Math.max(minPx, thicknessTiles * tw);
+    // depth when horizontal.
+    const depthH = Math.max(minPx, thicknessTiles * th);
 
     // unified origin consistent with other shapes.
     const {
@@ -4110,16 +4230,20 @@ class JABS_Engine
     let actionRect;
     switch (facing)
     {
-      case J.ABS.Directions.DOWN: // 2 → horizontal wall below origin
+      // 2 → horizontal wall below origin.
+      case J.ABS.Directions.DOWN:
         actionRect = new JABS_Aabb(originCx - (breadthW / 2), originCy, breadthW, depthH);
         break;
-      case J.ABS.Directions.UP: // 8 → horizontal wall above origin
+      // 8 → horizontal wall above origin.
+      case J.ABS.Directions.UP:
         actionRect = new JABS_Aabb(originCx - (breadthW / 2), originCy - depthH, breadthW, depthH);
         break;
-      case J.ABS.Directions.RIGHT: // 6 → vertical wall right of origin
+      // 6 → vertical wall right of origin.
+      case J.ABS.Directions.RIGHT:
         actionRect = new JABS_Aabb(originCx, originCy - (breadthH / 2), depthW, breadthH);
         break;
-      case J.ABS.Directions.LEFT: // (4) → vertical wall left of origin
+      // (4) → vertical wall left of origin.
+      case J.ABS.Directions.LEFT:
         actionRect = new JABS_Aabb(originCx - depthW, originCy - (breadthH / 2), depthW, breadthH);
         break;
       default:

--- a/src/plugins/abs/core/managers/JABS_HitboxPulseManager.js
+++ b/src/plugins/abs/core/managers/JABS_HitboxPulseManager.js
@@ -6,19 +6,29 @@
 class JABS_HitboxPulseManager
 {
   //region static fields
-  /** @type {PIXI.Container|null} */
+  /**
+   * @type {PIXI.Container|null}
+   */
   static _layer = null;
 
-  /** @type {Sprite_HitboxPulse[]} */
+  /**
+   * @type {Sprite_HitboxPulse[]}
+   */
   static _active = [];
 
-  /** @type {Sprite_HitboxPulse[]} */
+  /**
+   * @type {Sprite_HitboxPulse[]}
+   */
   static _pool = [];
 
-  /** @type {number} */
+  /**
+   * @type {number}
+   */
   static _cap = 8;
 
-  /** @type {JABS_HitboxPulseOptions} */
+  /**
+   * @type {JABS_HitboxPulseOptions}
+   */
   static _defaults = JABS_HitboxPulseOptions.defaults();
   //endregion static fields
 
@@ -268,7 +278,8 @@ class JABS_HitboxPulseManager
   static directionToRadians(dir)
   {
     // precomputed constants for clarity.
-    const RAD_0 = 0;           // right
+    // right.
+    const RAD_0 = 0;
     const RAD_45 = Math.PI / 4;
     const RAD_90 = Math.PI / 2;
     const RAD_180 = Math.PI;
@@ -277,14 +288,22 @@ class JABS_HitboxPulseManager
 
     switch (dir)
     {
-      case 6: return RAD_0;                // right
-      case 3: return RAD_45;               // down-right
-      case 2: return RAD_90;               // down
-      case 1: return RAD_180 - RAD_45;     // down-left (135°)
-      case 4: return RAD_180;              // left
-      case 7: return -RAD_180 + RAD_45;    // up-left (-135°)
-      case 8: return RAD_N90;              // up
-      case 9: return RAD_N45;              // up-right (-45°)
+      // right.
+      case 6: return RAD_0;
+      // down-right.
+      case 3: return RAD_45;
+      // down.
+      case 2: return RAD_90;
+      // down-left (135°).
+      case 1: return RAD_180 - RAD_45;
+      // left.
+      case 4: return RAD_180;
+      // up-left (-135°).
+      case 7: return -RAD_180 + RAD_45;
+      // up.
+      case 8: return RAD_N90;
+      // up-right (-45°).
+      case 9: return RAD_N45;
     }
 
     // default: point right.

--- a/src/plugins/abs/core/objects/Game_Action.js
+++ b/src/plugins/abs/core/objects/Game_Action.js
@@ -499,7 +499,8 @@ Game_Action.prototype.itemEffectAddState = function(target, effect)
 Game_Action.prototype.canItemEffectAddState = function(target, effect)
 {
   // if the target parried the result, then its state-related effects do not apply.
-  if (target.result()?.parried) return false;
+  const result = target.result();
+  if (result && result.parried) return false;
 
   // see if the state-related effects are applied!
   return true;

--- a/src/plugins/abs/core/objects/Game_Battler.js
+++ b/src/plugins/abs/core/objects/Game_Battler.js
@@ -492,7 +492,9 @@ J.ABS.Aliased.Game_Battler.set('states', Game_Battler.prototype.states);
 Game_Battler.prototype.states = function()
 {
   // grab the original states as they were.
-  /** @type {RPG_State[]} */
+  /**
+   * @type {RPG_State[]}
+   */
   const originalStates = J.ABS.Aliased.Game_Battler.get('states')
     .call(this);
 

--- a/src/plugins/abs/core/objects/Game_Map.js
+++ b/src/plugins/abs/core/objects/Game_Map.js
@@ -161,7 +161,9 @@ Game_Map.prototype.expiredActionEvents = function()
 Game_Map.prototype.actionEventsFromDataMapByUuid = function(uuid)
 {
   // the filter function for retrieving action metadatas from the datamap.
-  /** @param {rm.types.Event} metadata */
+  /**
+   * @param {rm.types.Event} metadata
+   */
   const filtering = metadata =>
   {
     // don't include invalid or non-action event metadatas.
@@ -249,7 +251,9 @@ Game_Map.prototype.expiredLootEvents = function()
 Game_Map.prototype.lootEventsFromDataMapByUuid = function(uuid)
 {
   // the filter function for retrieving loot metadatas from the datamap.
-  /** @param {rm.types.Event} metadata */
+  /**
+   * @param {rm.types.Event} metadata
+   */
   const filtering = metadata =>
   {
     // don't include invalid or non-action event metadatas.
@@ -343,23 +347,28 @@ Game_Map.prototype.newBattlerEvents = function()
 Game_Map.prototype.addEvent = function(event)
 {
   // attempt to find the first available hole in the event list.
-  let inserted = false; // whether or not we found a spot to insert.
+  // whether or not we found a spot to insert.
+  let inserted = false;
 
   for (let i = 0; i < this._events.length; i++)
   {
     // if the slot is empty/nullish, then reuse it.
     if (!this._events[i])
     {
-      this._events[i] = event; // assign into the first available hole.
-      inserted = true; // flag that we inserted.
-      break; // stop looking for holes.
+      // assign into the first available hole.
+      this._events[i] = event;
+      // flag that we inserted.
+      inserted = true;
+      // stop looking for holes.
+      break;
     }
   }
 
   // if we didn't find a hole, then append to the end as usual.
   if (!inserted)
   {
-    this._events.push(event); // append to the end.
+    // append to the end.
+    this._events.push(event);
   }
 };
 
@@ -382,7 +391,8 @@ Game_Map.prototype.removeEvent = function(eventToRemove)
     this.handleLootEventRemoval(eventToRemove);
 
     // mark the slot as empty to avoid sparseness while preserving indices.
-    this._events[eventIndex] = null; // keep array dense and reusable.
+    // keep array dense and reusable.
+    this._events[eventIndex] = null;
   }
 };
 
@@ -393,22 +403,26 @@ Game_Map.prototype.removeEvent = function(eventToRemove)
 Game_Map.prototype.handleActionEventRemoval = function(actionToRemove)
 {
   // don't process if this event isn't an action.
-  if (!actionToRemove.isJabsAction()) return; // only handle actions.
+  // only handle actions.
+  if (!actionToRemove.isJabsAction()) return;
 
   // get the relevant metadatas for the action.
   const actionMetadatas = this.actionEventsFromDataMapByUuid(actionToRemove.getJabsActionUuid());
 
   // all removed events get erased.
-  actionToRemove.erase(); // ensure event is erased visually/logic-wise.
+  // ensure event is erased visually/logic-wise.
+  actionToRemove.erase();
 
   // and also to cleanup the current list of active jabs action events.
-  $jabsEngine.clearActionEvents(); // purge internal tracking.
+  // purge internal tracking.
+  $jabsEngine.clearActionEvents();
 
   // iterate over each of the metadatas for deletion.
   actionMetadatas.forEach(actionMetadata =>
   {
     // instead of deleting (which creates sparse arrays), null the slot.
-    $dataMap.events[actionMetadata.actionIndex] = null; // maintain dense array kind.
+    // maintain dense array kind.
+    $dataMap.events[actionMetadata.actionIndex] = null;
   });
 };
 
@@ -419,7 +433,8 @@ Game_Map.prototype.handleActionEventRemoval = function(actionToRemove)
 Game_Map.prototype.handleLootEventRemoval = function(lootToRemove)
 {
   // don't process if this event isn't loot.
-  if (!lootToRemove.isJabsLoot()) return; // only handle loot.
+  // only handle loot.
+  if (!lootToRemove.isJabsLoot()) return;
 
   // get the relevant metadatas for the loot.
   const lootMetadatas = this.lootEventsFromDataMapByUuid(lootToRemove.getJabsLoot().uuid);
@@ -428,7 +443,8 @@ Game_Map.prototype.handleLootEventRemoval = function(lootToRemove)
   lootMetadatas.forEach(lootMetadata =>
   {
     // instead of deleting (which creates sparse arrays), null the slot.
-    $dataMap.events[lootMetadata.lootIndex] = null; // maintain dense array kind.
+    // maintain dense array kind.
+    $dataMap.events[lootMetadata.lootIndex] = null;
   });
 };
 
@@ -492,7 +508,7 @@ Game_Map.prototype.hasInteractableEventInFront = function(jabsBattler)
 
   // when using cyclone's movement plugin, rounding is necessary to accommodate interacting with events
   // without actually executing your weapon attack.
-  if (J.ABS.EXT?.CYCLE)
+  if (J.ABS.EXT.CYCLE)
   {
     x2 = Math.round($gameMap.roundXWithDirection(x1, direction));
     y2 = Math.round($gameMap.roundYWithDirection(y1, direction));

--- a/src/plugins/abs/core/sprites/Sprite_Animation.js
+++ b/src/plugins/abs/core/sprites/Sprite_Animation.js
@@ -1,3 +1,4 @@
+//region Sprite_Animation
 /**
  * Extends {@link Sprite_Animation.prototype.targetPosition}.<br/>
  * Adds a guard to ensure we don't attempt to calculate positions for destroyed sprites.
@@ -69,3 +70,4 @@ Sprite_Animation.prototype.targetSpritePosition = function (sprite)
     return new Point(0, 0);
   }
 };
+//endregion Sprite_Animation

--- a/src/plugins/abs/core/sprites/Sprite_AnimationMV.js
+++ b/src/plugins/abs/core/sprites/Sprite_AnimationMV.js
@@ -1,3 +1,4 @@
+//region Sprite_AnimationMV
 /**
  * Extends/Overrides {@link Sprite_AnimationMV.prototype.updatePosition}.<br/>
  * Adds a guard to ensure we don't attempt to follow destroyed or removed sprites.
@@ -76,3 +77,4 @@ Sprite_AnimationMV.prototype.updatePosition = function ()
       .call(this);
   }
 };
+//endregion Sprite_AnimationMV

--- a/src/plugins/abs/core/sprites/Spriteset_Map.js
+++ b/src/plugins/abs/core/sprites/Spriteset_Map.js
@@ -1278,7 +1278,7 @@ Spriteset_Map.prototype.getActionHitboxStyleFor = function (shape)
 
   // apply shape-specific overrides if provided.
   const key = (shape || String.empty).toLowerCase(); // normalized key.
-  const shapeOverrides = styles.byShape?.[key] || null; // optional per-shape.
+  const shapeOverrides = (styles.byShape || {})[key] || null;
 
   // produce the final style.
   const finalStyle = Object.assign({}, base, shapeOverrides || {}); // merged final style.
@@ -2068,13 +2068,13 @@ Spriteset_Map.prototype.getBattlerHitboxStyle = function (
 
   // apply kind-specific overrides if provided.
   const kindKey = (kind || 'battler').toLowerCase(); // normalized.
-  const byKind = styles.byKind?.[kindKey] || null; // optional kind overrides.
+  const byKind = (styles.byKind || {})[kindKey] || null;
 
   // apply state-specific overrides if provided (e.g., colliding).
-  const stateKey = (state || String.empty).toLowerCase(); // normalized.
+  const stateKey = (state || String.empty).toLowerCase();
   const byState = stateKey
-    ? (styles.byState?.[stateKey] || null)
-    : null; // optional state overrides.
+    ? ((styles.byState || {})[stateKey] || null)
+    : null;
 
   // layered result: base -> kind -> state.
   const finalStyle = Object.assign({}, base, byKind || {}, byState || {}); // merged final style.

--- a/src/plugins/abs/core/windows/Window_AbsHelp.js
+++ b/src/plugins/abs/core/windows/Window_AbsHelp.js
@@ -1,3 +1,4 @@
+//region Window_AbsHelp
 class Window_AbsHelp
   extends Window_Help
 {
@@ -6,3 +7,4 @@ class Window_AbsHelp
     super(rect);
   }
 }
+//endregion Window_AbsHelp

--- a/src/plugins/abs/core/windows/Window_AbsMenuSelect.js
+++ b/src/plugins/abs/core/windows/Window_AbsMenuSelect.js
@@ -251,7 +251,9 @@ class Window_AbsMenuSelect
     const leader = $gameParty.leader();
 
     // an iterator function for iterating over skill slots and rendering their data.
-    /** @param {JABS_SkillSlot} skillSlot */
+    /**
+     * @param {JABS_SkillSlot} skillSlot
+     */
     const forEacher = skillSlot =>
     {
       // initialize the command variables.

--- a/src/plugins/abs/ext/allyai/_metadata/initialization.js
+++ b/src/plugins/abs/ext/allyai/_metadata/initialization.js
@@ -1,3 +1,4 @@
+//region Introduction
 /* eslint-disable max-len */
 /**
  * The core where all of my extensions live: in the `J` object.
@@ -76,12 +77,18 @@ J.ABS.EXT.ALLYAI.Metadata.FormationTypes = [
     description: "The rear-wedge formation.\nAllies will fan out behind you for support.",
     formation:
       [
-        [ -1, -1 ], // 1 back-left (behind is negative Y when facing DOWN)
-        [  1, -1 ], // 2 back-right
-        [  0, -2 ], // 3 two tiles behind
-        [ -1, -2 ], // 4 farther back-left
-        [  1, -2 ], // 5 farther back-right
-        [  0, -4 ], // 6 three tiles behind
+        // 1 back-left (behind is negative Y when facing DOWN).
+        [ -1, -1 ],
+        // 2 back-right.
+        [  1, -1 ],
+        // 3 two tiles behind.
+        [  0, -2 ],
+        // 4 farther back-left.
+        [ -1, -2 ],
+        // 5 farther back-right.
+        [  1, -2 ],
+        // 6 three tiles behind.
+        [  0, -4 ],
       ],
     effects: [],
   },
@@ -91,12 +98,18 @@ J.ABS.EXT.ALLYAI.Metadata.FormationTypes = [
     description: "A side- flank formation.\nAllies will flank you at either side to look extra menacing.",
     formation:
       [
-        [ -1,  0 ], // 1 left
-        [  1,  0 ], // 2 right
-        [ -2,  0 ], // 3 far-left
-        [  2,  0 ], // 4 far-right
-        [ -3,  0 ], // 5 farther-left
-        [  3,  0 ], // 6 farther-right
+        // 1 left.
+        [ -1,  0 ],
+        // 2 right.
+        [  1,  0 ],
+        // 3 far-left.
+        [ -2,  0 ],
+        // 4 far-right.
+        [  2,  0 ],
+        // 5 farther-left.
+        [ -3,  0 ],
+        // 6 farther-right.
+        [  3,  0 ],
       ],
     effects: [],
   },
@@ -106,14 +119,22 @@ J.ABS.EXT.ALLYAI.Metadata.FormationTypes = [
     description: "The tight circle formation.\nNo one will get to most delicate squishy innard!",
     formation:
       [
-        [  0,  1 ], // 1 below
-        [  1,  0 ], // 2 right
-        [  0, -1 ], // 3 above
-        [ -1,  0 ], // 4 left
-        [  1,  1 ], // 5 lower-right
-        [ -1,  1 ], // 6 lower-left
-        [  1, -1 ], // 7 upper-right
-        [ -1, -1 ], // 8 upper-left
+        // 1 below.
+        [  0,  1 ],
+        // 2 right.
+        [  1,  0 ],
+        // 3 above.
+        [  0, -1 ],
+        // 4 left.
+        [ -1,  0 ],
+        // 5 lower-right.
+        [  1,  1 ],
+        // 6 lower-left.
+        [ -1,  1 ],
+        // 7 upper-right.
+        [  1, -1 ],
+        // 8 upper-left.
+        [ -1, -1 ],
       ],
     effects: [],
   },

--- a/src/plugins/abs/ext/allyai/_models/JABS_AllyAI.js
+++ b/src/plugins/abs/ext/allyai/_models/JABS_AllyAI.js
@@ -456,7 +456,8 @@ JABS_AllyAI.prototype.decideSupportCleansing = function(availableSkills, healer)
       // the find the first one that we can cleanse.
       const cleansableState = allyStates.find(state =>
       {
-        const isNegative = state.jabsNegative; // skills to be cleansed have a "negative" tag.
+        // skills to be cleansed have a "negative" tag.
+        const isNegative = state.jabsNegative;
         const canBeCleansed = this.determineBestSkillForStateCleansing(availableSkills, state.id, healer);
         return isNegative && canBeCleansed;
       });
@@ -526,9 +527,12 @@ JABS_AllyAI.prototype.decideSupportHealing = function(availableSkills, healer)
   {
     const testAction = new Game_Action(healer.getBattler());
     testAction.setSkill(skillId);
-    return (testAction.isForAliveFriend() &&  // must target living allies.
-      testAction.isRecover() &&               // must recover something.
-      testAction.isHpEffect());               // must affect hp.
+    // must target living allies.
+    return (testAction.isForAliveFriend() &&
+      // must recover something.
+      testAction.isRecover() &&
+      // must affect hp.
+      testAction.isHpEffect());
   });
 
   let bestSkillId = 0;
@@ -631,7 +635,8 @@ JABS_AllyAI.prototype.countLowHpAllies = function(healer, threshold = 0.6)
 JABS_AllyAI.prototype.bestFitHealingOneSkill = function(healingTypeSkills, healerBattler, lowestAllyBattler)
 {
   let bestSkillId = 0;
-  let smallestDifference = Number.MAX_SAFE_INTEGER; // need it to be an unrealistically high difference to start.
+  // need it to be an unrealistically high difference to start.
+  let smallestDifference = Number.MAX_SAFE_INTEGER;
   healingTypeSkills.forEach(skillId =>
   {
     const skill = healerBattler.skill(skillId);
@@ -687,7 +692,8 @@ JABS_AllyAI.prototype.bestFitHealingAllSkill = function(healingTypeSkills, heale
   // if there is only one skill that multi-targets, then use that.
   if (multiTargetHealingTypeSkills.length === 1) return multiTargetHealingTypeSkills[0];
 
-  let smallestDifference = 99999999; // need it to be an unrealistically high difference to start.
+  // need it to be an unrealistically high difference to start.
+  let smallestDifference = 99999999;
   multiTargetHealingTypeSkills.forEach(skillId =>
   {
     const skill = healerBattler.skill(skillId);

--- a/src/plugins/abs/ext/allyai/scenes/Scene_Map.js
+++ b/src/plugins/abs/ext/allyai/scenes/Scene_Map.js
@@ -325,7 +325,9 @@ Scene_Map.prototype.commandSelectAllyFormation = function()
 {
   const window = this.getAllyFormationWindow();
 
-  /** @type {JABS_Formation} */
+  /**
+   * @type {JABS_Formation}
+   */
   const selectedFormation = window.currentExt();
   $gameParty.setPartyFormation(selectedFormation.key);
   window.refresh();

--- a/src/plugins/abs/ext/allyai/windows/Window_AbsMenuSelect.js
+++ b/src/plugins/abs/ext/allyai/windows/Window_AbsMenuSelect.js
@@ -119,9 +119,11 @@ Window_AbsMenuSelect.prototype.addAllyFormationCommand = function()
 {
   // define the icons for passive/aggressive ally AI aggro settings.
   // build the command.
-  const allyFormationsCommand = new WindowCommandBuilder("Ally Formations") // TODO: parameterize this.
+  // tODO: parameterize this.
+  const allyFormationsCommand = new WindowCommandBuilder("Ally Formations")
     .setSymbol('ally-formations')
-    .setIconIndex(289) // TODO: parameterize this.
+    // tODO: parameterize this.
+    .setIconIndex(289)
     .setColorIndex(23)
     .build();
 

--- a/src/plugins/abs/ext/allyai/windows/Window_Formations.js
+++ b/src/plugins/abs/ext/allyai/windows/Window_Formations.js
@@ -1,3 +1,4 @@
+//region Window_Formations
 /**
  * A window that allows selection from a list of ally AI formations.
  */
@@ -65,3 +66,4 @@ class Window_Formations
     return this.lineHeight() * 2;
   }
 }
+//endregion Window_Formations

--- a/src/plugins/abs/ext/charge/_metadata/initialization.js
+++ b/src/plugins/abs/ext/charge/_metadata/initialization.js
@@ -1,3 +1,4 @@
+//region Introduction
 /**
  * The core where all of my extensions live: in the `J` object.
  */

--- a/src/plugins/abs/ext/cycle/_metadata/initialization.js
+++ b/src/plugins/abs/ext/cycle/_metadata/initialization.js
@@ -1,3 +1,4 @@
+//region Introduction
 /**
  * The core where all of my extensions live: in the `J` object.
  */

--- a/src/plugins/abs/ext/cycle/_models/JABS_Battler.js
+++ b/src/plugins/abs/ext/cycle/_models/JABS_Battler.js
@@ -1,3 +1,4 @@
+//region JABS_Battler
 /**
  * Sets the number of steps that will be force-moved when dodging.
  * @param {number} stepCount The number of steps to dodge.
@@ -35,3 +36,4 @@ JABS_Battler.prototype.destroy = function()
     CycloneMovement.loadDefaultCollisionTable();
   }
 };
+//endregion JABS_Battler

--- a/src/plugins/abs/ext/cycle/objects/Game_Follower.js
+++ b/src/plugins/abs/ext/cycle/objects/Game_Follower.js
@@ -1,3 +1,4 @@
+//region Game_Follower
 /**
  * Overrides {@link Game_Follower.chaseCharacter}.<br>
  * Prevents the follower from chasing after the player while they are in combat.
@@ -33,3 +34,4 @@ Game_Follower.prototype.isDoingJabsAllyAiThings = function()
   // we must be doing JABS AI things!
   return true;
 };
+//endregion Game_Follower

--- a/src/plugins/abs/ext/danger/_metadata/initialization.js
+++ b/src/plugins/abs/ext/danger/_metadata/initialization.js
@@ -1,3 +1,4 @@
+//region Introduction
 /**
  * The core where all of my extensions live: in the `J` object.
  */

--- a/src/plugins/abs/ext/danger/objects/Game_Battler.js
+++ b/src/plugins/abs/ext/danger/objects/Game_Battler.js
@@ -1,3 +1,4 @@
+//region Game_Battler
 /**
  * Gets the numeric representation of this battler's strength.
  * @returns {number}
@@ -75,3 +76,4 @@ Game_Battler.prototype.getDangerIndicatorIcon = function()
       return -1;
   }
 };
+//endregion Game_Battler

--- a/src/plugins/abs/ext/diag/_metadata/initialization.js
+++ b/src/plugins/abs/ext/diag/_metadata/initialization.js
@@ -1,3 +1,4 @@
+//region Initialization
 /**
  * The core where all of my extensions live: in the `J` object.
  */

--- a/src/plugins/abs/ext/diag/objects/Game_Event.js
+++ b/src/plugins/abs/ext/diag/objects/Game_Event.js
@@ -113,7 +113,7 @@ Game_Event.prototype.moveDiagonally = function(horz, vert)
   if (this.isJabsAction() === false) return;
 
   // if this is not a diagonal direction, don't try to modify facing.
-  if !this.isDiagonalDirection(this.direction()) return;
+  if (!this.isDiagonalDirection(this.direction())) return;
 
   // determine the correct direction to face and set it.
   const newDirection = this.normalizeActionDirection();

--- a/src/plugins/abs/ext/diag/objects/Game_Event.js
+++ b/src/plugins/abs/ext/diag/objects/Game_Event.js
@@ -113,7 +113,7 @@ Game_Event.prototype.moveDiagonally = function(horz, vert)
   if (this.isJabsAction() === false) return;
 
   // if this is not a diagonal direction, don't try to modify facing.
-  if (this.isDiagonalDirection(this.direction()) === false) return;
+  if !this.isDiagonalDirection(this.direction()) return;
 
   // determine the correct direction to face and set it.
   const newDirection = this.normalizeActionDirection();
@@ -139,55 +139,76 @@ Game_Event.prototype.normalizeActionDirection = function()
   // normalize the direction that should be faced.
   switch (castedDirection)
   {
-    case 2: // caster faced down
+    // caster faced down.
+    case 2:
       switch (actionDirection)
       {
-        case 1: // action moving lower left
-        case 3: // action moving lower right
+        // action moving lower left.
+        case 1:
+        // action moving lower right.
+        case 3:
           return castedDirection;
-        case 7: // action moving upper left
-        case 9: // action moving upper right
+        // action moving upper left.
+        case 7:
+        // action moving upper right.
+        case 9:
           return this.reverseDir(castedDirection);
       }
       return castedDirection;
 
-    case 4: // caster faced left
+    // caster faced left.
+    case 4:
       switch (actionDirection)
       {
-        case 1: // action moving lower left
-        case 7: // action moving upper left
+        // action moving lower left.
+        case 1:
+        // action moving upper left.
+        case 7:
           return castedDirection;
-        case 3: // action moving lower right
-        case 9: // action moving upper right
+        // action moving lower right.
+        case 3:
+        // action moving upper right.
+        case 9:
           return this.reverseDir(castedDirection);
       }
       return castedDirection;
 
-    case 6: // caster faced right
+    // caster faced right.
+    case 6:
       switch (actionDirection)
       {
-        case 3: // action moving lower right
-        case 9: // action moving upper right
+        // action moving lower right.
+        case 3:
+        // action moving upper right.
+        case 9:
           return castedDirection;
-        case 1: // action moving lower left
-        case 7: // action moving upper left
+        // action moving lower left.
+        case 1:
+        // action moving upper left.
+        case 7:
           return this.reverseDir(castedDirection);
       }
       return castedDirection;
 
-    case 8: // caster faced up
+    // caster faced up.
+    case 8:
       switch (actionDirection)
       {
-        case 7: // action moving upper left
-        case 9: // action moving upper right
+        // action moving upper left.
+        case 7:
+        // action moving upper right.
+        case 9:
           return castedDirection;
-        case 1: // action moving lower left
-        case 3: // action moving lower right
+        // action moving lower left.
+        case 1:
+        // action moving lower right.
+        case 3:
           return this.reverseDir(castedDirection);
       }
       return castedDirection;
 
-    default: // somehow we were not facing one of the four cardinal directions, return default.
+    // somehow we were not facing one of the four cardinal directions, return default.
+    default:
       return castedDirection;
   }
 };

--- a/src/plugins/abs/ext/formula/_metadata/initialization.js
+++ b/src/plugins/abs/ext/formula/_metadata/initialization.js
@@ -43,13 +43,19 @@ J.ABS.EXT.FORMULA.Aliased.JABS_Engine = new Map();
  * Execution-time context flags and helpers for this extension.
  */
 J.ABS.EXT.FORMULA.Context = {
-  /** Whether sub-executions should suppress cascading of this extension. */
+  /**
+   * Whether sub-executions should suppress cascading of this extension.
+   */
   suppressCascades: false,
 
-  /** Whether to suppress applyGlobal() (i.e., skip child skill common events). */
+  /**
+   * Whether to suppress applyGlobal() (i.e., skip child skill common events).
+   */
   suppressCommonEvents: false,
 
-  /** The active trigger while applying packets ("hit" | "use"). */
+  /**
+   * The active trigger while applying packets ("hit" | "use").
+   */
   activeTrigger: null,
 
   /**
@@ -71,7 +77,9 @@ J.ABS.EXT.FORMULA.Settings = {
    */
   logFlushTiming: "after-base",
 
-  /** Prefer appending if supported by the manager (so base logs remain visually first). */
+  /**
+   * Prefer appending if supported by the manager (so base logs remain visually first).
+   */
   preferAppend: true,
 };
 

--- a/src/plugins/abs/ext/formula/database/RPG_Skill.js
+++ b/src/plugins/abs/ext/formula/database/RPG_Skill.js
@@ -7,8 +7,10 @@
 RPG_Skill.prototype.jabsFormulaEffects = function()
 {
   // initialize cache location if missing.
-  this._j ||= {}; // shared J root.
-  this._j._abs ||= {}; // JABS root.
+  // shared J root.
+  this._j ||= {};
+  // jABS root.
+  this._j._abs ||= {};
 
   // build and cache on first access.
   if (!this._j._abs._formulaEffects)

--- a/src/plugins/abs/ext/formula/managers/JABS_Engine.js
+++ b/src/plugins/abs/ext/formula/managers/JABS_Engine.js
@@ -28,14 +28,17 @@ JABS_Engine.prototype.applyOnUseFormulaPackets = function(caster, primaryAction)
 {
   // obtain the underlying Game_Action from the JABS action.
   const gameAction = primaryAction.getAction();
-  if (!gameAction) return; // no underlying action => nothing to apply.
+  // no underlying action => nothing to apply.
+  if (!gameAction) return;
 
   // set context to on-use while evaluating packets.
   const ctx = J.ABS.EXT.FORMULA.Context;
   const prevTrigger = ctx.activeTrigger;
   const prevCascade = ctx.suppressCascades;
-  ctx.activeTrigger = FormulaEffect.Trigger.USE; // "use"
-  ctx.suppressCascades = false; // parent-level packets should execute.
+  // "use".
+  ctx.activeTrigger = FormulaEffect.Trigger.USE;
+  // parent-level packets should execute.
+  ctx.suppressCascades = false;
 
   try
   {
@@ -73,29 +76,40 @@ JABS_Engine.prototype.forceMapAction = function(
 {
   // build options based on inputs (to derive a primary action for on-use packets).
   const actionLocation = JABS_Location.Builder()
-    .setX(targetX) // set the target x.
-    .setY(targetY) // set the target y.
-    .build(); // build the location.
+    // set the target x.
+    .setX(targetX)
+    // set the target y.
+    .setY(targetY)
+    // build the location.
+    .build();
   const actionOptions = JABS_ActionOptions.Builder()
-    .setIsRetaliation(isRetaliation) // set if this is a retaliation.
-    .setLocation(actionLocation) // apply the action location.
-    .setIsTerrainDamage(isMapDamage) // set if this is environmental damage.
-    .build(); // build the options.
+    // set if this is a retaliation.
+    .setIsRetaliation(isRetaliation)
+    // apply the action location.
+    .setLocation(actionLocation)
+    // set if this is environmental damage.
+    .setIsTerrainDamage(isMapDamage)
+    // build the options.
+    .build();
 
   // generate the actions to obtain the primary action for on-use packet firing.
   // NOTE: this preview is used only to feed the on-use hook below; actual execution is
   // performed by the original method to avoid duplication and preserve core behavior.
-  const previewActions = caster.createJabsActionFromSkill(skillId, actionOptions); // create preview.
+  // create preview.
+  const previewActions = caster.createJabsActionFromSkill(skillId, actionOptions);
 
   // if we cannot execute map actions, then do not proceed.
-  if (!this.canExecuteMapActions(caster, previewActions)) return; // guard execution.
+  // guard execution.
+  if (!this.canExecuteMapActions(caster, previewActions)) return;
 
   // fire on-use packets at launch time for forced actions using the primary preview action.
-  this.applyOnUseFormulaPackets(caster, previewActions[0]); // launch-time on-use.
+  // launch-time on-use.
+  this.applyOnUseFormulaPackets(caster, previewActions[0]);
 
   // delegate to the original forceMapAction (immediate execution path without costs/cooldowns/cast time),
   // preserving all core behavior (animations, collisions, effects, logs, threat, etc.).
   J.ABS.EXT.FORMULA.Aliased.JABS_Engine.get("forceMapAction")
-    .call(this, caster, skillId, isRetaliation, targetX, targetY, isMapDamage); // call original.
+    // call original.
+    .call(this, caster, skillId, isRetaliation, targetX, targetY, isMapDamage);
 };
 //endregion JABS_Engine

--- a/src/plugins/abs/ext/formula/objects/Game_Action.js
+++ b/src/plugins/abs/ext/formula/objects/Game_Action.js
@@ -1,5 +1,4 @@
 //region Game_Action
-//region Game_Action
 /**
  * Extends {@link Game_Action.applyVirtualJabsAction}.<br/>
  * Injects on-use packets before the core apply flow, and on-hit packets after.
@@ -37,7 +36,8 @@ Game_Action.prototype.applyFormulaPackets = function(trigger, parentTarget)
 {
   // ensure we have an item/skill to check.
   const skill = this.item();
-  if (!skill || !skill.isSkill()) return; // only skills for now.
+  // only skills for now.
+  if (!skill || !skill.isSkill()) return;
 
   // gather all effects and filter by trigger.
   const allEffects = skill.jabsFormulaEffects();
@@ -190,15 +190,19 @@ Game_Action.prototype.applyFormulaModePacket = function(effect, recipient)
   const raw = this.evaluateFormula(effect.formula, this.subject(), recipient, this.item());
   if (!raw) return;
 
-  const isDamage = raw > 0; // identify damage vs healing/gain.
-  const baseMag = Math.abs(raw); // pipeline expects a positive magnitude.
+  // identify damage vs healing/gain.
+  const isDamage = raw > 0;
+  // pipeline expects a positive magnitude.
+  const baseMag = Math.abs(raw);
 
   // run magnitude through battle pipeline (element/phys-mag/guard/variance/JABS guard; REC on heals).
   const piped = this.pipeFormulaThroughBattleCalculations(recipient, baseMag, effect, isDamage);
 
   // finalize and apply by resource.
-  const mag = Math.max(0, Math.round(piped)); // enforce non-negative integer.
-  if (mag === 0) return; // no net impact.
+  // enforce non-negative integer.
+  const mag = Math.max(0, Math.round(piped));
+  // no net impact.
+  if (mag === 0) return;
 
   // snapshot the current result so our packet doesn't overwrite the base action's result.
   const r = recipient.result();
@@ -250,7 +254,8 @@ Game_Action.prototype.applyFormulaModePacket = function(effect, recipient)
   // action log for any resource, attributed to the parent skill id.
   const signed = isDamage
     ? mag
-    : -mag; // negative => heal/gain, positive => damage/loss.
+    // negative => heal/gain, positive => damage/loss.
+    : -mag;
   const parentSkillId = this.item()
     ? this.item().id
     : 0;
@@ -298,7 +303,8 @@ Game_Action.prototype.pipeFormulaThroughBattleCalculations = function(target, ma
   value *= this.calcElementRate(target);
 
   // 2) critical only for damage and only if parent was critical (on-hit context).
-  if (isDamage && J.ABS.EXT.FORMULA.Context.activeTrigger === FormulaEffect.Trigger.HIT && target.result()?.critical)
+  const targetResult = target.result();
+  if (isDamage && J.ABS.EXT.FORMULA.Context.activeTrigger === FormulaEffect.Trigger.HIT && targetResult && targetResult.critical)
   {
     value = this.applyCritical(value);
   }
@@ -374,12 +380,14 @@ Game_Action.prototype.executeChildSkillPacket = function(effect, recipient, pare
 {
   // look up the child skill.
   const child = $dataSkills[effect.skillId];
-  if (!child) return; // invalid skill id => nothing to do.
+  // invalid skill id => nothing to do.
+  if (!child) return;
 
   // resolve the subject as a JABS battler; full JABS actions require a JABS_Battler caster.
   const subject = this.subject();
   const jabsSubject = JABS_AiManager.getBattlerByUuid(subject.getUuid());
-  if (!jabsSubject) return; // subject must exist on-map as a JABS battler.
+  // subject must exist on-map as a JABS battler.
+  if (!jabsSubject) return;
 
   // optionally bias execution with the recipient’s current coordinates (useful for target/ground casts).
   let targetX = null;
@@ -494,7 +502,8 @@ Game_Action.prototype.generateFormulaActionLogIfAvailable = function(recipient, 
   const isHeal = signed < 0;
 
   // heals can also be critical; use the recipient's current action result flag if present.
-  const wasCrit = recipient.result()?.critical === true;
+  const recipientResult = recipient.result();
+  const wasCrit = recipientResult ? recipientResult.critical === true : false;
 
   // build and enqueue the action log entry using the standard execution line.
   const log = new ActionLogBuilder()

--- a/src/plugins/abs/ext/hitstop/_metadata/_pluginMetadata.js
+++ b/src/plugins/abs/ext/hitstop/_metadata/_pluginMetadata.js
@@ -71,7 +71,7 @@ class JHitstop_PluginMetadata
      */
     this.flashOnHit = false;
 
-    // region shake
+    //region shake
     /**
      * Enables a tiny screen shake when hitstop is applied.
      * @type {boolean}

--- a/src/plugins/abs/ext/hitstop/_metadata/initialization.js
+++ b/src/plugins/abs/ext/hitstop/_metadata/initialization.js
@@ -47,11 +47,17 @@ J.ABS.EXT.HITSTOP.Aliased.JABS_Action = new Map();
  * All regular expressions used by this plugin.
  */
 J.ABS.EXT.HITSTOP.RegExp = {
-  /** Skill: `<hitstop:N>` */
+  /**
+   * Skill: `<hitstop:N>`
+   */
   Hitstop: /<hitstop:[ ]?(\d+)>/i,
-  /** Skill: `<noHitstop>` */
+  /**
+   * Skill: `<noHitstop>`
+   */
   NoHitstop: /<noHitstop>/i,
-  /** Actor/Enemy: `<hitstopScale:P%>` */
+  /**
+   * Actor/Enemy: `<hitstopScale:P%>`
+   */
   HitstopScale: /<hitstopScale:[ ]?(\d+)%>/i,
 };
 //endregion initialization

--- a/src/plugins/abs/ext/input/_metadata/initialization.js
+++ b/src/plugins/abs/ext/input/_metadata/initialization.js
@@ -1,3 +1,4 @@
+//region introduction
 /**
  * The core where all of my extensions live: in the `J` object.
  */

--- a/src/plugins/abs/ext/input/managers/Input.js
+++ b/src/plugins/abs/ext/input/managers/Input.js
@@ -51,37 +51,56 @@ Input.keyMapper = {
   ...Input.keyMapper,
 
   // this is the new debug move-through for use with JABS.
-  192: J.ABS.EXT.INPUT.Symbols.Debug,       // ` (backtick)
+  // ` (backtick).
+  192: J.ABS.EXT.INPUT.Symbols.Debug,
 
   // core buttons.
-  90: J.ABS.EXT.INPUT.Symbols.Mainhand,       // z
-  88: J.ABS.EXT.INPUT.Symbols.Offhand,        // x
-  16: J.ABS.EXT.INPUT.Symbols.Dash,           // shift (already defined)
-  67: J.ABS.EXT.INPUT.Symbols.Tool,           // c
+  // z.
+  90: J.ABS.EXT.INPUT.Symbols.Mainhand,
+  // x.
+  88: J.ABS.EXT.INPUT.Symbols.Offhand,
+  // shift (already defined).
+  16: J.ABS.EXT.INPUT.Symbols.Dash,
+  // c.
+  67: J.ABS.EXT.INPUT.Symbols.Tool,
 
   // functional buttons.
-  81: J.ABS.EXT.INPUT.Symbols.SkillTrigger,   // q
-  17: J.ABS.EXT.INPUT.Symbols.StrafeTrigger,  // ctrl
-  69: J.ABS.EXT.INPUT.Symbols.GuardTrigger,   // e
-  9: J.ABS.EXT.INPUT.Symbols.MobilitySkill,   // tab
+  // q.
+  81: J.ABS.EXT.INPUT.Symbols.SkillTrigger,
+  // ctrl.
+  17: J.ABS.EXT.INPUT.Symbols.StrafeTrigger,
+  // e.
+  69: J.ABS.EXT.INPUT.Symbols.GuardTrigger,
+  // tab.
+  9: J.ABS.EXT.INPUT.Symbols.MobilitySkill,
 
   // quickmenu button.
-  13: J.ABS.EXT.INPUT.Symbols.Quickmenu,      // enter
+  // enter.
+  13: J.ABS.EXT.INPUT.Symbols.Quickmenu,
 
   // party cycling button.
-  46: J.ABS.EXT.INPUT.Symbols.PartyCycle,     // del
+  // del.
+  46: J.ABS.EXT.INPUT.Symbols.PartyCycle,
 
   // movement buttons.
-  38: J.ABS.EXT.INPUT.Symbols.DirUp,          // arrow up
-  40: J.ABS.EXT.INPUT.Symbols.DirDown,        // arrow down
-  37: J.ABS.EXT.INPUT.Symbols.DirLeft,        // arrow left
-  39: J.ABS.EXT.INPUT.Symbols.DirRight,       // arrow right
+  // arrow up.
+  38: J.ABS.EXT.INPUT.Symbols.DirUp,
+  // arrow down.
+  40: J.ABS.EXT.INPUT.Symbols.DirDown,
+  // arrow left.
+  37: J.ABS.EXT.INPUT.Symbols.DirLeft,
+  // arrow right.
+  39: J.ABS.EXT.INPUT.Symbols.DirRight,
 
   // keyboard alternative for the multi-button skills.
-  49: J.ABS.EXT.INPUT.Symbols.CombatSkill1,   // 1 = L1 + cross
-  50: J.ABS.EXT.INPUT.Symbols.CombatSkill2,   // 2 = L1 + circle
-  51: J.ABS.EXT.INPUT.Symbols.CombatSkill3,   // 3 = L1 + square
-  52: J.ABS.EXT.INPUT.Symbols.CombatSkill4,   // 4 = L1 + triangle
+  // 1 = L1 + cross.
+  49: J.ABS.EXT.INPUT.Symbols.CombatSkill1,
+  // 2 = L1 + circle.
+  50: J.ABS.EXT.INPUT.Symbols.CombatSkill2,
+  // 3 = L1 + square.
+  51: J.ABS.EXT.INPUT.Symbols.CombatSkill3,
+  // 4 = L1 + triangle.
+  52: J.ABS.EXT.INPUT.Symbols.CombatSkill4,
 };
 
 /**
@@ -99,44 +118,66 @@ Input.keyMapper = {
  */
 Input.gamepadMapper = {
   // action face buttons.
-  0: J.ABS.EXT.INPUT.Symbols.Mainhand,      // kross
-  1: J.ABS.EXT.INPUT.Symbols.Offhand,       // circle
-  2: J.ABS.EXT.INPUT.Symbols.Dash,          // square
-  3: J.ABS.EXT.INPUT.Symbols.Tool,          // triangle
+  // kross.
+  0: J.ABS.EXT.INPUT.Symbols.Mainhand,
+  // circle.
+  1: J.ABS.EXT.INPUT.Symbols.Offhand,
+  // square.
+  2: J.ABS.EXT.INPUT.Symbols.Dash,
+  // triangle.
+  3: J.ABS.EXT.INPUT.Symbols.Tool,
 
   // shoulder/trigger buttons.
-  4: J.ABS.EXT.INPUT.Symbols.SkillTrigger,  // (L1) left bumper
-  5: J.ABS.EXT.INPUT.Symbols.GuardTrigger,  // (R1) right bumper
-  6: J.ABS.EXT.INPUT.Symbols.StrafeTrigger, // (L2) left trigger
-  7: J.ABS.EXT.INPUT.Symbols.MobilitySkill, // (R2) right trigger
+  // (L1) left bumper.
+  4: J.ABS.EXT.INPUT.Symbols.SkillTrigger,
+  // (R1) right bumper.
+  5: J.ABS.EXT.INPUT.Symbols.GuardTrigger,
+  // (L2) left trigger.
+  6: J.ABS.EXT.INPUT.Symbols.StrafeTrigger,
+  // (R2) right trigger.
+  7: J.ABS.EXT.INPUT.Symbols.MobilitySkill,
 
   // meta/menu buttons.
-  8: J.ABS.EXT.INPUT.Symbols.PartyCycle,    // select
-  9: J.ABS.EXT.INPUT.Symbols.Quickmenu,     // start
+  // select.
+  8: J.ABS.EXT.INPUT.Symbols.PartyCycle,
+  // start.
+  9: J.ABS.EXT.INPUT.Symbols.Quickmenu,
 
   // stick-click buttons.
-  10: J.ABS.EXT.INPUT.Symbols.L3,           // (L3) left stick button
-  11: J.ABS.EXT.INPUT.Symbols.R3,           // (R3) right stick button
+  // (L3) left stick button.
+  10: J.ABS.EXT.INPUT.Symbols.L3,
+  // (R3) right stick button.
+  11: J.ABS.EXT.INPUT.Symbols.R3,
 
   // D-pad buttons remapped to dedicated shortcut symbols (not movement directions).
-  12: J.ABS.EXT.INPUT.Symbols.DPadUp,       // d-pad up (shortcut)
-  13: J.ABS.EXT.INPUT.Symbols.DPadDown,     // d-pad down (shortcut)
-  14: J.ABS.EXT.INPUT.Symbols.DPadLeft,     // d-pad left (shortcut)
-  15: J.ABS.EXT.INPUT.Symbols.DPadRight,    // d-pad right (shortcut)
+  // d-pad up (shortcut).
+  12: J.ABS.EXT.INPUT.Symbols.DPadUp,
+  // d-pad down (shortcut).
+  13: J.ABS.EXT.INPUT.Symbols.DPadDown,
+  // d-pad left (shortcut).
+  14: J.ABS.EXT.INPUT.Symbols.DPadLeft,
+  // d-pad right (shortcut).
+  15: J.ABS.EXT.INPUT.Symbols.DPadRight,
 
   // the analog stick should be natively supported for movement.
 };
 
-// region registries
+//region registries
 
 // Ensure a single bag for registry/bindings data on Input.
 Input._jRegistries ||= {
-  actions: Object.create(null),     // ns -> Array<action def>
-  symbolLabels: Object.create(null),// symbol -> label
-  capture: new Set(),               // Set<string>
-  bindings: Object.create(null),    // ns -> { key: string[] }
-  defaults: Object.create(null),    // ns -> { key: string[] }
-  bootstrapped: false,              // idempotency flag
+  // ns -> Array<action def>.
+  actions: Object.create(null),
+  // symbol -> label.
+  symbolLabels: Object.create(null),
+  // set<string>.
+  capture: new Set(),
+  // ns -> { key: string[] }.
+  bindings: Object.create(null),
+  // ns -> { key: string[] }.
+  defaults: Object.create(null),
+  // idempotency flag.
+  bootstrapped: false,
 };
 
 /**

--- a/src/plugins/abs/ext/input/scenes/Scene_JabsRemap.js
+++ b/src/plugins/abs/ext/input/scenes/Scene_JabsRemap.js
@@ -668,7 +668,8 @@ class Scene_JabsRemap
     const extKeys = Object.keys(ext);
     for (let i = 0; i < extKeys.length; i++)
     {
-      const compound = extKeys[i]; // in the form ns:key
+      // in the form ns:key.
+      const compound = extKeys[i];
       const arr = ext[compound];
       combined[`__ext__${compound}`] = Array.isArray(arr)
         ? arr.slice(0)

--- a/src/plugins/abs/ext/input/scenes/Scene_Menu.js
+++ b/src/plugins/abs/ext/input/scenes/Scene_Menu.js
@@ -1,3 +1,4 @@
+//region Scene_Menu
 /**
  * Extends {@link #createCommandWindow}.<br/>
  * Also wires the handler for opening the JABS input remapping scene.
@@ -16,3 +17,4 @@ Scene_Menu.prototype.createCommandWindow = function()
     SceneManager.push(Scene_JabsRemap);
   });
 };
+//endregion Scene_Menu

--- a/src/plugins/abs/ext/input/windows/Window_JabsRemapActions.js
+++ b/src/plugins/abs/ext/input/windows/Window_JabsRemapActions.js
@@ -878,21 +878,21 @@ class Window_JabsRemapActions
     if (button === 'Primary Actions')
     {
       // describe the purpose of primary actions.
-      return 'Primary actions used moment-to-moment: mainhand/offhand attacks and tools.\n' + 'These are your core mapped buttons for direct, immediate use.';
+      return 'Primary actions used moment-to-moment: mainhand/offhand attacks and tools.\nThese are your core mapped buttons for direct, immediate use.';
     }
 
     // provide descriptions for section headers when selected.
     if (button === 'Secondary Actions')
     {
       // describe the purpose of secondary actions.
-      return 'Secondary and modifier inputs: Skill Trigger, Rotate, Strafe, Dodge.\n' + 'Hold or tap to modify movement or enable combat skill slots.';
+      return 'Secondary and modifier inputs: Skill Trigger, Rotate, Strafe, Dodge.\nHold or tap to modify movement or enable combat skill slots.';
     }
 
     // provide descriptions for section headers when selected.
     if (button === 'Functional Actions')
     {
       // describe the purpose of functional actions.
-      return 'Functional shortcuts unrelated to attacks: open the JABS menu, cycle party leader.\n' + 'Useful for management between encounters or to swap leaders on the fly.';
+      return 'Functional shortcuts unrelated to attacks: open the JABS menu, cycle party leader.\nUseful for management between encounters or to swap leaders on the fly.';
     }
 
     // a small dictionary of descriptions per logical action.

--- a/src/plugins/abs/ext/input/windows/Window_JabsRemapPrompt.js
+++ b/src/plugins/abs/ext/input/windows/Window_JabsRemapPrompt.js
@@ -12,7 +12,8 @@ class Window_JabsRemapPrompt
    * Can be migrated to plugin parameters later.
    * @type {number}
    */
-  static WarmupFrames = 20; // ~0.33s
+  // ~0.33s.
+  static WarmupFrames = 20;
 
   /**
    * Maximum frames the prompt remains active before auto-closing.
@@ -20,7 +21,8 @@ class Window_JabsRemapPrompt
    * Can be migrated to plugin parameters later.
    * @type {number}
    */
-  static TimeoutFrames = 5 * 60; // 5s
+  // 5s.
+  static TimeoutFrames = 5 * 60;
   //endregion static
 
   /**

--- a/src/plugins/abs/ext/input/windows/Window_MenuCommand.js
+++ b/src/plugins/abs/ext/input/windows/Window_MenuCommand.js
@@ -1,3 +1,4 @@
+//region Window_MenuCommand
 /**
  * Extends {@link #addOriginalCommands}.<br/>
  * Also adds a command to open the JABS input remapping scene from the main menu.
@@ -56,3 +57,4 @@ Window_MenuCommand.prototype.canAddJabsRemapCommand = function()
   // render the command!
   return true;
 };
+//endregion Window_MenuCommand

--- a/src/plugins/abs/ext/pixel/_metadata/initialization.js
+++ b/src/plugins/abs/ext/pixel/_metadata/initialization.js
@@ -67,7 +67,9 @@ J.ABS.EXT.PIXEL.Aliased = {
  * A small debug container for one-frame collision sampling traces.
  */
 J.ABS.EXT.PIXEL.Debug = {
-  /** @type {{x:number,y:number,color:string}[]} */
+  /**
+   * @type {{x:number,y:number,color:string}[]}
+   */
   samples: [],
 
   /**
@@ -81,7 +83,9 @@ J.ABS.EXT.PIXEL.Debug = {
     this.samples.push({ x, y, color });
   },
 
-  /** Clears samples at end-of-frame. */
+  /**
+   * Clears samples at end-of-frame.
+   */
   clear()
   {
     this.samples.length = 0;

--- a/src/plugins/abs/ext/pixel/managers/JABS_AiManager.js
+++ b/src/plugins/abs/ext/pixel/managers/JABS_AiManager.js
@@ -35,8 +35,10 @@ JABS_AiManager.moveTowardSlotIfNeeded = function(allyBattler, desiredX, desiredY
   const chr = allyBattler.getCharacter();
 
   // resolve tolerances.
-  let tolerance = 0.45; // default if ALLYAI not present.
-  let hysteresis = 0.25; // extra ring outside tolerance for gentle throttling near target.
+  // default if ALLYAI not present.
+  let tolerance = 0.45;
+  // extra ring outside tolerance for gentle throttling near target.
+  let hysteresis = 0.25;
   if (J.ABS.EXT.ALLYAI && J.ABS.EXT.ALLYAI.Metadata)
   {
     // use the configured formation tolerance if available.
@@ -151,8 +153,10 @@ JABS_AiManager.moveTowardSlotIfNeeded = function(allyBattler, desiredX, desiredY
   const chr = allyBattler.getCharacter();
 
   // resolve tolerances.
-  let tolerance = 0.45; // default if ALLYAI not present.
-  let hysteresis = 0.25; // extra ring outside tolerance for gentle throttling near target.
+  // default if ALLYAI not present.
+  let tolerance = 0.45;
+  // extra ring outside tolerance for gentle throttling near target.
+  let hysteresis = 0.25;
   if (J.ABS.EXT.ALLYAI && J.ABS.EXT.ALLYAI.Metadata)
   {
     tolerance = J.ABS.EXT.ALLYAI.Metadata.FormationTolerance;

--- a/src/plugins/abs/ext/pixel/objects/Game_Character.js
+++ b/src/plugins/abs/ext/pixel/objects/Game_Character.js
@@ -1,3 +1,4 @@
+//region Game_Character
 /**
  * Extends {@link processMoveCommand}.<br>
  * Ensures when move routes are being processed, that we adjust the x,y coordinates.
@@ -31,3 +32,4 @@ Game_Character.prototype.searchLimit = function()
 {
   return 40;
 };
+//endregion Game_Character

--- a/src/plugins/abs/ext/pixel/objects/Game_CharacterBase.js
+++ b/src/plugins/abs/ext/pixel/objects/Game_CharacterBase.js
@@ -514,7 +514,8 @@ Game_CharacterBase.prototype.recordPixelPosition = function()
     const point = {
       x: this.x,
       y: this.y
-    }; //new Point(this.x, this.y);
+    // new Point(this.x, this.y);.
+    };
 
     // add the point to the tracking.
     this.addPositionalRecord(point);
@@ -2058,8 +2059,10 @@ Game_CharacterBase.prototype._pixelCheckLeftPassage = function(x, y, xDest, hb, 
     const ny = row / count;
 
     // DEBUG markers.
-    J.ABS.EXT.PIXEL.Debug.push(curColX,  ny, "rgba(255, 255, 0, 0.6)"); // yellow current
-    J.ABS.EXT.PIXEL.Debug.push(destColX, ny, "rgba(0, 255, 255, 0.6)"); // cyan dest
+    // yellow current.
+    J.ABS.EXT.PIXEL.Debug.push(curColX,  ny, "rgba(255, 255, 0, 0.6)");
+    // cyan dest.
+    J.ABS.EXT.PIXEL.Debug.push(destColX, ny, "rgba(0, 255, 255, 0.6)");
 
     // Current left-most subcell must allow moving LEFT (exiting left).
     if (this._pixelIsPositionPassable(curColX, ny, J.ABS.Directions.LEFT) === false) return false;
@@ -2121,8 +2124,10 @@ Game_CharacterBase.prototype._pixelCheckRightPassage = function(x, y, xDest, hb,
     const ny = row / count;
 
     // DEBUG markers.
-    J.ABS.EXT.PIXEL.Debug.push(curColX,  ny, "rgba(255, 255, 0, 0.6)"); // yellow current
-    J.ABS.EXT.PIXEL.Debug.push(destColX, ny, "rgba(0, 255, 255, 0.6)");  // cyan dest
+    // yellow current.
+    J.ABS.EXT.PIXEL.Debug.push(curColX,  ny, "rgba(255, 255, 0, 0.6)");
+    // cyan dest.
+    J.ABS.EXT.PIXEL.Debug.push(destColX, ny, "rgba(0, 255, 255, 0.6)");
 
     // Current right-most must allow RIGHT (exiting right).
     if (this._pixelIsPositionPassable(curColX, ny, J.ABS.Directions.RIGHT) === false) return false;
@@ -2186,8 +2191,10 @@ Game_CharacterBase.prototype._pixelCheckUpPassage = function(x, y, yDest, hb, co
     const nx = col / count;
 
     // DEBUG markers.
-    J.ABS.EXT.PIXEL.Debug.push(nx, curRowY,  "rgba(255, 255, 0, 0.6)");    // yellow current
-    J.ABS.EXT.PIXEL.Debug.push(nx, destRowY, "rgba(0, 255, 255, 0.6)");    // cyan dest
+    // yellow current.
+    J.ABS.EXT.PIXEL.Debug.push(nx, curRowY,  "rgba(255, 255, 0, 0.6)");
+    // cyan dest.
+    J.ABS.EXT.PIXEL.Debug.push(nx, destRowY, "rgba(0, 255, 255, 0.6)");
 
     // Current top must allow UP (exiting upward).
     if (this._pixelIsPositionPassable(nx, curRowY,  J.ABS.Directions.UP)   === false) return false;
@@ -2249,8 +2256,10 @@ Game_CharacterBase.prototype._pixelCheckDownPassage = function(x, y, yDest, hb, 
     const nx = col / count;
 
     // DEBUG markers.
-    J.ABS.EXT.PIXEL.Debug.push(nx, curRowY,  "rgba(255, 255, 0, 0.6)"); // yellow current
-    J.ABS.EXT.PIXEL.Debug.push(nx, destRowY, "rgba(0, 255, 255, 0.6)"); // cyan dest
+    // yellow current.
+    J.ABS.EXT.PIXEL.Debug.push(nx, curRowY,  "rgba(255, 255, 0, 0.6)");
+    // cyan dest.
+    J.ABS.EXT.PIXEL.Debug.push(nx, destRowY, "rgba(0, 255, 255, 0.6)");
 
     // Current bottom must allow DOWN (exiting downward).
     if (this._pixelIsPositionPassable(nx, curRowY,  J.ABS.Directions.DOWN) === false) return false;

--- a/src/plugins/abs/ext/pixel/objects/Game_Follower.js
+++ b/src/plugins/abs/ext/pixel/objects/Game_Follower.js
@@ -1,3 +1,4 @@
+//region Game_Follower
 /**
  * Updates the direction and position based on the preceding character.
  * This forces followers to always face the character infront of them in the follower train.
@@ -154,3 +155,4 @@ Game_Follower.prototype.moveDiagonally = function(horz, vert)
   J.ABS.EXT.PIXEL.Aliased.Game_Follower.get("moveDiagonally")
     .call(this, horz, vert);
 };
+//endregion Game_Follower

--- a/src/plugins/abs/ext/pixel/objects/Game_Player.js
+++ b/src/plugins/abs/ext/pixel/objects/Game_Player.js
@@ -1,3 +1,4 @@
+//region Game_Player
 /**
  * Overrides {@link Game_Player.checkEventTriggerHere}.<br>
  * Includes the rounding of the x,y coordinates when checking event triggers for things beneath you.
@@ -71,7 +72,8 @@ Game_Player.prototype.checkEventTriggerTouch = function(x, y)
 
   // TODO: does this actually need to round?
   // determine the threshold for pixel movement regarding event triggering.
-  const didTrigger = Math.abs(roundX - x) < 0.3 && Math.abs(roundY - y) < 0.3; // within 1/3 of a tile triggers?
+  // within 1/3 of a tile triggers?
+  const didTrigger = Math.abs(roundX - x) < 0.3 && Math.abs(roundY - y) < 0.3;
 
   // check if the event was triggered with the threshold coordinates.
   if (didTrigger)
@@ -318,3 +320,4 @@ Game_Player.prototype.stopFollowersPixelMoving = function()
     follower.stopPixelMoving();
   });
 };
+//endregion Game_Player

--- a/src/plugins/abs/ext/pixel/objects/JABS_Battler.js
+++ b/src/plugins/abs/ext/pixel/objects/JABS_Battler.js
@@ -525,61 +525,77 @@ JABS_Battler.prototype.angleToDirection = function(angle)
   const half = 22.5;
 
   // RIGHT: -22.5 .. 22.5
-  const isRight = angle > -half && angle <= half; // 6
+  // 6.
+  const isRight = angle > -half && angle <= half;
 
   // DOWN-RIGHT: 22.5 .. 67.5
-  const isDownRight = angle > half && angle <= (half + 45); // 3
+  // 3.
+  const isDownRight = angle > half && angle <= (half + 45);
 
   // DOWN: 67.5 .. 112.5
-  const isDown = angle > (half + 45) && angle <= (half + 90); // 2
+  // 2.
+  const isDown = angle > (half + 45) && angle <= (half + 90);
 
   // DOWN-LEFT: 112.5 .. 157.5
-  const isDownLeft = angle > (half + 90) && angle <= (half + 135); // 1
+  // 1.
+  const isDownLeft = angle > (half + 90) && angle <= (half + 135);
 
   // LEFT: >157.5 or <= -157.5
-  const isLeft = angle > (half + 135) || angle <= -(half + 135); // 4
+  // 4.
+  const isLeft = angle > (half + 135) || angle <= -(half + 135);
 
   // UP-LEFT: -157.5 .. -112.5
-  const isUpLeft = angle > -(half + 135) && angle <= -(half + 90); // 7
+  // 7.
+  const isUpLeft = angle > -(half + 135) && angle <= -(half + 90);
 
   // UP: -112.5 .. -67.5
-  const isUp = angle > -(half + 90) && angle <= -(half + 45); // 8
+  // 8.
+  const isUp = angle > -(half + 90) && angle <= -(half + 45);
 
   // UP-RIGHT: -67.5 .. -22.5
-  const isUpRight = angle > -(half + 45) && angle <= -half; // 9
+  // 9.
+  const isUpRight = angle > -(half + 45) && angle <= -half;
 
   // Map the sector to the direction numbers.
   if (isRight)
   {
-    return J.ABS.Directions.RIGHT; // 6
+    // 6.
+    return J.ABS.Directions.RIGHT;
   }
   else if (isDownRight)
   {
-    return J.ABS.Directions.LOWERRIGHT; // 3
+    // 3.
+    return J.ABS.Directions.LOWERRIGHT;
   }
   else if (isDown)
   {
-    return J.ABS.Directions.DOWN; // 2
+    // 2.
+    return J.ABS.Directions.DOWN;
   }
   else if (isDownLeft)
   {
-    return J.ABS.Directions.LOWERLEFT; // 1
+    // 1.
+    return J.ABS.Directions.LOWERLEFT;
   }
   else if (isLeft)
   {
-    return J.ABS.Directions.LEFT; // 4
+    // 4.
+    return J.ABS.Directions.LEFT;
   }
   else if (isUpLeft)
   {
-    return J.ABS.Directions.UPPERLEFT; // 7
+    // 7.
+    return J.ABS.Directions.UPPERLEFT;
   }
   else if (isUp)
   {
-    return J.ABS.Directions.UP; // 8
+    // 8.
+    return J.ABS.Directions.UP;
   }
   else if (isUpRight)
   {
-    return J.ABS.Directions.UPPERRIGHT; // 9
+    // 9.
+    return J.ABS.Directions.UPPERRIGHT;
   }
 
   // Unknown sector; return 0.

--- a/src/plugins/abs/ext/shield/objects/_Game_Battler.js
+++ b/src/plugins/abs/ext/shield/objects/_Game_Battler.js
@@ -68,11 +68,13 @@ Game_Battler.prototype.getShieldStates = function()
       const bPri = bShield.getPriority() || 0;
       if (aPri !== bPri)
       {
-        return bPri - aPri; // DESC
+        // dESC.
+        return bPri - aPri;
       }
 
       // tie-breaker: FIFO by appliedAt (earlier first).
-      return aShield.getAppliedAt() - bShield.getAppliedAt(); // ASC
+      // aSC.
+      return aShield.getAppliedAt() - bShield.getAppliedAt();
     });
 };
 

--- a/src/plugins/abs/ext/speed/_metadata/initialization.js
+++ b/src/plugins/abs/ext/speed/_metadata/initialization.js
@@ -1,3 +1,4 @@
+//region Introduction
 /**
  * The core where all of my extensions live: in the `J` object.
  */

--- a/src/plugins/abs/ext/speed/managers/IconManager.js
+++ b/src/plugins/abs/ext/speed/managers/IconManager.js
@@ -9,7 +9,8 @@ IconManager.longParam = function(paramId)
   switch (paramId)
   {
     case 31:
-      return this.movespeed(); // move
+      // move.
+      return this.movespeed();
     default:
       return J.ABS.EXT.SPEED.Aliased.IconManager.get('longParam')
         .call(this, paramId);

--- a/src/plugins/abs/ext/speed/managers/TextManager.js
+++ b/src/plugins/abs/ext/speed/managers/TextManager.js
@@ -9,7 +9,8 @@ TextManager.longParam = function(paramId)
   switch (paramId)
   {
     case 31:
-      return this.movespeed(); // move speed boost
+      // move speed boost.
+      return this.movespeed();
     default:
       // perform original logic.
       return J.ABS.EXT.SPEED.Aliased.TextManager.get('longParam')
@@ -36,7 +37,8 @@ TextManager.longParamDescription = function(paramId)
   switch (paramId)
   {
     case 31:
-      return this.moveSpeedDescription(); // move speed boost
+      // move speed boost.
+      return this.moveSpeedDescription();
     default:
       // perform original logic.
       return J.ABS.EXT.SPEED.Aliased.TextManager.get('longParamDescription')

--- a/src/plugins/abs/ext/speed/objects/Game_Character.js
+++ b/src/plugins/abs/ext/speed/objects/Game_Character.js
@@ -70,7 +70,8 @@ Game_Character.prototype.minimumDistancePerFrame = function()
 {
   // the minimum speed is "2" aka "4x slower" according to events.
   // remove comment to let it go lower, but be careful, thats really low!
-  const minimumDistance = 0.015625; // / 2;
+  // / 2;.
+  const minimumDistance = 0.015625;
 
   // return the calculated amount.
   return minimumDistance;

--- a/src/plugins/abs/ext/star/_models/StarOrigin.js
+++ b/src/plugins/abs/ext/star/_models/StarOrigin.js
@@ -1,3 +1,4 @@
+//region StarOrigin
 /**
  * A simple container of the coordinates of a destination.
  */
@@ -34,3 +35,4 @@ class StarOrigin
     this.y = y;
   }
 }
+//endregion StarOrigin

--- a/src/plugins/abs/ext/star/_models/StarPhase.js
+++ b/src/plugins/abs/ext/star/_models/StarPhase.js
@@ -1,3 +1,4 @@
+//region StarPhase
 /**
  * A single phase in the stars battle.
  */
@@ -26,3 +27,4 @@ class StarPhase
    */
   key = 0;
 }
+//endregion StarPhase

--- a/src/plugins/abs/ext/star/_models/StarPhases.js
+++ b/src/plugins/abs/ext/star/_models/StarPhases.js
@@ -1,3 +1,4 @@
+//region StarPhases
 /**
  * A collection of {@link StarPhase}s that represent the flow of a star battle.
  * @type {StarPhases}
@@ -52,3 +53,4 @@ class StarPhases
    */
   static BACKTOMAP = new StarPhase("Back-to-map", 5);
 }
+//endregion StarPhases

--- a/src/plugins/abs/ext/star/managers/BattleManager.js
+++ b/src/plugins/abs/ext/star/managers/BattleManager.js
@@ -1,3 +1,4 @@
+//region BattleManager
 /**
  * The `enemyMap` is a property containing the master map from which enemies
  * from the troop are derived from.
@@ -178,3 +179,4 @@ BattleManager.origin = function()
 {
   return this._originLocation;
 };
+//endregion BattleManager

--- a/src/plugins/abs/ext/star/managers/DataManager.js
+++ b/src/plugins/abs/ext/star/managers/DataManager.js
@@ -1,3 +1,4 @@
+//region DataManager
 /**
  * Extends {@link DataManager.createGameObjects}.<br>
  * Includes fetching the enemy map and storing it memory.
@@ -76,3 +77,4 @@ DataManager.onEnemyMapGet = function(xhr, name, src, url)
     this.gracefulFail(name, src, url);
   }
 };
+//endregion DataManager

--- a/src/plugins/abs/ext/star/objects/Game_Interpreter.js
+++ b/src/plugins/abs/ext/star/objects/Game_Interpreter.js
@@ -1,3 +1,4 @@
+//region Game_Interpreter
 /**
  * Overrides {@link Game_Interpreter.command301}.<br>
  * Alters the event command handler of "Battle Processing".
@@ -64,3 +65,4 @@ Game_Interpreter.prototype.command301convertToTroopId = function(designationType
   console.error(`invalid event command params, `, designationType, troopIdentifier);
   throw new Error('borked');
 };
+//endregion Game_Interpreter

--- a/src/plugins/abs/ext/star/objects/Game_Player.js
+++ b/src/plugins/abs/ext/star/objects/Game_Player.js
@@ -1,3 +1,4 @@
+//region Game_Player
 /**
  * Extends {@link Game_Player.clearTransferInfo}.<br>
  * Parse out enemy data from the troop and convert them into JABS battlers.
@@ -44,3 +45,4 @@ Game_Player.prototype.reserveOriginTransfer = function()
   } = BattleManager.origin();
   this.reserveTransfer(mapId, x, y);
 };
+//endregion Game_Player

--- a/src/plugins/abs/ext/star/objects/Game_Troop.js
+++ b/src/plugins/abs/ext/star/objects/Game_Troop.js
@@ -1,3 +1,4 @@
+//region Game_Troop
 /**
  * Extends {@link Game_Troop.initialize}.<br>
  * Initializes our additional members for STABS.
@@ -60,3 +61,4 @@ Game_Troop.prototype.areEnemiesAlive = function()
 {
   return this.getRemainingEnemyCount() > 0;
 };
+//endregion Game_Troop

--- a/src/plugins/abs/ext/star/scenes/Scene_Map.js
+++ b/src/plugins/abs/ext/star/scenes/Scene_Map.js
@@ -1,3 +1,4 @@
+//region Scene_Map
 /**
  * Overrides {@link Scene_Map.updateEncounter}.<br>
  * Disables base encounter scene management.
@@ -24,3 +25,4 @@ Scene_Map.prototype.update = function()
 
   //? TODO: Modify encountereffect here.
 };
+//endregion Scene_Map

--- a/src/plugins/abs/ext/timing/_metadata/initialization.js
+++ b/src/plugins/abs/ext/timing/_metadata/initialization.js
@@ -1,3 +1,4 @@
+//region Introduction
 /**
  * The core where all of my extensions live: in the `J` object.
  */

--- a/src/plugins/abs/ext/timing/objects/Game_Battler.js
+++ b/src/plugins/abs/ext/timing/objects/Game_Battler.js
@@ -461,13 +461,16 @@ Game_Battler.prototype.applyFastCooldown = function(originalCooldownTime)
   if (!originalCooldownTime) return 0;
 
   // get the base value.
-  const baseParam = this.baseFastCooldown(); // this.getBaseFastCooldown();
+  // this.getBaseFastCooldown();.
+  const baseParam = this.baseFastCooldown();
 
   // grab the flat modifier.
-  const flatModifier = this.fastCooldownFlat(); //this.getFastCooldownFlat();
+  // this.getFastCooldownFlat();.
+  const flatModifier = this.fastCooldownFlat();
 
   // grab the multiplicative modifier, and add the base-100 to the value.
-  const multModifier = this.fastCooldownRate(); //this.getFastCooldownRate();
+  // this.getFastCooldownRate();.
+  const multModifier = this.fastCooldownRate();
 
   // short circuit before calculations if we have no values.
   if (!baseParam && !flatModifier && !multModifier) return originalCooldownTime;

--- a/src/plugins/abs/ext/tools/_metadata/initialization.js
+++ b/src/plugins/abs/ext/tools/_metadata/initialization.js
@@ -1,3 +1,4 @@
+//region Introduction
 /**
  * The core where all of my extensions live: in the `J` object.
  */

--- a/src/plugins/abs/ext/tools/_models/JABS_Battler.js
+++ b/src/plugins/abs/ext/tools/_models/JABS_Battler.js
@@ -1,3 +1,4 @@
+//region JABS_Battler
 /**
  * Initializes the properties of this battler that are not related to anything in particular.
  */
@@ -296,3 +297,4 @@ JABS_Battler.gapCloseWiggleRoom = function()
 {
   return 0.5;
 };
+//endregion JABS_Battler

--- a/src/plugins/abs/ext/tools/managers/JABS_Engine.js
+++ b/src/plugins/abs/ext/tools/managers/JABS_Engine.js
@@ -1,3 +1,4 @@
+//region JABS_Engine
 /**
  * Processes the various on-hit effects against the target.
  * @param {JABS_Action} action The JABS action containing the action data.
@@ -49,3 +50,4 @@ JABS_Engine.prototype.canGapClose = function(action, target)
   // we can gap close!
   return true;
 };
+//endregion JABS_Engine

--- a/src/plugins/abs/ext/tools/objects/Game_Battler.js
+++ b/src/plugins/abs/ext/tools/objects/Game_Battler.js
@@ -1,3 +1,4 @@
+//region Game_Battler
 /**
  * Determines whether or not this battler is a gap close target.
  * @returns {boolean} True if this battler is a gap close target, false otherwise.
@@ -9,3 +10,4 @@ Game_Battler.prototype.isGapClosable = function()
     J.ABS.EXT.TOOLS.RegExp.GapCloseTarget
   );
 };
+//endregion Game_Battler

--- a/src/plugins/abs/ext/tools/objects/Game_CharacterBase.js
+++ b/src/plugins/abs/ext/tools/objects/Game_CharacterBase.js
@@ -1,3 +1,4 @@
+//region Game_CharacterBase
 /**
  * Extends {@link Game_CharacterBase.initMembers}.<br>
  * Also initializes our new members.
@@ -44,7 +45,8 @@ Game_CharacterBase.prototype.initToolsMembers = function()
 
   this._j._tools._grabThrow._throw._through = false;
 
-  this._j._tools._grabThrow._throw._directionFixAlways = false; // TODO: from plugin params.
+  // tODO: from plugin params.
+  this._j._tools._grabThrow._throw._directionFixAlways = false;
 
   this._j._tools._grabThrow._throw._directionFix = false;
 
@@ -52,3 +54,4 @@ Game_CharacterBase.prototype.initToolsMembers = function()
 
   this._j._tools._grabThrow._throw._wait = new JABS_Timer(0);
 };
+//endregion Game_CharacterBase

--- a/src/plugins/abs/ext/tools/objects/Game_Event.js
+++ b/src/plugins/abs/ext/tools/objects/Game_Event.js
@@ -1,3 +1,4 @@
+//region Game_Event
 /**
  * Determines whether or not this event has any gap close target overrides.
  * @returns {boolean} True if this event has a gap close override, false otherwise.
@@ -25,3 +26,4 @@ Game_Event.prototype.isGapClosable = function()
   // return what we found.
   return gapCloseTarget;
 };
+//endregion Game_Event

--- a/src/plugins/abs/ext/tools/objects/Game_System.js
+++ b/src/plugins/abs/ext/tools/objects/Game_System.js
@@ -1,3 +1,4 @@
+//region Game_System
 /**
  * Extends {@link Game_System.initMembers}.<br>
  * Also initializes our new members.
@@ -29,7 +30,8 @@ Game_System.prototype.initToolsMembers = function()
    * Whether or not the grab and throw functionality is currently enabled.
    * @type {boolean}
    */
-  this._j._tools._grabThrowEnabled = true; // TODO: parameterize this.
+  // tODO: parameterize this.
+  this._j._tools._grabThrowEnabled = true;
 };
 
 /**
@@ -57,3 +59,4 @@ Game_System.prototype.toggleGrabThrowEnabled = function()
 {
   this._j._tools._grabThrowEnabled = !this.isGrabThrowEnabled();
 };
+//endregion Game_System


### PR DESCRIPTION
## `J-ABS` [minor] update
## `J-ABS-AllyAI` [patch] update
## `J-ABS-Charge` [patch] update
## `J-ABS-CycloneAdapter` [patch] update
## `J-ABS-DangerIndicator` [patch] update
## `J-ABS-Diagonals` [patch] update
## `J-ABS-Formula` [patch] update
## `J-ABS-Hitstop` [patch] update
## `J-ABS-InputManager` [patch] update
## `J-ABS-PixelMovement` [patch] update
## `J-ABS-Poses` [patch] update
## `J-ABS-Shield` [patch] update
## `J-ABS-Speed` [patch] update
## `J-ABS-Star` [patch] update
## `J-ABS-Timing` [patch] update
## `J-ABS-Tools` [patch] update
## `J-SkillSlots` [patch] update

Phase 1 mechanical/style normalization across all JABS core + extension plugins.

- Removed all optional chaining (`?.`) — replaced with explicit null guards where the value is genuinely nullable (`event`, `result()`), or with direct access where upstream code already guarantees non-null (`JABS_Location.Clone`, `J.ABS.EXT.CYCLE`)
- Audited all `//region` / `//endregion` markers: fixed malformed markers (spaces, missing pairs), wrapped 28 files that had zero region coverage, removed a duplicate region header in `J-ABS-Formula`
- Moved all trailing inline comments to their own line above the relevant code; normalized to lowercase with a trailing period; removed narrating comments that restated the code
- Expanded all single-line JSDoc (`/** ... */`) to the required multiline format; added missing `@param` / `@returns` on public methods
- Converted `'str' + var` string concatenation to template literals
- Hotfix: restored missing parentheses on `if`-condition in `J-ABS-Diagonals` `Game_Event.moveDiagonally` that the comment-mover script inadvertently stripped
