### PR TITLE
cleanup(jabs): phase 3a safe refactors

### DIFF
--- a/.cursor/rules/workspace.mdc
+++ b/.cursor/rules/workspace.mdc
@@ -1,0 +1,69 @@
+---
+description: Universal context for the JMZ workspace — all three projects, coding standards, workflow, and known future work.
+alwaysApply: true
+---
+
+# JMZ Workspace
+
+## Projects
+
+Three git repos live side-by-side under `/var/mnt/exdrive/dev/gaming/`:
+
+| Folder | What it is |
+|---|---|
+| `rmmz-plugins` | Monorepo of RPG Maker MZ plugins (JavaScript, no modules in `/src/plugins/**`). Primary project. |
+| `ca` | Consumer test game ("Chef Adventure"). The actual RMMZ project lives at `ca/chef-adventure/`. |
+| `jmz-data-editor` | React + Neutralino.js GUI for editing plugin data. TypeScript + Vite + Bun. |
+
+## Author & Style
+
+- **No emojis** in code or responses unless explicitly requested.
+- **No unnecessary comments** that just restate the code. Comments explain *why*, not *what*.
+- Always read `rmmz-plugins/.junie/guidelines.md` before working in `rmmz-plugins` — it is the authoritative style reference.
+
+## Universal Coding Style (all three projects)
+
+- **Allman braces**: opening `{` on its own line for functions, classes, and all blocks — including arrow functions.
+- **Semicolons**: always required.
+- **2-space indent**.
+- **Inline comments**: one line above the code they describe, never on the same line. Lowercase, end with a period.
+- **JsDocs**: always multiline (`/**` / ` * ` / `*/`). Include `@param` and `@returns`. Never echo back change history or feedback.
+- **Explicit boolean checks**: prefer `if (condition === false)` over `if (!condition)`. Exception: `!value` is fine for null/undefined guards.
+- **No optional chaining** (`?.`). Assume state is valid; do not add defensive guards unless explicitly asked.
+- **No nested ternaries**. Spell them out as `if` blocks.
+- **Destructure** when using more than one property from an object or array.
+- **Template literals** for string interpolation; never `+` concatenation.
+- **Trailing commas** on multiline objects/arrays are acceptable and encouraged.
+- **Line length**: 120 characters max (except `_annotations.js` files in rmmz-plugins).
+
+## rmmz-plugins Specific
+
+- **Single quotes** for strings.
+- **No `import`/`export` anywhere in `rmmz-plugins` plugin source.** These files are concatenated by `combine.js` and loaded as plain JS by the RMMZ engine — there is no compilation step. Modules simply do not work here. (`src/build-tools` uses Node `require`/`import` normally since it runs in Node, not in the game.)
+- **No IIFEs**. Use object namespaces (`J.ABS`, `J.SKS`, etc.) and alias maps.
+- **Prototype + alias pattern** for augmenting engine/other-plugin classes. `class extends` for new scene/window subclasses (unless serialized → prototype constructor).
+- **Serialized models** (saved to file via `JsonEx`): use prototype constructors with JSON-safe fields only. See `_models/` directories for examples.
+- **`//region` / `//endregion`** wrappers on every file; region name = filename.
+- Use `RPGManager` methods for all notetag parsing. Never parse `note` strings manually.
+- Build tools: `bun run build:<plugin>` → `combine.js` concatenates source into `out/`. Built files are committed to `project/js/plugins/`.
+- PR format: per-plugin `## \`J-PluginName\` [major/minor/patch] update` sections with bullet points. No generic Summary/Test Plan tables.
+
+## jmz-data-editor Specific
+
+- **TypeScript** throughout. Preserve ambient RMMZ-style `import X = Rmmz.*` usage.
+- **Double quotes** for strings and imports.
+- **Named exports grouped at the bottom** of each file.
+- UI is built with **MUI (Material-UI)**. State via `useState` / `useEffect`.
+- App is organized into "boards" per editor type (enemies, crafting, SDP, etc.).
+
+## Workflow
+
+- **OS**: Bazzite Linux (immutable Fedora base). No `rpm-ostree` or `apt` without a reboot. Install user binaries to `~/.local/bin`.
+- **Package manager**: Bun everywhere. Never suggest `npm` or `yarn`.
+- **GitHub CLI**: `gh` is installed at `~/.local/bin/gh` and authenticated as `je-can-code`. Use it for all PR operations. Write PR bodies to a temp file and pass via `--body-file` to avoid heredoc quoting issues.
+- **Git credential helper**: configured via `gh auth setup-git` — `git push` works without GUI prompts.
+
+## Known Future Work (do not tackle without checking first)
+
+1. **`JsonEx` serialization registry** — `JsonEx` resolves classes via `window[className]`. Plan: add `J.register(constructor)` in J-Base and audit all serializable models. Tracked in `guidelines.md`.
+2. **`checkForBooleanFromNoteByRegex` audit** — Any property that checks a negatively-named tag (hide/block/disable) without `nullIfEmpty: true` has inverted logic. A full sweep of all such properties is needed. Do not fix opportunistically; do it as a dedicated PR.

