### PR TITLE
refactor: centralize external JSON config loading

### DIFF
--- a/.cursor/rules/workspace.mdc
+++ b/.cursor/rules/workspace.mdc
@@ -31,6 +31,7 @@ Jeremy’s plugin code uses **pedagogical inline comments** on purpose: the same
 
 ## ESLint Compliance
 - **Never violate ESLint rules.** `rmmz-plugins` enforces `eol-last: ["error", "never"]` — files must NOT end with a trailing newline. When using the `Write` tool, the final character of the `contents` string must be the last character of the file (no `\n` after the closing `//endregion` or final line). Always run `ReadLints` on newly written files to catch violations before committing.
+- **Always run `bun run lint` after code changes.** Jeremy’s terminal command `bunx eslint "src/plugins/**/*.js" "src/build-tools/**/*.js" "eslint.config.js"` is equivalent to the lint script; treat `bun run lint` as the default. All lint **errors** must be fixed. Lint **warnings** should be addressed or explicitly justified (e.g., suppressed with a targeted one-liner) depending on the concern and intent.
 
 ## Universal Coding Style (all three projects)
 

--- a/project/js/plugins/J-Base.js
+++ b/project/js/plugins/J-Base.js
@@ -3963,6 +3963,153 @@ DataManager.setupBattleTest = function()
 //endregion caching
 //endregion DataManager
 
