### PR TITLE
fix: align skill/state models with schema

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -5,7 +5,7 @@
   "packages": {
     "": {
       "name": "plugin-dev-utilities",
-      "license": "AGPL-3.0-or-later",
+      "license": "MIT",
       "dependencies": {
         "async": "^3.2.4",
         "glob": "^10.3.3"

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "plugin-dev-utilities",
   "type": "module",
-  "license": "AGPL-3.0-or-later",
+  "license": "MIT",
   "author": "je-can-code",
   "devDependencies": {
     "@babel/plugin-syntax-import-assertions": "^7.22.5",

--- a/src/plugins/_base/database/implementations/RPG_Skill.js
+++ b/src/plugins/_base/database/implementations/RPG_Skill.js
@@ -19,12 +19,6 @@ class RPG_Skill
   message2 = String.empty;
 
   /**
-   * The type of message for this skill.
-   * @type {number}
-   */
-  messageType = 0;
-
-  /**
    * The amount of MP required to execute this skill.
    * @type {number}
    */
@@ -80,7 +74,6 @@ class RPG_Skill
     // map the data.
     this.message1 = skill.message1;
     this.message2 = skill.message2;
-    this.messageType = skill.messageType;
     this.mpCost = skill.mpCost;
     this.requiredWtypeId1 = skill.requiredWtypeId1;
     this.requiredWtypeId2 = skill.requiredWtypeId2;

--- a/src/plugins/_base/database/implementations/RPG_State.js
+++ b/src/plugins/_base/database/implementations/RPG_State.js
@@ -59,13 +59,6 @@ class RPG_State
   message4 = String.empty;
 
   /**
-   * The type of message this is.
-   * (unsure)
-   * @type {number}
-   */
-  messageType = 1;
-
-  /**
    * The minimum number of turns this state will persist.
    * Requires `restriction` to not be 0 to be leveraged.
    * @type {number}
@@ -154,7 +147,6 @@ class RPG_State
     this.message2 = state.message2;
     this.message3 = state.message3;
     this.message4 = state.message4;
-    this.messageType = state.messageType;
     this.minTurns = state.minTurns;
     this.motion = state.motion;
     this.overlay = state.overlay;


### PR DESCRIPTION
## `J-Base` [patch]

- Remove unused `messageType` hydration/field from `RPG_Skill` and `RPG_State`.

## Other plugins

- Standardize tooling package license metadata to MIT.