--- a/jmz.code-workspace
+++ b/jmz.code-workspace
@@ -1,0 +1,16 @@
+{
+  "folders": [
+    {
+      "name": "rmmz-plugins",
+      "path": "."
+    },
+    {
+      "name": "ca",
+      "path": "../ca"
+    },
+    {
+      "name": "jmz-data-editor",
+      "path": "../jmz-data-editor"
+    }
+  ]
+}

--- a/project/js/plugins/abs/J-ABS.js
+++ b/project/js/plugins/abs/J-ABS.js
@@ -15573,7 +15573,7 @@ J.ABS.Metadata.HitboxOverlaysInitiallyVisible = (J.ABS.PluginParameters['hitboxO
 
 // disengage configurations.
 J.ABS.Metadata.ShowDisengageBalloon = (J.ABS.PluginParameters['showDisengageBalloon'] === 'true');
-J.ABS.Metadata.DisengageBalloonId = Number(J.ABS.PluginParameters['disengageBalloonId']) || J.ABS.Balloons.Frustration;
+J.ABS.Metadata.DisengageBalloonId = Number(J.ABS.PluginParameters['disengageBalloonId']) || 7;
 
 // quick menu commands configurations.
 J.ABS.Metadata.EquipCombatSkillsText = J.ABS.PluginParameters['equipCombatSkillsText'];

--- a/project/js/plugins/abs/J-ABS.js
+++ b/project/js/plugins/abs/J-ABS.js
@@ -3541,6 +3541,9 @@ JABS_Battler.prototype.onEngage = function()
  */
 JABS_Battler.prototype.disengageTarget = function()
 {
+  // fire the hook before state is cleared so it can inspect engagement status.
+  this.onDisengage();
+
   // clear any targeting.
   this.setTarget(null);
   this.setAllyTarget(null);
@@ -3560,9 +3563,6 @@ JABS_Battler.prototype.disengageTarget = function()
 
   // reset all the phases back to default.
   this.resetPhases();
-
-  // perform on-disengage effects.
-  this.onDisengage();
 };
 
 /**
@@ -3571,6 +3571,9 @@ JABS_Battler.prototype.disengageTarget = function()
  */
 JABS_Battler.prototype.onDisengage = function()
 {
+  // only react to genuine disengagements, not initialization resets.
+  if (!this.isEngaged()) return;
+
   if (J.ABS.Metadata.ShowDisengageBalloon === false) return;
   this.showBalloon(J.ABS.Metadata.DisengageBalloonId);
 };

--- a/project/js/plugins/abs/J-ABS.js
+++ b/project/js/plugins/abs/J-ABS.js
@@ -3523,7 +3523,16 @@ JABS_Battler.prototype.engageTarget = function(target)
   // if we're alerted, also clear the alert state.
   this.clearAlert();
 
-  // TODO: abstract this.
+  // perform on-engage effects.
+  this.onEngage();
+};
+
+/**
+ * A hook to perform all side effects of engaging a target.
+ * Extensions may alias this to add telemetry, custom visuals, or other behavior.
+ */
+JABS_Battler.prototype.onEngage = function()
+{
   this.showBalloon(J.ABS.Balloons.Exclamation);
 };
 
@@ -3551,6 +3560,19 @@ JABS_Battler.prototype.disengageTarget = function()
 
   // reset all the phases back to default.
   this.resetPhases();
+
+  // perform on-disengage effects.
+  this.onDisengage();
+};
+
+/**
+ * A hook to perform all side effects of disengaging from a target.
+ * Extensions may alias this to add telemetry, custom visuals, or other behavior.
+ */
+JABS_Battler.prototype.onDisengage = function()
+{
+  if (J.ABS.Metadata.ShowDisengageBalloon === false) return;
+  this.showBalloon(J.ABS.Metadata.DisengageBalloonId);
 };
 
 /**
@@ -15145,6 +15167,25 @@ class JABS_Timer
  * @desc Whether or not to overlay the map with battler and action hitbox visuals- for debugging.
  * @default false
  *
+ *
+ * @param disengageConfigs
+ * @text DISENGAGE SETUP
+ *
+ * @param showDisengageBalloon
+ * @parent disengageConfigs
+ * @type boolean
+ * @text Show Disengage Balloon
+ * @desc Whether or not to show a balloon above a battler when they disengage from their target.
+ * @default false
+ *
+ * @param disengageBalloonId
+ * @parent disengageConfigs
+ * @type number
+ * @text Disengage Balloon Id
+ * @desc The id of the balloon to display when a battler disengages. Requires "Show Disengage Balloon" to be enabled.
+ * @default 7
+ *
+ *
  * @param quickmenuConfigs
  * @text QUICKMENU SETUP
  *
@@ -15529,6 +15570,10 @@ J.ABS.Metadata.DisableTextPops = Boolean(J.ABS.PluginParameters['disableTextPops
 J.ABS.Metadata.AllyRubberbandAdjustment = Number(J.ABS.PluginParameters['allyRubberbandAdjustment']);
 J.ABS.Metadata.DashSpeedBoost = Number(J.ABS.PluginParameters['dashSpeedBoost']);
 J.ABS.Metadata.HitboxOverlaysInitiallyVisible = (J.ABS.PluginParameters['hitboxOverlaysInitiallyVisible'] === 'true');
+
+// disengage configurations.
+J.ABS.Metadata.ShowDisengageBalloon = (J.ABS.PluginParameters['showDisengageBalloon'] === 'true');
+J.ABS.Metadata.DisengageBalloonId = Number(J.ABS.PluginParameters['disengageBalloonId']) || J.ABS.Balloons.Frustration;
 
 // quick menu commands configurations.
 J.ABS.Metadata.EquipCombatSkillsText = J.ABS.PluginParameters['equipCombatSkillsText'];
@@ -25836,19 +25881,14 @@ Game_Action.prototype.processParry = function(jabsBattler)
   // perform on-parry effects.
   this.onParry(jabsBattler);
 
-  // TODO: pull the parry logic out of the requestanimation function.
-  // play the parry animation.
-  const parryAnimationId = 122;
-  jabsBattler.getCharacter()
-    .requestAnimation(parryAnimationId);
-
   // reset the player's guarding.
   jabsBattler.setParryWindow(0);
   jabsBattler.setGuardSkillId(0);
 };
 
 /**
- * A hook to perform actions on-parry.
+ * A hook to perform all side effects of a successful parry.
+ * Extensions may alias this to add telemetry, custom visuals, or other behavior.
  * @param {JABS_Battler} jabsBattler The battler that is parrying.
  */
 Game_Action.prototype.onParry = function(jabsBattler)