+//region ExternalJsonConfigLoader
+/**
+ * A centralized loader for external JSON configuration files in the project.
+ *
+ * This is intended to eliminate duplicated "read file → guard null/empty → JSON.parse try/catch → validate → classify"
+ * boilerplate across plugin metadata initializers.
+ *
+ * This loader is deliberately "domain-agnostic": it knows how to read and parse JSON, but it does not know what the
+ * JSON means. Callers can provide a validator and/or mapper to enforce plugin-specific shapes and transform the parsed
+ * blob into a classified result.
+ */
+// eslint-disable-next-line no-unused-vars
+class ExternalJsonConfigLoader
+{
+  /**
+   * Loads, parses, validates, and optionally maps JSON configuration from a project-relative path.
+   * @template TConfigJson The raw JSON shape after {@link JSON.parse}.
+   * @template TConfigResult The optional mapped/classified result shape.
+   * @param {string} configPath Project-relative path, ex: `data/config.sdp.json`.
+   * @param {ExternalJsonConfigLoaderOptions<TConfigJson, TConfigResult>=} options Additional options to customize
+   * behavior.
+   * @returns {TConfigResult|TConfigJson} The parsed JSON blob, or mapped result if a mapper was provided.
+   */
+  static load(configPath, options = null)
+  {
+    const actualOptions = options ?? new ExternalJsonConfigLoaderOptions();
+
+    // read the raw json text from the filesystem.
+    const rawConfig = StorageManager.fsReadFile(configPath);
+
+    // missing or empty config is a fatal error for plugins that rely on external configuration.
+    if (rawConfig === null || rawConfig === String.empty)
+    {
+      throw this.#missingConfigError(configPath, actualOptions.pluginName, actualOptions.configName);
+    }
+
+    // parse the json in a way that always includes the file path.
+    let parsed;
+    try
+    {
+      parsed = /** @type {TConfigJson} */ (JSON.parse(rawConfig));
+    }
+    catch (e)
+    {
+      const prefix = this.#errorPrefix(actualOptions.pluginName, actualOptions.configName);
+      throw new Error(`${prefix}failed to parse JSON at ${configPath}: ${e.message}`);
+    }
+
+    // json can parse to null; treat that the same as "missing", because downstream logic expects an object/array.
+    if (parsed === null)
+    {
+      throw this.#missingConfigError(configPath, actualOptions.pluginName, actualOptions.configName);
+    }
+
+    // if provided, validate the parsed blob before mapping/classifying.
+    if (actualOptions.validator)
+    {
+      try
+      {
+        actualOptions.validator(parsed);
+      }
+      catch (e)
+      {
+        const prefix = this.#errorPrefix(actualOptions.pluginName, actualOptions.configName);
+        throw new Error(`${prefix}invalid JSON config at ${configPath}: ${e.message}`);
+      }
+    }
+
+    // map/classify the parsed blob when requested.
+    const result = actualOptions.mapper
+      ? actualOptions.mapper(parsed)
+      : parsed;
+
+    // optionally log what was loaded, if enabled at the base level.
+    if (J.BASE.Metadata.ShowExternalFileLoadInfo)
+    {
+      this.#logLoadInfo(configPath, result, actualOptions.logSummary);
+    }
+
+    // return the parsed blob or mapped result.
+    return result;
+  }
+
+  /**
+   * Builds and returns a standardized "missing config" Error.
+   * @param {string} configPath The path that was attempted.
+   * @param {string=} pluginName The plugin name for message context.
+   * @param {string=} configName The config name for message context.
+   * @returns {Error}
+   */
+  static #missingConfigError(configPath, pluginName, configName)
+  {
+    const prefix = this.#errorPrefix(pluginName, configName);
+    const label = configName ?? 'configuration';
+    return new Error(`${prefix}missing ${label} file at ${configPath}.`);
+  }
+
+  /**
+   * Builds a consistent prefix for all errors emitted by this loader.
+   * @param {string=} pluginName The plugin name for message context.
+   * @param {string=} configName The config name for message context.
+   * @returns {string}
+   */
+  static #errorPrefix(pluginName, configName)
+  {
+    // build the context prefix.
+    const parts = [];
+    if (pluginName) parts.push(pluginName);
+    if (configName) parts.push(configName);
+
+    // if we have no context, then don't add one.
+    if (parts.length === 0) return String.empty;
+
+    // return the bracketed prefix with a trailing space.
+    return `[${parts.join('::')}] `;
+  }
+
+  /**
+   * Logs informational details about what was loaded from disk.
+   * @param {string} configPath The project-relative config path.
+   * @param {any} result The result of loading (parsed or mapped).
+   * @param {(result: any) => string|string[]=} logSummary Optional summary builder.
+   */
+  static #logLoadInfo(configPath, result, logSummary)
+  {
+    // if a summary builder was provided, use it.
+    if (logSummary)
+    {
+      const built = logSummary(result);
+      const lines = Array.isArray(built)
+        ? built
+        : [ built ];
+
+      console.log(`loaded:
+${lines.map(line => `      ${line}`)
+    .join('\n')}
+      from file ${configPath}.`);
+      return;
+    }
+
+    // without a summary, fall back to a minimal single-line log.
+    console.log(`loaded external JSON from file ${configPath}.`);
+  }
+}
+
+//endregion ExternalJsonConfigLoader
+
 //region Graphics
 /**
  * The horizontal padding between {@link Graphics.width} and {@link Graphics.boxWidth}.<br>
@@ -6829,6 +6976,198 @@ class BuiltWindowCommand
 
   //endregion getters
 }
+
+//region ExternalJsonConfigLoaderOptions
+/**
+ * The options for {@link ExternalJsonConfigLoader.load}.<br>
+ * This exists to avoid anonymous option objects throughout the codebase.
+ * @template TConfigJson The raw JSON shape after {@link JSON.parse}.
+ * @template TConfigResult The optional mapped/classified result shape.
+ */
+class ExternalJsonConfigLoaderOptions
+{
+  /**
+   * A factory for generating {@link ExternalJsonConfigLoaderOptions}.<br>
+   * @returns {ExternalJsonConfigLoaderOptionsBuilder}
+   * @constructor
+   */
+  static Builder = () => new ExternalJsonConfigLoaderOptionsBuilder();
+
+  /**
+   * The plugin name used for error context.
+   * @type {string|null}
+   */
+  pluginName = null;
+
+  /**
+   * A friendly label for the config used for error context.
+   * @type {string|null}
+   */
+  configName = null;
+
+  /**
+   * Optional validator; throw an Error to reject the parsed blob.
+   * @type {((parsed: TConfigJson) => void)|null}
+   */
+  validator = null;
+
+  /**
+   * Optional mapper/classifier for transforming the parsed blob.
+   * @type {((parsed: TConfigJson) => TConfigResult)|null}
+   */
+  mapper = null;
+
+  /**
+   * Optional log builder when info logging is enabled.
+   * @type {((result: TConfigResult|TConfigJson) => (string|string[]))|null}
+   */
+  logSummary = null;
+
+  /**
+   * Constructor.
+   * @param {string=} pluginName The plugin name used for error context.
+   * @param {string=} configName A friendly label for the config used for error context.
+   */
+  constructor(pluginName = null, configName = null)
+  {
+    this.pluginName = pluginName;
+    this.configName = configName;
+  }
+}
+
+//region ExternalJsonConfigLoaderOptionsBuilder
+/**
+ * A builder for {@link ExternalJsonConfigLoaderOptions}.<br>
+ * Exists to keep configuration setup explicit and chainable.
+ * @template TConfigJson The raw JSON shape after {@link JSON.parse}.
+ * @template TConfigResult The optional mapped/classified result shape.
+ */
+class ExternalJsonConfigLoaderOptionsBuilder
+{
+  //region properties
+  /**
+   * The plugin name used for error context.
+   * @type {string|null}
+   */
+  #pluginName = null;
+
+  /**
+   * A friendly label for the config used for error context.
+   * @type {string|null}
+   */
+  #configName = null;
+
+  /**
+   * Optional validator; throw an Error to reject the parsed blob.
+   * @type {((parsed: TConfigJson) => void)|null}
+   */
+  #validator = null;
+
+  /**
+   * Optional mapper/classifier for transforming the parsed blob.
+   * @type {((parsed: TConfigJson) => TConfigResult)|null}
+   */
+  #mapper = null;
+
+  /**
+   * Optional log builder when info logging is enabled.
+   * @type {((result: TConfigResult|TConfigJson) => (string|string[]))|null}
+   */
+  #logSummary = null;
+
+  //endregion properties
+
+  /**
+   * Builds the {@link ExternalJsonConfigLoaderOptions}.
+   * @returns {ExternalJsonConfigLoaderOptions<TConfigJson, TConfigResult>}
+   */
+  build()
+  {
+    // build the options model from the provided parameters.
+    const options = new ExternalJsonConfigLoaderOptions(this.#pluginName, this.#configName);
+    options.validator = this.#validator;
+    options.mapper = this.#mapper;
+    options.logSummary = this.#logSummary;
+
+    // clear the builder parameters.
+    this.#clear();
+
+    // return the newly-built options.
+    return options;
+  }
+
+  //region setters
+  /**
+   * Sets the plugin name used for error context.
+   * @param {string|null} pluginName The plugin name.
+   * @returns {ExternalJsonConfigLoaderOptionsBuilder}
+   */
+  pluginName(pluginName)
+  {
+    this.#pluginName = pluginName;
+    return this;
+  }
+
+  /**
+   * Sets the config name used for error context.
+   * @param {string|null} configName The config name.
+   * @returns {ExternalJsonConfigLoaderOptionsBuilder}
+   */
+  configName(configName)
+  {
+    this.#configName = configName;
+    return this;
+  }
+
+  /**
+   * Sets the validator callback used for rejecting invalid parsed blobs.
+   * @param {((parsed: TConfigJson) => void)|null} validator The validator callback.
+   * @returns {ExternalJsonConfigLoaderOptionsBuilder<TConfigJson, TConfigResult>}
+   */
+  validator(validator)
+  {
+    this.#validator = validator;
+    return this;
+  }
+
+  /**
+   * Sets the mapper/classifier callback used for transforming parsed blobs.
+   * @param {((parsed: TConfigJson) => TConfigResult)|null} mapper The mapper callback.
+   * @returns {ExternalJsonConfigLoaderOptionsBuilder<TConfigJson, TConfigResult>}
+   */
+  mapper(mapper)
+  {
+    this.#mapper = mapper;
+    return this;
+  }
+
+  /**
+   * Sets the log summary callback used for information logs.
+   * @param {((result: TConfigResult|TConfigJson) => (string|string[]))|null} logSummary The summary callback.
+   * @returns {ExternalJsonConfigLoaderOptionsBuilder<TConfigJson, TConfigResult>}
+   */
+  logSummary(logSummary)
+  {
+    this.#logSummary = logSummary;
+    return this;
+  }
+
+  //endregion setters
+
+  /**
+   * Clears the data in the builder.
+   */
+  #clear()
+  {
+    this.#pluginName = null;
+    this.#configName = null;
+    this.#validator = null;
+    this.#mapper = null;
+    this.#logSummary = null;
+  }
+}
+//endregion ExternalJsonConfigLoaderOptionsBuilder
+//endregion ExternalJsonConfigLoaderOptions
 
 //region GaugeOptionsBuilder
 /**

--- a/project/js/plugins/J-Difficulty.js
+++ b/project/js/plugins/J-Difficulty.js
@@ -1009,47 +1009,21 @@ class J_DiffPluginMetadata
    */
   initializeDifficulties()
   {
-    const rawConfig = StorageManager.fsReadFile(J_DiffPluginMetadata.CONFIG_PATH);
-    if (rawConfig === null || rawConfig === '')
-    {
-      console.error('no Difficulty configuration was found in the /data directory of the project.');
-      console.error('Consider adding configuration using the J-MZ data editor, or hand-writing one.');
-      throw new Error('Difficulty plugin is being used, but no config file is present.');
-    }
-
-    let parsedDifficulties;
-    try
-    {
-      parsedDifficulties = JSON.parse(rawConfig);
-    }
-    catch (e)
-    {
-      throw new Error(
-        `Failed to parse JSON at ${J_DiffPluginMetadata.CONFIG_PATH}: ${e.message}`,
-      );
-    }
-
-    if (parsedDifficulties === null)
-    {
-      console.error('no Difficulty configuration was found in the /data directory of the project.');
-      console.error('Consider adding configuration using the J-MZ data editor, or hand-writing one.');
-      throw new Error('Difficulty plugin is being used, but no config file is present.');
-    }
-
-    const classifiedMetadatas = J_DiffPluginMetadata.classifyDifficulties(parsedDifficulties);
+    const classifiedMetadatas = ExternalJsonConfigLoader.load(
+      J_DiffPluginMetadata.CONFIG_PATH,
+      ExternalJsonConfigLoaderOptions.Builder()
+        .pluginName('J-Difficulty')
+        .configName('difficulty configuration')
+        .mapper(J_DiffPluginMetadata.classifyDifficulties.bind(J_DiffPluginMetadata))
+        .logSummary(result => [ `- ${result.size} difficulty layers` ])
+        .build()
+    );
 
     /**
      * A map of difficulty layer metadatas by their key.
      * @type {Map<string, DifficultyMetadata>}
      */
     this.allMetadatas = classifiedMetadatas;
-
-    if (J.BASE.Metadata.ShowExternalFileLoadInfo)
-    {
-      console.log(`loaded:
-      - ${this.allMetadatas.size} difficulty layers
-      from file ${J_DiffPluginMetadata.CONFIG_PATH}.`);
-    }
   }
 
   initializeMetadata()

--- a/project/js/plugins/J-Proficiency.js
+++ b/project/js/plugins/J-Proficiency.js
@@ -419,32 +419,15 @@ class J_ProficiencyPluginMetadata
    */
   initializeProficiencies()
   {
-    const rawConfig = StorageManager.fsReadFile(J_ProficiencyPluginMetadata.CONFIG_PATH);
-    if (rawConfig === null || rawConfig === '')
-    {
-      console.error('no proficiency configuration was found in the /data directory of the project.');
-      console.error('Consider adding configuration using the J-MZ data editor, or hand-writing one.');
-      throw new Error('Proficiency plugin is being used, but no config file is present.');
-    }
-
-    let parsedConditionals;
-    try
-    {
-      parsedConditionals = JSON.parse(rawConfig);
-    }
-    catch (e)
-    {
-      throw new Error(`Failed to parse JSON at ${J_ProficiencyPluginMetadata.CONFIG_PATH}: ${e.message}`,);
-    }
-
-    if (parsedConditionals === null)
-    {
-      console.error('no proficiency configuration was found in the /data directory of the project.');
-      console.error('Consider adding configuration using the J-MZ data editor, or hand-writing one.');
-      throw new Error('Proficiency plugin is being used, but no config file is present.');
-    }
-
-    const classifiedConditionalData = J_ProficiencyPluginMetadata.classifyConditionals(parsedConditionals);
+    const classifiedConditionalData = ExternalJsonConfigLoader.load(
+      J_ProficiencyPluginMetadata.CONFIG_PATH,
+      ExternalJsonConfigLoaderOptions.Builder()
+        .pluginName('J-Proficiency')
+        .configName('proficiency configuration')
+        .mapper(J_ProficiencyPluginMetadata.classifyConditionals.bind(J_ProficiencyPluginMetadata))
+        .logSummary(result => [ `- ${result.length} proficiency conditionals` ])
+        .build()
+    );
 
     /**
      * The collection of all defined skill proficiencies.
@@ -473,14 +456,6 @@ class J_ProficiencyPluginMetadata
         data.push(conditional);
       });
     });
-
-    // check if we're allowed to show the loading information before showing it.
-    if (J.BASE.Metadata.ShowExternalFileLoadInfo)
-    {
-      console.log(`loaded:
-      - ${this.conditionals.length} proficiency conditionals
-      from file ${J_ProficiencyPluginMetadata.CONFIG_PATH}.`);
-    }
   }
 }
 

--- a/project/js/plugins/J-SDP.js
+++ b/project/js/plugins/J-SDP.js
@@ -1236,35 +1236,19 @@ class J_SdpPluginMetadata
    */
   initializePanels()
   {
-    const rawConfig = StorageManager.fsReadFile(J_SdpPluginMetadata.CONFIG_PATH);
-    if (rawConfig === null || rawConfig === '')
-    {
-      console.error('no SDP configuration was found in the /data directory of the project.');
-      console.error('Consider adding configuration using the J-MZ data editor, or hand-writing one.');
-      throw new Error('SDP plugin is being used, but no config file is present.');
-    }
-
-    let parsedPanels;
-    try
-    {
-      parsedPanels = JSON.parse(rawConfig);
-    }
-    catch (e)
-    {
-      throw new Error(
-        `Failed to parse JSON at ${J_SdpPluginMetadata.CONFIG_PATH}: ${e.message}`,
-      );
-    }
-
-    if (parsedPanels === null)
-    {
-      console.error('no SDP configuration was found in the /data directory of the project.');
-      console.error('Consider adding configuration using the J-MZ data editor, or hand-writing one.');
-      throw new Error('SDP plugin is being used, but no config file is present.');
-    }
-
     // classify each panel.
-    const classifiedPanels = J_SdpPluginMetadata.classifyPanels(parsedPanels.sdps);
+    const canLogLoadInfo = J_SdpPluginMetadata.#hasMinimumBaseVersion();
+    const classifiedPanels = ExternalJsonConfigLoader.load(
+      J_SdpPluginMetadata.CONFIG_PATH,
+      ExternalJsonConfigLoaderOptions.Builder()
+        .pluginName('J-SDP')
+        .configName('sdp configuration')
+        .mapper(parsed => J_SdpPluginMetadata.classifyPanels(parsed.sdps))
+        .logSummary(canLogLoadInfo
+          ? result => [ `- ${result.length} panels` ]
+          : null)
+        .build()
+    );
 
     /**
      * The collection of all defined SDPs.
@@ -1280,13 +1264,6 @@ class J_SdpPluginMetadata
      * @type {Map<string, StatDistributionPanel>}
      */
     this.panelsMap = panelMap;
-
-    if (J_SdpPluginMetadata.#hasMinimumBaseVersion() && J.BASE.Metadata.ShowExternalFileLoadInfo)
-    {
-      console.log(`loaded:
-      - ${this.panels.length} panels
-      from file ${J_SdpPluginMetadata.CONFIG_PATH}.`);
-    }
   }
 
   initializeMetadata()

--- a/project/js/plugins/jafting/ext/J-JAFTING-Creation.js
+++ b/project/js/plugins/jafting/ext/J-JAFTING-Creation.js
@@ -1586,34 +1586,21 @@ class J_CraftingCreatePluginMetadata
    */
   initializeConfiguration()
   {
-    const rawConfig = StorageManager.fsReadFile(J_CraftingCreatePluginMetadata.CONFIG_PATH);
-    if (rawConfig === null || rawConfig === '')
-    {
-      console.error('no crafting configuration was found in the /data directory of the project.');
-      console.error('Consider adding configuration using the J-MZ data editor, or hand-writing one.');
-      throw new Error('Crafting plugin is being used, but no config file is present.');
-    }
-
-    let parsedJson;
-    try
-    {
-      parsedJson = JSON.parse(rawConfig);
-    }
-    catch (e)
-    {
-      throw new Error(
-        `Failed to parse JSON at ${J_CraftingCreatePluginMetadata.CONFIG_PATH}: ${e.message}`,
-      );
-    }
-
-    if (parsedJson === null)
-    {
-      console.error('no crafting configuration was found in the /data directory of the project.');
-      console.error('Consider adding configuration using the J-MZ data editor, or hand-writing one.');
-      throw new Error('Crafting plugin is being used, but no config file is present.');
-    }
-
-    const classifiedCraftingConfig = J_CraftingCreatePluginMetadata.classify(parsedJson);
+    const canLogLoadInfo = J_CraftingCreatePluginMetadata.#hasMinimumBaseVersion();
+    const classifiedCraftingConfig = ExternalJsonConfigLoader.load(
+      J_CraftingCreatePluginMetadata.CONFIG_PATH,
+      ExternalJsonConfigLoaderOptions.Builder()
+        .pluginName('J-JAFTING-Creation')
+        .configName('crafting configuration')
+        .mapper(J_CraftingCreatePluginMetadata.classify.bind(J_CraftingCreatePluginMetadata))
+        .logSummary(canLogLoadInfo
+          ? result => [
+            `- ${result.recipes().length} recipes`,
+            `- ${result.categories().length} categories`,
+          ]
+          : null)
+        .build()
+    );
 
     /**
      * The collection of all defined jafting recipes.
@@ -1644,14 +1631,6 @@ class J_CraftingCreatePluginMetadata
      * @type {Map<string, CraftingCategory>}
      */
     this.categoriesMap = categoriesMap;
-
-    if (J_CraftingCreatePluginMetadata.#hasMinimumBaseVersion() && J.BASE.Metadata.ShowExternalFileLoadInfo)
-    {
-      console.log(`loaded:
-      - ${this.recipes.length} recipes
-      - ${this.categories.length} categories
-      from file ${J_CraftingCreatePluginMetadata.CONFIG_PATH}.`);
-    }
   }
 
   /**

--- a/project/js/plugins/omni/ext/J-Omni-Questopedia.js
+++ b/project/js/plugins/omni/ext/J-Omni-Questopedia.js
@@ -2516,33 +2516,21 @@ class J_QUEST_PluginMetadata
 
   initializeQuests()
   {
-    const rawConfig = StorageManager.fsReadFile(J_QUEST_PluginMetadata.CONFIG_PATH);
-    if (rawConfig === null || rawConfig === '')
-    {
-      console.error('no quest configuration was found in the /data directory of the project.');
-      console.error('Consider adding configuration using the J-MZ data editor, or hand-writing one.');
-      throw new Error('OmniQuest plugin is being used, but no config file is present.');
-    }
-
-    /** @type {OmniConfiguration} */
-    let parsedConfiguration;
-    try
-    {
-      parsedConfiguration = JSON.parse(rawConfig);
-    }
-    catch (e)
-    {
-      throw new Error(
-        `Failed to parse JSON at ${J_QUEST_PluginMetadata.CONFIG_PATH}: ${e.message}`,
-      );
-    }
-
-    if (parsedConfiguration === null)
-    {
-      console.error('no quest configuration was found in the /data directory of the project.');
-      console.error('Consider adding configuration using the J-MZ data editor, or hand-writing one.');
-      throw new Error('OmniQuest plugin is being used, but no config file is present.');
-    }
+    const canLogLoadInfo = J_QUEST_PluginMetadata.#hasMinimumBaseVersion();
+    const parsedConfiguration = ExternalJsonConfigLoader.load(
+      J_QUEST_PluginMetadata.CONFIG_PATH,
+      ExternalJsonConfigLoaderOptions.Builder()
+        .pluginName('J-Omni-Questopedia')
+        .configName('quest configuration')
+        .logSummary(canLogLoadInfo
+          ? result => [
+            `- ${result.quests.length} quests`,
+            `- ${result.categories.length} categories`,
+            `- ${result.tags.length} tags`,
+          ]
+          : null)
+        .build()
+    );
 
     const classifiedQuests = J_QUEST_PluginMetadata.classifyQuests(parsedConfiguration.quests);
 
@@ -2590,15 +2578,6 @@ class J_QUEST_PluginMetadata
      * @type {Map<string, OmniTag>}
      */
     this.tagsMap = tagMap;
-
-    if (J_QUEST_PluginMetadata.#hasMinimumBaseVersion() && J.BASE.Metadata.ShowExternalFileLoadInfo)
-    {
-      console.log(`loaded:
-        - ${this.quests.length} quests
-        - ${this.categories.length} categories
-        - ${this.tags.length} tags
-        from file ${J_QUEST_PluginMetadata.CONFIG_PATH}.`);
-    }
   }
 
   /**

--- a/src/plugins/_base/managers/ExternalJsonConfigLoader.js
+++ b/src/plugins/_base/managers/ExternalJsonConfigLoader.js
@@ -1,0 +1,146 @@
+//region ExternalJsonConfigLoader
+/**
+ * A centralized loader for external JSON configuration files in the project.
+ *
+ * This is intended to eliminate duplicated "read file → guard null/empty → JSON.parse try/catch → validate → classify"
+ * boilerplate across plugin metadata initializers.
+ *
+ * This loader is deliberately "domain-agnostic": it knows how to read and parse JSON, but it does not know what the
+ * JSON means. Callers can provide a validator and/or mapper to enforce plugin-specific shapes and transform the parsed
+ * blob into a classified result.
+ */
+// eslint-disable-next-line no-unused-vars
+class ExternalJsonConfigLoader
+{
+  /**
+   * Loads, parses, validates, and optionally maps JSON configuration from a project-relative path.
+   * @template TConfigJson The raw JSON shape after {@link JSON.parse}.
+   * @template TConfigResult The optional mapped/classified result shape.
+   * @param {string} configPath Project-relative path, ex: `data/config.sdp.json`.
+   * @param {ExternalJsonConfigLoaderOptions<TConfigJson, TConfigResult>=} options Additional options to customize
+   * behavior.
+   * @returns {TConfigResult|TConfigJson} The parsed JSON blob, or mapped result if a mapper was provided.
+   */
+  static load(configPath, options = null)
+  {
+    const actualOptions = options ?? new ExternalJsonConfigLoaderOptions();
+
+    // read the raw json text from the filesystem.
+    const rawConfig = StorageManager.fsReadFile(configPath);
+
+    // missing or empty config is a fatal error for plugins that rely on external configuration.
+    if (rawConfig === null || rawConfig === String.empty)
+    {
+      throw this.#missingConfigError(configPath, actualOptions.pluginName, actualOptions.configName);
+    }
+
+    // parse the json in a way that always includes the file path.
+    let parsed;
+    try
+    {
+      parsed = /** @type {TConfigJson} */ (JSON.parse(rawConfig));
+    }
+    catch (e)
+    {
+      const prefix = this.#errorPrefix(actualOptions.pluginName, actualOptions.configName);
+      throw new Error(`${prefix}failed to parse JSON at ${configPath}: ${e.message}`);
+    }
+
+    // json can parse to null; treat that the same as "missing", because downstream logic expects an object/array.
+    if (parsed === null)
+    {
+      throw this.#missingConfigError(configPath, actualOptions.pluginName, actualOptions.configName);
+    }
+
+    // if provided, validate the parsed blob before mapping/classifying.
+    if (actualOptions.validator)
+    {
+      try
+      {
+        actualOptions.validator(parsed);
+      }
+      catch (e)
+      {
+        const prefix = this.#errorPrefix(actualOptions.pluginName, actualOptions.configName);
+        throw new Error(`${prefix}invalid JSON config at ${configPath}: ${e.message}`);
+      }
+    }
+
+    // map/classify the parsed blob when requested.
+    const result = actualOptions.mapper
+      ? actualOptions.mapper(parsed)
+      : parsed;
+
+    // optionally log what was loaded, if enabled at the base level.
+    if (J.BASE.Metadata.ShowExternalFileLoadInfo)
+    {
+      this.#logLoadInfo(configPath, result, actualOptions.logSummary);
+    }
+
+    // return the parsed blob or mapped result.
+    return result;
+  }
+
+  /**
+   * Builds and returns a standardized "missing config" Error.
+   * @param {string} configPath The path that was attempted.
+   * @param {string=} pluginName The plugin name for message context.
+   * @param {string=} configName The config name for message context.
+   * @returns {Error}
+   */
+  static #missingConfigError(configPath, pluginName, configName)
+  {
+    const prefix = this.#errorPrefix(pluginName, configName);
+    const label = configName ?? 'configuration';
+    return new Error(`${prefix}missing ${label} file at ${configPath}.`);
+  }
+
+  /**
+   * Builds a consistent prefix for all errors emitted by this loader.
+   * @param {string=} pluginName The plugin name for message context.
+   * @param {string=} configName The config name for message context.
+   * @returns {string}
+   */
+  static #errorPrefix(pluginName, configName)
+  {
+    // build the context prefix.
+    const parts = [];
+    if (pluginName) parts.push(pluginName);
+    if (configName) parts.push(configName);
+
+    // if we have no context, then don't add one.
+    if (parts.length === 0) return String.empty;
+
+    // return the bracketed prefix with a trailing space.
+    return `[${parts.join('::')}] `;
+  }
+
+  /**
+   * Logs informational details about what was loaded from disk.
+   * @param {string} configPath The project-relative config path.
+   * @param {any} result The result of loading (parsed or mapped).
+   * @param {(result: any) => string|string[]=} logSummary Optional summary builder.
+   */
+  static #logLoadInfo(configPath, result, logSummary)
+  {
+    // if a summary builder was provided, use it.
+    if (logSummary)
+    {
+      const built = logSummary(result);
+      const lines = Array.isArray(built)
+        ? built
+        : [ built ];
+
+      console.log(`loaded:
+${lines.map(line => `      ${line}`)
+    .join('\n')}
+      from file ${configPath}.`);
+      return;
+    }
+
+    // without a summary, fall back to a minimal single-line log.
+    console.log(`loaded external JSON from file ${configPath}.`);
+  }
+}
+
+//endregion ExternalJsonConfigLoader

--- a/src/plugins/_base/models/ExternalJsonConfigLoaderOptions.js
+++ b/src/plugins/_base/models/ExternalJsonConfigLoaderOptions.js
@@ -1,0 +1,191 @@
+//region ExternalJsonConfigLoaderOptions
+/**
+ * The options for {@link ExternalJsonConfigLoader.load}.<br>
+ * This exists to avoid anonymous option objects throughout the codebase.
+ * @template TConfigJson The raw JSON shape after {@link JSON.parse}.
+ * @template TConfigResult The optional mapped/classified result shape.
+ */
+class ExternalJsonConfigLoaderOptions
+{
+  /**
+   * A factory for generating {@link ExternalJsonConfigLoaderOptions}.<br>
+   * @returns {ExternalJsonConfigLoaderOptionsBuilder}
+   * @constructor
+   */
+  static Builder = () => new ExternalJsonConfigLoaderOptionsBuilder();
+
+  /**
+   * The plugin name used for error context.
+   * @type {string|null}
+   */
+  pluginName = null;
+
+  /**
+   * A friendly label for the config used for error context.
+   * @type {string|null}
+   */
+  configName = null;
+
+  /**
+   * Optional validator; throw an Error to reject the parsed blob.
+   * @type {((parsed: TConfigJson) => void)|null}
+   */
+  validator = null;
+
+  /**
+   * Optional mapper/classifier for transforming the parsed blob.
+   * @type {((parsed: TConfigJson) => TConfigResult)|null}
+   */
+  mapper = null;
+
+  /**
+   * Optional log builder when info logging is enabled.
+   * @type {((result: TConfigResult|TConfigJson) => (string|string[]))|null}
+   */
+  logSummary = null;
+
+  /**
+   * Constructor.
+   * @param {string=} pluginName The plugin name used for error context.
+   * @param {string=} configName A friendly label for the config used for error context.
+   */
+  constructor(pluginName = null, configName = null)
+  {
+    this.pluginName = pluginName;
+    this.configName = configName;
+  }
+}
+
+//region ExternalJsonConfigLoaderOptionsBuilder
+/**
+ * A builder for {@link ExternalJsonConfigLoaderOptions}.<br>
+ * Exists to keep configuration setup explicit and chainable.
+ * @template TConfigJson The raw JSON shape after {@link JSON.parse}.
+ * @template TConfigResult The optional mapped/classified result shape.
+ */
+class ExternalJsonConfigLoaderOptionsBuilder
+{
+  //region properties
+  /**
+   * The plugin name used for error context.
+   * @type {string|null}
+   */
+  #pluginName = null;
+
+  /**
+   * A friendly label for the config used for error context.
+   * @type {string|null}
+   */
+  #configName = null;
+
+  /**
+   * Optional validator; throw an Error to reject the parsed blob.
+   * @type {((parsed: TConfigJson) => void)|null}
+   */
+  #validator = null;
+
+  /**
+   * Optional mapper/classifier for transforming the parsed blob.
+   * @type {((parsed: TConfigJson) => TConfigResult)|null}
+   */
+  #mapper = null;
+
+  /**
+   * Optional log builder when info logging is enabled.
+   * @type {((result: TConfigResult|TConfigJson) => (string|string[]))|null}
+   */
+  #logSummary = null;
+
+  //endregion properties
+
+  /**
+   * Builds the {@link ExternalJsonConfigLoaderOptions}.
+   * @returns {ExternalJsonConfigLoaderOptions<TConfigJson, TConfigResult>}
+   */
+  build()
+  {
+    // build the options model from the provided parameters.
+    const options = new ExternalJsonConfigLoaderOptions(this.#pluginName, this.#configName);
+    options.validator = this.#validator;
+    options.mapper = this.#mapper;
+    options.logSummary = this.#logSummary;
+
+    // clear the builder parameters.
+    this.#clear();
+
+    // return the newly-built options.
+    return options;
+  }
+
+  //region setters
+  /**
+   * Sets the plugin name used for error context.
+   * @param {string|null} pluginName The plugin name.
+   * @returns {ExternalJsonConfigLoaderOptionsBuilder}
+   */
+  pluginName(pluginName)
+  {
+    this.#pluginName = pluginName;
+    return this;
+  }
+
+  /**
+   * Sets the config name used for error context.
+   * @param {string|null} configName The config name.
+   * @returns {ExternalJsonConfigLoaderOptionsBuilder}
+   */
+  configName(configName)
+  {
+    this.#configName = configName;
+    return this;
+  }
+
+  /**
+   * Sets the validator callback used for rejecting invalid parsed blobs.
+   * @param {((parsed: TConfigJson) => void)|null} validator The validator callback.
+   * @returns {ExternalJsonConfigLoaderOptionsBuilder<TConfigJson, TConfigResult>}
+   */
+  validator(validator)
+  {
+    this.#validator = validator;
+    return this;
+  }
+
+  /**
+   * Sets the mapper/classifier callback used for transforming parsed blobs.
+   * @param {((parsed: TConfigJson) => TConfigResult)|null} mapper The mapper callback.
+   * @returns {ExternalJsonConfigLoaderOptionsBuilder<TConfigJson, TConfigResult>}
+   */
+  mapper(mapper)
+  {
+    this.#mapper = mapper;
+    return this;
+  }
+
+  /**
+   * Sets the log summary callback used for information logs.
+   * @param {((result: TConfigResult|TConfigJson) => (string|string[]))|null} logSummary The summary callback.
+   * @returns {ExternalJsonConfigLoaderOptionsBuilder<TConfigJson, TConfigResult>}
+   */
+  logSummary(logSummary)
+  {
+    this.#logSummary = logSummary;
+    return this;
+  }
+
+  //endregion setters
+
+  /**
+   * Clears the data in the builder.
+   */
+  #clear()
+  {
+    this.#pluginName = null;
+    this.#configName = null;
+    this.#validator = null;
+    this.#mapper = null;
+    this.#logSummary = null;
+  }
+}
+//endregion ExternalJsonConfigLoaderOptionsBuilder
+//endregion ExternalJsonConfigLoaderOptions

--- a/src/plugins/diff/_metadata/_pluginMetadata.js
+++ b/src/plugins/diff/_metadata/_pluginMetadata.js
@@ -169,47 +169,21 @@ class J_DiffPluginMetadata
    */
   initializeDifficulties()
   {
-    const rawConfig = StorageManager.fsReadFile(J_DiffPluginMetadata.CONFIG_PATH);
-    if (rawConfig === null || rawConfig === '')
-    {
-      console.error('no Difficulty configuration was found in the /data directory of the project.');
-      console.error('Consider adding configuration using the J-MZ data editor, or hand-writing one.');
-      throw new Error('Difficulty plugin is being used, but no config file is present.');
-    }
-
-    let parsedDifficulties;
-    try
-    {
-      parsedDifficulties = JSON.parse(rawConfig);
-    }
-    catch (e)
-    {
-      throw new Error(
-        `Failed to parse JSON at ${J_DiffPluginMetadata.CONFIG_PATH}: ${e.message}`,
-      );
-    }
-
-    if (parsedDifficulties === null)
-    {
-      console.error('no Difficulty configuration was found in the /data directory of the project.');
-      console.error('Consider adding configuration using the J-MZ data editor, or hand-writing one.');
-      throw new Error('Difficulty plugin is being used, but no config file is present.');
-    }
-
-    const classifiedMetadatas = J_DiffPluginMetadata.classifyDifficulties(parsedDifficulties);
+    const classifiedMetadatas = ExternalJsonConfigLoader.load(
+      J_DiffPluginMetadata.CONFIG_PATH,
+      ExternalJsonConfigLoaderOptions.Builder()
+        .pluginName('J-Difficulty')
+        .configName('difficulty configuration')
+        .mapper(J_DiffPluginMetadata.classifyDifficulties.bind(J_DiffPluginMetadata))
+        .logSummary(result => [ `- ${result.size} difficulty layers` ])
+        .build()
+    );
 
     /**
      * A map of difficulty layer metadatas by their key.
      * @type {Map<string, DifficultyMetadata>}
      */
     this.allMetadatas = classifiedMetadatas;
-
-    if (J.BASE.Metadata.ShowExternalFileLoadInfo)
-    {
-      console.log(`loaded:
-      - ${this.allMetadatas.size} difficulty layers
-      from file ${J_DiffPluginMetadata.CONFIG_PATH}.`);
-    }
   }
 
   initializeMetadata()

--- a/src/plugins/jafting/ext/create/_metadata/_pluginMetadata.js
+++ b/src/plugins/jafting/ext/create/_metadata/_pluginMetadata.js
@@ -141,34 +141,21 @@ class J_CraftingCreatePluginMetadata
    */
   initializeConfiguration()
   {
-    const rawConfig = StorageManager.fsReadFile(J_CraftingCreatePluginMetadata.CONFIG_PATH);
-    if (rawConfig === null || rawConfig === '')
-    {
-      console.error('no crafting configuration was found in the /data directory of the project.');
-      console.error('Consider adding configuration using the J-MZ data editor, or hand-writing one.');
-      throw new Error('Crafting plugin is being used, but no config file is present.');
-    }
-
-    let parsedJson;
-    try
-    {
-      parsedJson = JSON.parse(rawConfig);
-    }
-    catch (e)
-    {
-      throw new Error(
-        `Failed to parse JSON at ${J_CraftingCreatePluginMetadata.CONFIG_PATH}: ${e.message}`,
-      );
-    }
-
-    if (parsedJson === null)
-    {
-      console.error('no crafting configuration was found in the /data directory of the project.');
-      console.error('Consider adding configuration using the J-MZ data editor, or hand-writing one.');
-      throw new Error('Crafting plugin is being used, but no config file is present.');
-    }
-
-    const classifiedCraftingConfig = J_CraftingCreatePluginMetadata.classify(parsedJson);
+    const canLogLoadInfo = J_CraftingCreatePluginMetadata.#hasMinimumBaseVersion();
+    const classifiedCraftingConfig = ExternalJsonConfigLoader.load(
+      J_CraftingCreatePluginMetadata.CONFIG_PATH,
+      ExternalJsonConfigLoaderOptions.Builder()
+        .pluginName('J-JAFTING-Creation')
+        .configName('crafting configuration')
+        .mapper(J_CraftingCreatePluginMetadata.classify.bind(J_CraftingCreatePluginMetadata))
+        .logSummary(canLogLoadInfo
+          ? result => [
+            `- ${result.recipes().length} recipes`,
+            `- ${result.categories().length} categories`,
+          ]
+          : null)
+        .build()
+    );
 
     /**
      * The collection of all defined jafting recipes.
@@ -199,14 +186,6 @@ class J_CraftingCreatePluginMetadata
      * @type {Map<string, CraftingCategory>}
      */
     this.categoriesMap = categoriesMap;
-
-    if (J_CraftingCreatePluginMetadata.#hasMinimumBaseVersion() && J.BASE.Metadata.ShowExternalFileLoadInfo)
-    {
-      console.log(`loaded:
-      - ${this.recipes.length} recipes
-      - ${this.categories.length} categories
-      from file ${J_CraftingCreatePluginMetadata.CONFIG_PATH}.`);
-    }
   }
 
   /**

--- a/src/plugins/omni/ext/quest/_metadata/_pluginMetadata.js
+++ b/src/plugins/omni/ext/quest/_metadata/_pluginMetadata.js
@@ -66,33 +66,21 @@ class J_QUEST_PluginMetadata
 
   initializeQuests()
   {
-    const rawConfig = StorageManager.fsReadFile(J_QUEST_PluginMetadata.CONFIG_PATH);
-    if (rawConfig === null || rawConfig === '')
-    {
-      console.error('no quest configuration was found in the /data directory of the project.');
-      console.error('Consider adding configuration using the J-MZ data editor, or hand-writing one.');
-      throw new Error('OmniQuest plugin is being used, but no config file is present.');
-    }
-
-    /** @type {OmniConfiguration} */
-    let parsedConfiguration;
-    try
-    {
-      parsedConfiguration = JSON.parse(rawConfig);
-    }
-    catch (e)
-    {
-      throw new Error(
-        `Failed to parse JSON at ${J_QUEST_PluginMetadata.CONFIG_PATH}: ${e.message}`,
-      );
-    }
-
-    if (parsedConfiguration === null)
-    {
-      console.error('no quest configuration was found in the /data directory of the project.');
-      console.error('Consider adding configuration using the J-MZ data editor, or hand-writing one.');
-      throw new Error('OmniQuest plugin is being used, but no config file is present.');
-    }
+    const canLogLoadInfo = J_QUEST_PluginMetadata.#hasMinimumBaseVersion();
+    const parsedConfiguration = ExternalJsonConfigLoader.load(
+      J_QUEST_PluginMetadata.CONFIG_PATH,
+      ExternalJsonConfigLoaderOptions.Builder()
+        .pluginName('J-Omni-Questopedia')
+        .configName('quest configuration')
+        .logSummary(canLogLoadInfo
+          ? result => [
+            `- ${result.quests.length} quests`,
+            `- ${result.categories.length} categories`,
+            `- ${result.tags.length} tags`,
+          ]
+          : null)
+        .build()
+    );
 
     const classifiedQuests = J_QUEST_PluginMetadata.classifyQuests(parsedConfiguration.quests);
 
@@ -140,15 +128,6 @@ class J_QUEST_PluginMetadata
      * @type {Map<string, OmniTag>}
      */
     this.tagsMap = tagMap;
-
-    if (J_QUEST_PluginMetadata.#hasMinimumBaseVersion() && J.BASE.Metadata.ShowExternalFileLoadInfo)
-    {
-      console.log(`loaded:
-        - ${this.quests.length} quests
-        - ${this.categories.length} categories
-        - ${this.tags.length} tags
-        from file ${J_QUEST_PluginMetadata.CONFIG_PATH}.`);
-    }
   }
 
   /**

--- a/src/plugins/prof/_metadata/_pluginMetadata.js
+++ b/src/plugins/prof/_metadata/_pluginMetadata.js
@@ -47,32 +47,15 @@ class J_ProficiencyPluginMetadata
    */
   initializeProficiencies()
   {
-    const rawConfig = StorageManager.fsReadFile(J_ProficiencyPluginMetadata.CONFIG_PATH);
-    if (rawConfig === null || rawConfig === '')
-    {
-      console.error('no proficiency configuration was found in the /data directory of the project.');
-      console.error('Consider adding configuration using the J-MZ data editor, or hand-writing one.');
-      throw new Error('Proficiency plugin is being used, but no config file is present.');
-    }
-
-    let parsedConditionals;
-    try
-    {
-      parsedConditionals = JSON.parse(rawConfig);
-    }
-    catch (e)
-    {
-      throw new Error(`Failed to parse JSON at ${J_ProficiencyPluginMetadata.CONFIG_PATH}: ${e.message}`,);
-    }
-
-    if (parsedConditionals === null)
-    {
-      console.error('no proficiency configuration was found in the /data directory of the project.');
-      console.error('Consider adding configuration using the J-MZ data editor, or hand-writing one.');
-      throw new Error('Proficiency plugin is being used, but no config file is present.');
-    }
-
-    const classifiedConditionalData = J_ProficiencyPluginMetadata.classifyConditionals(parsedConditionals);
+    const classifiedConditionalData = ExternalJsonConfigLoader.load(
+      J_ProficiencyPluginMetadata.CONFIG_PATH,
+      ExternalJsonConfigLoaderOptions.Builder()
+        .pluginName('J-Proficiency')
+        .configName('proficiency configuration')
+        .mapper(J_ProficiencyPluginMetadata.classifyConditionals.bind(J_ProficiencyPluginMetadata))
+        .logSummary(result => [ `- ${result.length} proficiency conditionals` ])
+        .build()
+    );
 
     /**
      * The collection of all defined skill proficiencies.
@@ -101,14 +84,6 @@ class J_ProficiencyPluginMetadata
         data.push(conditional);
       });
     });
-
-    // check if we're allowed to show the loading information before showing it.
-    if (J.BASE.Metadata.ShowExternalFileLoadInfo)
-    {
-      console.log(`loaded:
-      - ${this.conditionals.length} proficiency conditionals
-      from file ${J_ProficiencyPluginMetadata.CONFIG_PATH}.`);
-    }
   }
 }
 

--- a/src/plugins/sdp/_metadata/_pluginMetadata.js
+++ b/src/plugins/sdp/_metadata/_pluginMetadata.js
@@ -116,35 +116,19 @@ class J_SdpPluginMetadata
    */
   initializePanels()
   {
-    const rawConfig = StorageManager.fsReadFile(J_SdpPluginMetadata.CONFIG_PATH);
-    if (rawConfig === null || rawConfig === '')
-    {
-      console.error('no SDP configuration was found in the /data directory of the project.');
-      console.error('Consider adding configuration using the J-MZ data editor, or hand-writing one.');
-      throw new Error('SDP plugin is being used, but no config file is present.');
-    }
-
-    let parsedPanels;
-    try
-    {
-      parsedPanels = JSON.parse(rawConfig);
-    }
-    catch (e)
-    {
-      throw new Error(
-        `Failed to parse JSON at ${J_SdpPluginMetadata.CONFIG_PATH}: ${e.message}`,
-      );
-    }
-
-    if (parsedPanels === null)
-    {
-      console.error('no SDP configuration was found in the /data directory of the project.');
-      console.error('Consider adding configuration using the J-MZ data editor, or hand-writing one.');
-      throw new Error('SDP plugin is being used, but no config file is present.');
-    }
-
     // classify each panel.
-    const classifiedPanels = J_SdpPluginMetadata.classifyPanels(parsedPanels.sdps);
+    const canLogLoadInfo = J_SdpPluginMetadata.#hasMinimumBaseVersion();
+    const classifiedPanels = ExternalJsonConfigLoader.load(
+      J_SdpPluginMetadata.CONFIG_PATH,
+      ExternalJsonConfigLoaderOptions.Builder()
+        .pluginName('J-SDP')
+        .configName('sdp configuration')
+        .mapper(parsed => J_SdpPluginMetadata.classifyPanels(parsed.sdps))
+        .logSummary(canLogLoadInfo
+          ? result => [ `- ${result.length} panels` ]
+          : null)
+        .build()
+    );
 
     /**
      * The collection of all defined SDPs.
@@ -160,13 +144,6 @@ class J_SdpPluginMetadata
      * @type {Map<string, StatDistributionPanel>}
      */
     this.panelsMap = panelMap;
-
-    if (J_SdpPluginMetadata.#hasMinimumBaseVersion() && J.BASE.Metadata.ShowExternalFileLoadInfo)
-    {
-      console.log(`loaded:
-      - ${this.panels.length} panels
-      from file ${J_SdpPluginMetadata.CONFIG_PATH}.`);
-    }
   }
 
   initializeMetadata()


### PR DESCRIPTION
## `J-Base` [minor]

- Added `ExternalJsonConfigLoader` + `ExternalJsonConfigLoaderOptions` to centralize external JSON config file loading/parsing/validation/logging.
- Standardized error shapes to always include config path and plugin/context prefix.

## `J-Difficulty` [patch]

- Migrated difficulty config load/parse/classify to `ExternalJsonConfigLoader`.

## `J-Proficiency` [patch]

- Migrated proficiency config load/parse/classify to `ExternalJsonConfigLoader`.

## `J-SDP` [patch]

- Migrated SDP config load/parse/classify to `ExternalJsonConfigLoader` (keeps SDP-specific filtering/classification in SDP).

## `J-Omni-Questopedia` [patch]

- Migrated quest config load/parse to `ExternalJsonConfigLoader`.

## `J-JAFTING-Creation` [patch]

- Migrated crafting config load/parse/classify to `ExternalJsonConfigLoader`.