@@ -25859,6 +25899,11 @@ Game_Action.prototype.onParry = function(jabsBattler)
   // gain 10x of the tp from the guard skill when parrying.
   jabsBattler.getBattler()
     .gainTp(guardSkillTp);
+
+  // play the parry animation.
+  const parryAnimationId = 122;
+  jabsBattler.getCharacter()
+    .requestAnimation(parryAnimationId);
 };
 
 /**

--- a/src/plugins/abs/core/__models/JABS_Battler/_reference.js
+++ b/src/plugins/abs/core/__models/JABS_Battler/_reference.js
@@ -804,6 +804,9 @@ JABS_Battler.prototype.onEngage = function()
  */
 JABS_Battler.prototype.disengageTarget = function()
 {
+  // fire the hook before state is cleared so it can inspect engagement status.
+  this.onDisengage();
+
   // clear any targeting.
   this.setTarget(null);
   this.setAllyTarget(null);
@@ -823,9 +826,6 @@ JABS_Battler.prototype.disengageTarget = function()
 
   // reset all the phases back to default.
   this.resetPhases();
-
-  // perform on-disengage effects.
-  this.onDisengage();
 };
 
 /**
@@ -834,6 +834,9 @@ JABS_Battler.prototype.disengageTarget = function()
  */
 JABS_Battler.prototype.onDisengage = function()
 {
+  // only react to genuine disengagements, not initialization resets.
+  if (!this.isEngaged()) return;
+
   if (J.ABS.Metadata.ShowDisengageBalloon === false) return;
   this.showBalloon(J.ABS.Metadata.DisengageBalloonId);
 };

--- a/src/plugins/abs/core/__models/JABS_Battler/_reference.js
+++ b/src/plugins/abs/core/__models/JABS_Battler/_reference.js
@@ -786,7 +786,16 @@ JABS_Battler.prototype.engageTarget = function(target)
   // if we're alerted, also clear the alert state.
   this.clearAlert();
 
-  // TODO: abstract this.
+  // perform on-engage effects.
+  this.onEngage();
+};
+
+/**
+ * A hook to perform all side effects of engaging a target.
+ * Extensions may alias this to add telemetry, custom visuals, or other behavior.
+ */
+JABS_Battler.prototype.onEngage = function()
+{
   this.showBalloon(J.ABS.Balloons.Exclamation);
 };
 
@@ -814,6 +823,19 @@ JABS_Battler.prototype.disengageTarget = function()
 
   // reset all the phases back to default.
   this.resetPhases();
+
+  // perform on-disengage effects.
+  this.onDisengage();
+};
+
+/**
+ * A hook to perform all side effects of disengaging from a target.
+ * Extensions may alias this to add telemetry, custom visuals, or other behavior.
+ */
+JABS_Battler.prototype.onDisengage = function()
+{
+  if (J.ABS.Metadata.ShowDisengageBalloon === false) return;
+  this.showBalloon(J.ABS.Metadata.DisengageBalloonId);
 };
 
 /**

--- a/src/plugins/abs/core/_metadata/_annotations.js
+++ b/src/plugins/abs/core/_metadata/_annotations.js
@@ -1828,6 +1828,25 @@
  * @desc Whether or not to overlay the map with battler and action hitbox visuals- for debugging.
  * @default false
  *
+ *
+ * @param disengageConfigs
+ * @text DISENGAGE SETUP
+ *
+ * @param showDisengageBalloon
+ * @parent disengageConfigs
+ * @type boolean
+ * @text Show Disengage Balloon
+ * @desc Whether or not to show a balloon above a battler when they disengage from their target.
+ * @default false
+ *
+ * @param disengageBalloonId
+ * @parent disengageConfigs
+ * @type number
+ * @text Disengage Balloon Id
+ * @desc The id of the balloon to display when a battler disengages. Requires "Show Disengage Balloon" to be enabled.
+ * @default 7
+ *
+ *
  * @param quickmenuConfigs
  * @text QUICKMENU SETUP
  *

--- a/src/plugins/abs/core/_metadata/initialization.js
+++ b/src/plugins/abs/core/_metadata/initialization.js
@@ -171,7 +171,7 @@ J.ABS.Metadata.HitboxOverlaysInitiallyVisible = (J.ABS.PluginParameters['hitboxO
 
 // disengage configurations.
 J.ABS.Metadata.ShowDisengageBalloon = (J.ABS.PluginParameters['showDisengageBalloon'] === 'true');
-J.ABS.Metadata.DisengageBalloonId = Number(J.ABS.PluginParameters['disengageBalloonId']) || J.ABS.Balloons.Frustration;
+J.ABS.Metadata.DisengageBalloonId = Number(J.ABS.PluginParameters['disengageBalloonId']) || 7;
 
 // quick menu commands configurations.
 J.ABS.Metadata.EquipCombatSkillsText = J.ABS.PluginParameters['equipCombatSkillsText'];

--- a/src/plugins/abs/core/_metadata/initialization.js
+++ b/src/plugins/abs/core/_metadata/initialization.js
@@ -169,6 +169,10 @@ J.ABS.Metadata.AllyRubberbandAdjustment = Number(J.ABS.PluginParameters['allyRub
 J.ABS.Metadata.DashSpeedBoost = Number(J.ABS.PluginParameters['dashSpeedBoost']);
 J.ABS.Metadata.HitboxOverlaysInitiallyVisible = (J.ABS.PluginParameters['hitboxOverlaysInitiallyVisible'] === 'true');
 
+// disengage configurations.
+J.ABS.Metadata.ShowDisengageBalloon = (J.ABS.PluginParameters['showDisengageBalloon'] === 'true');
+J.ABS.Metadata.DisengageBalloonId = Number(J.ABS.PluginParameters['disengageBalloonId']) || J.ABS.Balloons.Frustration;
+
 // quick menu commands configurations.
 J.ABS.Metadata.EquipCombatSkillsText = J.ABS.PluginParameters['equipCombatSkillsText'];
 J.ABS.Metadata.EquipDodgeSkillsText = J.ABS.PluginParameters['equipDodgeSkillsText'];

--- a/src/plugins/abs/core/objects/Game_Action.js
+++ b/src/plugins/abs/core/objects/Game_Action.js
@@ -315,19 +315,14 @@ Game_Action.prototype.processParry = function(jabsBattler)
   // perform on-parry effects.
   this.onParry(jabsBattler);
 
-  // TODO: pull the parry logic out of the requestanimation function.
-  // play the parry animation.
-  const parryAnimationId = 122;
-  jabsBattler.getCharacter()
-    .requestAnimation(parryAnimationId);
-
   // reset the player's guarding.
   jabsBattler.setParryWindow(0);
   jabsBattler.setGuardSkillId(0);
 };
 
 /**
- * A hook to perform actions on-parry.
+ * A hook to perform all side effects of a successful parry.
+ * Extensions may alias this to add telemetry, custom visuals, or other behavior.
  * @param {JABS_Battler} jabsBattler The battler that is parrying.
  */
 Game_Action.prototype.onParry = function(jabsBattler)
@@ -338,6 +333,11 @@ Game_Action.prototype.onParry = function(jabsBattler)
   // gain 10x of the tp from the guard skill when parrying.
   jabsBattler.getBattler()
     .gainTp(guardSkillTp);
+
+  // play the parry animation.
+  const parryAnimationId = 122;
+  jabsBattler.getCharacter()
+    .requestAnimation(parryAnimationId);
 };
 
 /**


### PR DESCRIPTION
## `J-ABS` patch update

- Folded `requestAnimation` call into the existing `onParry` hook, making it the single extension point for all parry side effects (TP, animation, and future telemetry hooks)
- Extracted `onEngage()` virtual method from `engageTarget` — extensions may alias to customize or suppress the engage balloon
- Extracted `onDisengage()` virtual method from `disengageTarget` with two new plugin parameters: `showDisengageBalloon` (boolean, default `false`) and `disengageBalloonId` (number, default `7` / Frustration) — the disengage balloon feature is now fully configurable without code changes
